### PR TITLE
Throw in py2c of boost::variant converter

### DIFF
--- a/triqs/python_tools/converters/variant.hpp
+++ b/triqs/python_tools/converters/variant.hpp
@@ -45,8 +45,7 @@ template<typename Iter, typename IterEnd> struct py2c_impl {
 
 template<typename Iter> struct py2c_impl<Iter,Iter> {
  static variant_t apply(PyObject *ob) {
-  // Should never be reached
-  return typename boost::mpl::deref<begin_t>::type();
+  TRIQS_RUNTIME_ERROR << "Internal error: py2c called for a Python object incompatible with boost::variant";
  }
 };
 


### PR DESCRIPTION
After a brief discussion with Olivier (https://github.com/TRIQS/triqs/commit/ae88e397c0e5c220cd96306544301e2f5e88bd1f#commitcomment-8584681) I'm convinced, that `py_converter<boost::variant<Types...>::py2c_impl<Iter,Iter>::apply()` should throw.

This has 3 advantages:
- The code will compile even if the first bounded type of `variant` hasn't got a default constructor (tested);
- The compiler will not issue a warning about a missing `return` statement (also tested);
- If something goes terrible wrong with the converter, one will know, what exactly.
