### PR TITLE
[cmake] New approach to running Python tests in TRIQS applications

### DIFF
--- a/cmake/TRIQSConfig.cmake.in
+++ b/cmake/TRIQSConfig.cmake.in
@@ -34,6 +34,7 @@ set(TRIQS_LIBRARY_GSL     @GSL_LIBRARIES@)
 set(TRIQS_WITH_PYTHON_SUPPORT @TRIQS_WITH_PYTHON_SUPPORT@)
 set(TRIQS_HDF5_DIFF_EXECUTABLE @TRIQS_HDF5_DIFF_EXECUTABLE@)
 set(TRIQS_HDF5_COMMAND_PATH @TRIQS_HDF5_COMMAND_PATH@)
+set(TRIQS_PYTHON_LIB_DEST_ROOT @TRIQS_PYTHON_LIB_DEST_ROOT@)
 set(TRIQS_PYTHON_LIB_DEST @TRIQS_PYTHON_LIB_DEST@)
 
 # for people who want to quickly add everything TRIQS has detected...
@@ -240,6 +241,69 @@ macro (triqs_prepare_local_pytriqs_merged_with_my_python python_destination)
 
 endmacro()
 
+# A macro to create a local copy of triqs with the added python
+macro (triqs_prepare_local_pytriqs python_destination)
+
+  # Create the local build_pytriqs executable
+  file(WRITE ${CMAKE_BINARY_DIR}/build_pytriqs
+  "#!/bin/bash
+export PYTHONPATH=${CMAKE_BINARY_DIR}:${TRIQS_PATH}/${TRIQS_PYTHON_LIB_DEST_ROOT}:$PYTHONPATH
+${TRIQS_PYTHON_INTERPRETER} $@"
+  )
+  execute_process(COMMAND chmod 755 ${CMAKE_BINARY_DIR}/build_pytriqs)
+
+  # Create the local build_ipytriqs executable
+  file(WRITE ${CMAKE_BINARY_DIR}/build_ipytriqs
+  "#!/bin/bash
+export PYTHONPATH=${CMAKE_BINARY_DIR}:${TRIQS_PATH}/${TRIQS_PYTHON_LIB_DEST_ROOT}:$PYTHONPATH
+
+${TRIQS_PYTHON_INTERPRETER} -c \"
+import sys
+import IPython
+assert IPython.__version__ >= '2' , 'ipython version too low: need 2.x or higher for the notebook'
+from IPython.terminal.ipapp import launch_new_instance
+sys.exit(launch_new_instance())
+\" $@"
+  )
+  execute_process(COMMAND chmod 755 ${CMAKE_BINARY_DIR}/build_ipytriqs)
+
+  # Create the local build_ipytriqs_notebook executable
+  file(WRITE ${CMAKE_BINARY_DIR}/build_ipytriqs_notebook
+  "#!/bin/bash
+export PYTHONPATH=${CMAKE_BINARY_DIR}:${TRIQS_PATH}/${TRIQS_PYTHON_LIB_DEST_ROOT}:$PYTHONPATH
+
+${TRIQS_PYTHON_INTERPRETER} -c \"
+import sys
+sys.argv.insert(1, 'notebook')
+import IPython
+assert IPython.__version__ >= '2' , 'ipython version too low: need 2.x or higher for the notebook'
+# pylab=inline is REMOVED in 3.x version of IPython.
+if IPython.__version__ < '3.0.0':
+  sys.argv.insert(2, '--pylab=inline')
+  sys.argv.insert(3, '--MappingKernelManager.time_to_dead=3600')
+else:
+  sys.argv.insert(2, '--MappingKernelManager.time_to_dead=3600')
+from IPython.terminal.ipapp import launch_new_instance
+sys.exit(launch_new_instance())
+\" $@"
+  )
+  execute_process(COMMAND chmod 755 ${CMAKE_BINARY_DIR}/build_ipytriqs_notebook)
+
+  # Create sitecustomize.py file
+  # It will redirect import requests from pytriqs/${python_destination} to python dir
+  string(REPLACE "/" "." python_destination_with_dots ${python_destination})
+  file(WRITE ${CMAKE_BINARY_DIR}/sitecustomize.py
+  "package_name = 'pytriqs.${python_destination_with_dots}'
+def application_pytriqs_import(name,*args,**kwargs):
+  if name.startswith(package_name):
+    name = 'python' + name[len(package_name):]
+  return builtin_import(name,*args,**kwargs)
+
+import __builtin__
+__builtin__.__import__, builtin_import = application_pytriqs_import, __builtin__.__import__"
+  )
+
+endmacro(triqs_prepare_local_pytriqs)
 
 #
 # This macro builds the f2py module

--- a/cmake/TRIQSConfig.cmake.in
+++ b/cmake/TRIQSConfig.cmake.in
@@ -303,18 +303,32 @@ import __builtin__
 __builtin__.__import__, builtin_import = application_pytriqs_import, __builtin__.__import__"
   )
 
- # Install all other files
- install(DIRECTORY ${CMAKE_SOURCE_DIR}/python/ DESTINATION ${TRIQS_PYTHON_LIB_DEST}/${python_destination} FILES_MATCHING PATTERN *.py)
+  # Install the __init__.py files
+  set(INIT_PY_INSTALLATION_SCRIPT
+  "
+set(partial_dir \"${python_destination}\")
+while(partial_dir MATCHES \"/\")
+  string(REGEX REPLACE \"/[^/]*$\" \"\" partial_dir \${partial_dir})
+  set(init_py_path \"${TRIQS_PATH}/${TRIQS_PYTHON_LIB_DEST}/\${partial_dir}/__init__.py\")
+  if(NOT EXISTS \"\${init_py_path}\")
+    message(STATUS \"Generating: \${init_py_path}\")
+    file(WRITE \${init_py_path} \"__all__=[]\")
+  endif()
+endwhile()")
+  install(CODE ${INIT_PY_INSTALLATION_SCRIPT})
 
- # Set a rule to have original python files copied to their destination if modified
- file(GLOB_RECURSE python_sources RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.py)
- set(py_copy_tar ${CMAKE_CURRENT_BINARY_DIR}/py_copy.tar)
- add_custom_command(OUTPUT ${py_copy_tar}
+  # Install all other files
+  install(DIRECTORY ${CMAKE_SOURCE_DIR}/python/ DESTINATION ${TRIQS_PYTHON_LIB_DEST}/${python_destination} FILES_MATCHING PATTERN *.py)
+
+  # Set a rule to have original python files copied to their destination if modified
+  file(GLOB_RECURSE python_sources RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.py)
+  set(py_copy_tar ${CMAKE_CURRENT_BINARY_DIR}/py_copy.tar)
+  add_custom_command(OUTPUT ${py_copy_tar}
      COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_CURRENT_SOURCE_DIR} tar cf ${py_copy_tar} ${python_sources}
      COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_CURRENT_BINARY_DIR} tar xf ${py_copy_tar}
      COMMAND ${CMAKE_COMMAND} -E remove ${py_copy_tar}
      DEPENDS ${python_sources})
- add_custom_target(py_copy ALL DEPENDS ${py_copy_tar})
+  add_custom_target(py_copy ALL DEPENDS ${py_copy_tar})
 
 endmacro(triqs_prepare_local_pytriqs)
 

--- a/cmake/TRIQSConfig.cmake.in
+++ b/cmake/TRIQSConfig.cmake.in
@@ -303,6 +303,19 @@ import __builtin__
 __builtin__.__import__, builtin_import = application_pytriqs_import, __builtin__.__import__"
   )
 
+ # Install all other files
+ install(DIRECTORY ${CMAKE_SOURCE_DIR}/python/ DESTINATION ${TRIQS_PYTHON_LIB_DEST}/${python_destination} FILES_MATCHING PATTERN *.py)
+
+ # Set a rule to have original python files copied to their destination if modified
+ file(GLOB_RECURSE python_sources RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.py)
+ set(py_copy_tar ${CMAKE_CURRENT_BINARY_DIR}/py_copy.tar)
+ add_custom_command(OUTPUT ${py_copy_tar}
+     COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_CURRENT_SOURCE_DIR} tar cf ${py_copy_tar} ${python_sources}
+     COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_CURRENT_BINARY_DIR} tar xf ${py_copy_tar}
+     COMMAND ${CMAKE_COMMAND} -E remove ${py_copy_tar}
+     DEPENDS ${python_sources})
+ add_custom_target(py_copy ALL DEPENDS ${py_copy_tar})
+
 endmacro(triqs_prepare_local_pytriqs)
 
 #


### PR DESCRIPTION
This pull request is meant to improve the way Python tests of TRIQS applications are run.

# Problem description

To be able to successfully run a Python test script, the Python interpreter needs access to a 'logical sum' of two pytriqs package trees,

* one from an installation of the TRIQS library (`${TRIQS_PYTHON_LIB_DEST_ROOT}`);
* and one from the build directory of the application (normally `${CMAKE_BINARY_DIR}/python`).

The second tree takes precedence over the first in case both trees contain similar branches. 

# Current solution

There is currently a special CMake macro called `triqs_prepare_local_pytriqs_merged_with_my_python()`.
Besides other things, it scans through the installed pytriqs package tree and recreates the corresponding directory structure in `${CMAKE_BINARY_DIR}/pytriqs`.
Files in the installed tree are represented by symlinks in the destination tree. If a file has an counterpart in `${CMAKE_BINARY_DIR}/python`, the a symlink pointing at that location is created.
Once the merged tree is prepared, one can use it by adding `${CMAKE_BINARY_DIR}/pytriqs` to `PYTHONPATH`.

This solution proved to work, however, I've been seeing weird symlink-related build failures happening once in a while (especially, when I was developing two or more TRIQS applications simultaneously.)
So I decided to come up with a less complicated and fragile solution.

# Proposed solution

Here I define a new macro `triqs_prepare_local_pytriqs(python_destination)`. It has two functions.

* It creates three local wrapper scripts `build_pytriqs`, `build_ipytriqs` and `build_ipytriqs_notebook` (just as the old macro does). The scripts have received an update that puts them in sync with the scripts from `/shells` dir.
* It also generates a short python script `${CMAKE_BINARY_DIR}/sitecustomize.py`.

Python automatically imports `sitecustomize.py` before running a script or an interactive shell (given the CWD is `${CMAKE_BINARY_DIR}`). This scripts installs a special hook, which intercepts calls to the `__import__()` builtin function. The hook checks whether a part of the application subpackage (for instance, `pytriqs/applications/impurity_solvers/cthyb`) is about to be imported. If it is the case, the hook rewrites the name of the subpackage and effectively redirects import request to `${CMAKE_BINARY_DIR}/python`.

In the described approach no local copy of the pytriqs tree is needed at all.

For testing purposes I created a cthyb branch `new_python_build_system`, where the introduced mechanism is used: TRIQS/cthyb@c4ecb22cbece75539bf82a020fba798f11668690.

P.S. The old `triqs_prepare_local_pytriqs_merged_with_my_python()` is kept intact for the existing applications. It should be announced to be deprecated, if this pull request is accepted.