### PR TITLE
[1.2-dev] Python converter for std::set + test

### DIFF
--- a/test/pytriqs/wrap_test/a.hpp
+++ b/test/pytriqs/wrap_test/a.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <iostream>
 #include <vector>
+#include <set>
 #include <ostream>
 #include <triqs/arrays.hpp>
 //#include <triqs/h5.hpp>
@@ -188,6 +189,12 @@ inline std::map<std::string,std::vector<int>> map_to_mapvec(std::map<std::string
   std::map<std::string,std::vector<int>> mm;
   for(auto const &x: m) mm.emplace(x.first, std::vector<int>{x.second, 3, 5});
   return mm;
+}
+
+inline std::set<int> set_to_set(std::set<std::string> const &s) {
+  std::set<int> ss;
+  for(auto const &x: s) ss.insert(x.size());
+  return ss;
 }
 
 inline std::function<int(int,int)>  make_fnt_ii() {

--- a/test/pytriqs/wrap_test/my_module_desc.py
+++ b/test/pytriqs/wrap_test/my_module_desc.py
@@ -111,6 +111,8 @@ module.add_function (name = "use_fnt_iid", signature = "void(std::function<int(i
 
 module.add_function (name = "map_to_mapvec", signature = "std::map<std::string,std::vector<int>>(std::map<std::string,int> m)", doc = "DOC of print_map")
 
+module.add_function (name = "set_to_set", signature = "std::set<int>(std::set<std::string> s)", doc = "DOC of print_map")
+
 def f1(x,y):
     print " I am in f1 ", x,y
     print y + 1/0.2

--- a/test/pytriqs/wrap_test/wrap_a.output
+++ b/test/pytriqs/wrap_test/wrap_a.output
@@ -19,6 +19,7 @@ use_fnt iid
 use_fnt iid 
 45
 {'a': [1, 3, 5], 'b': [2, 3, 5], 'sjkdf': [5, 3, 5]}
+set([1, 3, 4])
  rereading from hdf5   I am an A with x= 6.9
 'cmy_module\n__reduce_reconstructor__Ac\np0\n(I1\nF3.0\ntp1\nRp2\n.'
  I am an A with x= 3

--- a/test/pytriqs/wrap_test/wrap_a.py
+++ b/test/pytriqs/wrap_test/wrap_a.py
@@ -35,6 +35,8 @@ use_fnt_iid(fp2)
 
 print map_to_mapvec({'a':1, "b":2, "sjkdf":5})
 
+print set_to_set(set(['abcd','2','345','klmn']))
+
 from pytriqs.archive import *
 import pytriqs.archive.hdf_archive_schemes
 

--- a/triqs/python_tools/wrapper_tools.hpp
+++ b/triqs/python_tools/wrapper_tools.hpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <complex>
 #include <vector>
+#include <set>
 #include <triqs/utility/exceptions.hpp>
 #include "./pyref.hpp"
 #include <time.h>
@@ -334,6 +335,43 @@ template <typename K, typename V> struct py_converter<std::map<K,V>> {
    for (int i = 0; i < len; i++)
      res.emplace(py_converter<K>::py2c(PyList_GET_ITEM((PyObject*)keys, i)),  //borrowed ref
                  py_converter<V>::py2c(PyList_GET_ITEM((PyObject*)values, i))); //borrowed ref
+   return res;
+ }
+};
+
+// --- sets ---
+template <typename K> struct py_converter<std::set<K>> {
+ static PyObject * c2py(std::set<K> const &s) {
+  PyObject * set = PySet_New(NULL);
+  for (auto & x : s) if (PySet_Add(set, py_converter<K>::c2py(x)) == -1) { Py_DECREF(set); return NULL;} // error
+  return set;
+ }
+ static PyObject * c2py(std::set<K> &s) {
+  PyObject * set = PySet_New(NULL);
+  for (auto & x : s) if (PySet_Add(set, py_converter<K>::c2py(x)) == -1) { Py_DECREF(set); return NULL;} // error
+  return set;
+ }
+ static bool is_convertible(PyObject *ob, bool raise_exception) {
+  if (!PySet_Check(ob)) goto _false;
+  {
+   pyref keys_it = PyObject_GetIter(ob);
+   pyref key;
+   while(bool(key = PyIter_Next(keys_it))){
+    if (!py_converter<K>::is_convertible(key,raise_exception)) goto _false; //borrowed ref
+   }
+   return true;
+  }
+  _false:
+  if (raise_exception) { PyErr_SetString(PyExc_TypeError, "Cannot convert to std::set");}
+  return false;
+ }
+ static std::set<K> py2c(PyObject * ob) {
+   std::set<K> res;
+   pyref keys_it = PyObject_GetIter(ob);
+   pyref key;
+   while(bool(key = PyIter_Next(keys_it))){
+    res.insert(py_converter<K>::py2c(key));  //borrowed ref
+   }
    return res;
  }
 };


### PR DESCRIPTION
Python converter for `std::set`. Test 'wrap_a' has been changed accordingly.
One of possible uses is passing parameters from Python to a constructor of `fundamental_operator_set`.
