### PR TITLE
[hilbert_space] Fix for function project(state,hilbert_space)

### DIFF
--- a/triqs/hilbert_space/state.hpp
+++ b/triqs/hilbert_space/state.hpp
@@ -102,7 +102,7 @@ class state<HilbertSpace, ScalarType, true> : boost::additive<state<HilbertSpace
  friend value_type dot_product(state const& s1, state const& s2) {
   value_type res = 0.0;
   for (auto const& a : s1.ampli) {
-   if (s2.ampli.count(a.first) == 1) res += conj_(a.second) * s2.ampli.at(a.first);
+   if (s2.ampli.count(a.first) == 1) res += triqs::utility::_conj(a.second) * s2.ampli.at(a.first);
   }
   return res;
  }

--- a/triqs/hilbert_space/state.hpp
+++ b/triqs/hilbert_space/state.hpp
@@ -265,7 +265,7 @@ template<typename TargetState, typename OriginalState>
 TargetState project(OriginalState const& psi, hilbert_space const& proj_hs) {
  TargetState proj_psi(proj_hs);
  auto const& hs = psi.get_hilbert();
- auto f = __lambda1<TargetState,hilbert_space> {proj_psi, hs};
+ auto f = __lambda1<TargetState,decltype(hs)> {proj_psi, hs};
  foreach(psi, f);
  return proj_psi;
 }
@@ -274,7 +274,7 @@ template<typename TargetState, typename OriginalState>
 TargetState project(OriginalState const& psi, sub_hilbert_space const& proj_hs) {
  TargetState proj_psi(proj_hs);
  auto const& hs = psi.get_hilbert();
- auto f = __lambda2<TargetState,sub_hilbert_space,hilbert_space> {proj_psi, proj_hs, hs};
+ auto f = __lambda2<TargetState,sub_hilbert_space,decltype(hs)> {proj_psi, proj_hs, hs};
  foreach(psi,f);
  return proj_psi;
 }


### PR DESCRIPTION
* A workaround for a bug in Clang 3.4 was itself buggy.
* Need this fix urgently for the state classification functionality in cthyb.