### PR TITLE
[arrays] tridiag_worker: support for complex Hermitian matrices

### DIFF
--- a/test/triqs/arrays/tridiag.cpp
+++ b/test/triqs/arrays/tridiag.cpp
@@ -19,60 +19,65 @@
  *
  ******************************************************************************/
 #include "./common.hpp"
-#include <triqs/arrays/linalg/eigenelements.hpp>
 #include <triqs/arrays/blas_lapack/stev.hpp>
+#include <triqs/utility/is_complex.hpp>
+
 using namespace triqs::arrays;
 using namespace triqs;
+using dcomplex = std::complex<double>;
+
+double _conj(double x) { return x; }
+dcomplex _conj(dcomplex x) { return conj(x); }
+
+template <typename T> void check_eig(matrix<T> M, matrix_view<T> vectors, vector_view<double, 1> values) {
+ auto _ = range();
+ for (auto i : range(0,first_dim(M))) {
+  std::cerr << "check "<< i << std::endl;
+  std::cerr << (M -values(i))* vectors(i, _)<<std::endl;
+  assert_all_close(M * vectors(i, _), values(i) * vectors(i, _), 1.e-14);
+ }
+}
+
+template<typename Md, typename Me> void test(Md d, Me e) {
+ using value_t = typename Me::value_type;
+
+ matrix<value_t> A(first_dim(d),first_dim(d));
+ assign_foreach(A,[&](size_t i, size_t j){
+     return j==i ? d(i) :
+            j==i+1 ? e(i) :
+            j==i-1 ? _conj(e(j)) :
+            .0;
+ });
+
+ blas::tridiag_worker<triqs::is_complex<value_t>::value> w(2*first_dim(d));
+ w(d,e);
+
+ std::cerr << "A = " << A << std::endl;
+ std::cerr << " values = " << w.values() << std::endl;
+ std::cerr << " vectors = " << w.vectors() << std::endl;
+ check_eig(A, w.vectors(), w.values());
+}
 
 int main(int argc, char **argv) {
 
- std::cerr << "Real matrix" << std::endl;
+ // Real symmetric matrix
  {
- arrays::vector<double> D (5), DD(4);
- for (size_t i=0; i<5; ++i) {D(i) = 3.2*i+2.3;}
- for (size_t i=0; i<4; ++i) {DD(i) = 2.4*(i+1.82) + 0.78;} 
-
- auto R = range(0,5);
-
- blas::tridiag_worker<false> w(10);
- w(D,DD);
- std::cerr<<" values = "<< w.values()<<std::endl;
- std::cerr<<" vectors = "<< w.vectors()(R,R)<<std::endl;
-
- //check
- matrix<double> A(5,5); A()=0;
- for (size_t i=0; i<5; ++i) A(i,i) = D(i);
- for (size_t i=0; i<4; ++i) { A(i,i+1) = DD(i); A(i+1,i) = DD(i);}
-
- std::cerr<<"A = "<<A<<std::endl;
-
- for(int n=0; n<5; ++n) assert_all_close(A*w.vectors()(n,R),w.values()(n)*w.vectors()(n,R),1.e-10);
+  vector<double> d(5);
+  vector<double> e(4);
+  assign_foreach(d,[](size_t i){ return 3.2*i+2.3; });
+  assign_foreach(e,[](size_t i){ return 2.4*(i+1.82) + 0.78; });
+  e(1) = .0;
+  test(d,e);
  }
 
- std::cerr << std::endl << "Complex matrix" << std::endl;
+ // Complex Hermitian matrix
  {
- std::complex<double> I(0,1.0);
- arrays::vector<double> D (5);
- arrays::vector<std::complex<double>> DD(4);
- for (size_t i=0; i<5; ++i) {D(i) = 3.2*i+2.3;}
- for (size_t i=0; i<4; ++i) {DD(i) = 2.4*(i+1.82) + 0.78*I;}
- DD(1) = 0;
-
- auto R = range(0,5);
-
- blas::tridiag_worker<true> w(10);
- w(D,DD);
- std::cerr<<" values = "<< w.values()<<std::endl;
- std::cerr<<" vectors = "<< w.vectors()(R,R)<<std::endl;
-
- //check
- matrix<std::complex<double>> A(5,5); A()=0;
- for (size_t i=0; i<5; ++i) A(i,i) = D(i);
- for (size_t i=0; i<4; ++i) {A(i,i+1) = DD(i); A(i+1,i) = conj(DD(i));}
-
- std::cerr<<"A = "<<A<<std::endl;
-
- for(int n=0; n<5; ++n) assert_all_close(A*w.vectors()(n,R),w.values()(n)*w.vectors()(n,R),1.e-10);
+  vector<double> d(5);
+  vector<dcomplex> e(4);
+  assign_foreach(d,[](size_t i){ return 3.2*i+2.3; });
+  assign_foreach(e,[](size_t i){ return 2.4*(i+1.82) + 0.78*dcomplex(0,1.0); });
+  e(1) = .0;
+  test(d,e);
  }
 
  return 0;

--- a/triqs/arrays/blas_lapack/stev.hpp
+++ b/triqs/arrays/blas_lapack/stev.hpp
@@ -36,7 +36,9 @@ namespace triqs { namespace arrays { namespace blas {
   }
  }
 
- struct tridiag_worker { 
+ template<bool Complex = false> struct tridiag_worker {};
+
+ template<> struct tridiag_worker<false> {
   arrays::vector<double> D,E,W;
   matrix<double> Z;
   size_t s;
@@ -54,6 +56,39 @@ namespace triqs { namespace arrays { namespace blas {
    }
   arrays::vector_view<double> values() const { return D(range(0,s));}
   matrix_view<double> vectors() const { return Z(range(0,s),range(0,s));}
+ };
+
+ template<> struct tridiag_worker<true> {
+  arrays::vector<double> D,E,W;
+  matrix<double> Z;
+  arrays::vector<std::complex<double>> U; // similarity transformation
+  matrix<std::complex<double>> V;         // transformed eigenvectors
+  size_t s;
+  tridiag_worker (size_t n){ s=0; resize(n);}
+  void resize(size_t n) { if (s<n) {D.resize(n); E.resize(n); W.resize(2*n+1); Z.resize(n,n); U.resize(n); V.resize(n,n);} s = n; }
+  template<typename VTd, typename VTe>
+   void operator()(VTd const & d, VTe const & e /* superdiagonal */) {
+    if (e.size() != d.size() -1) TRIQS_RUNTIME_ERROR << " Error in tridiagonal matrix diagonalization size mismatch";
+    resize(d.size());
+    D(range(0,s)) = d;
+    // construct transformed off-diagonal elements
+    U(0) = 1.0;
+    for(size_t n=0; n<s-1; ++n){
+     double abs_e = abs(e(n));
+     U(n+1) = U(n)*(abs_e<1e-10 ? 1.0 : conj(e(n))/abs_e);
+     E(n) = (e(n)*conj(U(n))*U(n+1)).real();
+    }
+    int info;
+    f77::stev ('V',d.size(),D.data_start(),E.data_start(), Z.data_start(), Z.shape(0),W.data_start(), info);
+    if (info !=0) TRIQS_RUNTIME_ERROR << " Error in tridiagonal matrix diagonalization "<< info;
+
+    // Back-transform the eigenvectors
+    for(size_t n1=0; n1<s; ++n1)
+     for(size_t n2=0; n2<s; ++n2)
+      V(n1,n2) = Z(n1,n2)*conj(U(n1))*U(n2);
+   }
+  arrays::vector_view<double> values() const { return D(range(0,s));}
+  matrix_view<std::complex<double>> vectors() const { return V(range(0,s),range(0,s));}
  };
 
 }}}// namespace

--- a/triqs/arrays/blas_lapack/stev.hpp
+++ b/triqs/arrays/blas_lapack/stev.hpp
@@ -75,7 +75,7 @@ namespace triqs { namespace arrays { namespace blas {
     U(0) = 1.0;
     for(size_t n=0; n<s-1; ++n){
      double abs_e = abs(e(n));
-     U(n+1) = U(n)*(abs_e<1e-10 ? 1.0 : conj(e(n))/abs_e);
+     U(n+1) = U(n)*(std::isnormal(abs_e) ? conj(e(n))/abs_e : 1.0);
      E(n) = (e(n)*conj(U(n))*U(n+1)).real();
     }
     int info;
@@ -83,9 +83,7 @@ namespace triqs { namespace arrays { namespace blas {
     if (info !=0) TRIQS_RUNTIME_ERROR << " Error in tridiagonal matrix diagonalization "<< info;
 
     // Back-transform the eigenvectors
-    for(size_t n1=0; n1<s; ++n1)
-     for(size_t n2=0; n2<s; ++n2)
-      V(n1,n2) = Z(n1,n2)*conj(U(n1))*U(n2);
+    assign_foreach(V, [this](size_t i, size_t j) { return Z(i,j)*conj(U(i))*U(j); });
    }
   arrays::vector_view<double> values() const { return D(range(0,s));}
   matrix_view<std::complex<double>> vectors() const { return V(range(0,s),range(0,s));}

--- a/triqs/arrays/blas_lapack/stev.hpp
+++ b/triqs/arrays/blas_lapack/stev.hpp
@@ -67,19 +67,23 @@ namespace triqs { namespace arrays { namespace blas {
   tridiag_worker (size_t n){ s=0; resize(n);}
   void resize(size_t n) { if (s<n) {D.resize(n); E.resize(n); W.resize(2*n+1); Z.resize(n,n); U.resize(n); V.resize(n,n);} s = n; }
   template<typename VTd, typename VTe>
-   void operator()(VTd const & d, VTe const & e /* superdiagonal */) {
-    if (e.size() != d.size() -1) TRIQS_RUNTIME_ERROR << " Error in tridiagonal matrix diagonalization size mismatch";
-    resize(d.size());
-    D(range(0,s)) = d;
-    // construct transformed off-diagonal elements
-    U(0) = 1.0;
-    for(size_t n=0; n<s-1; ++n){
-     double abs_e = abs(e(n));
-     U(n+1) = U(n)*(std::isnormal(abs_e) ? conj(e(n))/abs_e : 1.0);
-     E(n) = (e(n)*conj(U(n))*U(n+1)).real();
+   void operator()(VTd const & diag, VTe const & supdiag /* superdiagonal */) {
+    if (supdiag.size() != diag.size() -1) TRIQS_RUNTIME_ERROR << " Error in tridiagonal matrix diagonalization size mismatch";
+    resize(diag.size());
+    D(range(0,s)) = diag;
+    // construct transformed off-diagonal elements;
+    auto U_it = std::begin(U);
+    auto E_it = std::begin(E);
+    *U_it = 1.0;
+    for(auto e : supdiag){
+      auto U_old = *U_it;
+      ++U_it;
+      *U_it = U_old*(std::isnormal(abs(e)) ? conj(e)/abs(e) : 1.0);
+      *E_it = std::real(e*conj(U_old)*(*U_it));
+      ++E_it;
     }
     int info;
-    f77::stev ('V',d.size(),D.data_start(),E.data_start(), Z.data_start(), Z.shape(0),W.data_start(), info);
+    f77::stev ('V',diag.size(),D.data_start(),E.data_start(), Z.data_start(), Z.shape(0),W.data_start(), info);
     if (info !=0) TRIQS_RUNTIME_ERROR << " Error in tridiagonal matrix diagonalization "<< info;
 
     // Back-transform the eigenvectors


### PR DESCRIPTION
A tridiagonal complex Hermitian matrix can be easily (in linear time) made real symmetric through a similarity transformation. Such a transformation replaces the off-diagonal elements of the matrix by their absolute values. The transformation itself is given by a diagonal unitary matrix, which can be stored as a complex vector.

After an application of `dstev` to the real matrix, the eigenvectors must be back-transformed using the stored transformation matrix.