### PR TITLE
cuboid::domain_t fix for std::vector constructor

### DIFF
--- a/triqs/arrays/indexmaps/cuboid/domain.hpp
+++ b/triqs/arrays/indexmaps/cuboid/domain.hpp
@@ -52,7 +52,7 @@ namespace triqs { namespace arrays { namespace indexmaps { namespace cuboid {
    domain_t (n_uple && lengths):lengths_(std::move(lengths)) {}
    domain_t (mini_vector<int,Rank> const & lengths):lengths_(lengths) {}
    domain_t (std::vector<std::size_t> const & l):lengths_() {
-    if (!(l.size()==rank)) TRIQS_RUNTIME_ERROR << "cuboid domain_t construction : vector size incorrect : got "<<l.size() <<" while expected "<< rank;
+    if (!(l.size()==Rank)) TRIQS_RUNTIME_ERROR << "cuboid domain_t construction : vector size incorrect : got "<<l.size() <<" while expected "<< Rank;
     lengths_ = n_uple(l);
    }
    domain_t (const domain_t & C) = default;


### PR DESCRIPTION
This code previously couldn't be linked
`tqa::indexmaps::cuboid::domain_t<1> d({10});`
because of the corresponding constructor from std::vector using `static constexpr rank == Rank` in `triqs/arrays/indexmaps/cuboid/domain.hpp`. The constructor is defined inside the class definition, and so has the problem similar to the one, listed below.
See http://stackoverflow.com/questions/8016780/undefined-reference-to-static-constexpr-char
It works, if one uses the name from the template declaration.
