### PR TITLE
corrected switched assignment of IndicesL and IndicesR

### DIFF
--- a/pytriqs/gf/local/gf_generic.py
+++ b/pytriqs/gf/local/gf_generic.py
@@ -51,7 +51,7 @@ class GfGeneric:
         self.name = name
         self._derived = derived
 
-        self.indicesR, self.indicesL = indices_pack
+        self.indicesL, self.indicesR = indices_pack
 
         copy_reg.pickle(derived, reductor, builder_cls_with_dict_arg )
 


### PR DESCRIPTION
the following would give obvious wrong results:

```
In [1]: from pytriqs.gf.local import GfImFreq

In [2]: A=GfImFreq(indicesL=['L'],indicesR=['R'],beta=50)

In [3]: A
Out[3]: GfImFreq g: indicesL = ['R'], indicesR = ['L']                                                                               
```

Even worse, if you give differnt number of indices for L and R, then N1 and N2 (determined correctly) and indicesL, indicesR would not be consistent. The assignment now is consistent with the return https://github.com/TRIQS/triqs/blob/master/pytriqs/gf/local/tools.py#L77
