### PR TITLE
[hilbert_space] Meaningful exception message from fundamental_operator_set::operator[]

### DIFF
--- a/triqs/hilbert_space/fundamental_operator_set.hpp
+++ b/triqs/hilbert_space/fundamental_operator_set.hpp
@@ -20,6 +20,7 @@
  ******************************************************************************/
 #pragma once
 #include <triqs/operators/many_body_operator.hpp>
+#include <triqs/utility/exceptions.hpp>
 #include <vector>
 #include <set>
 #include <map>
@@ -64,7 +65,18 @@ class fundamental_operator_set {
  int size() const { return map_index_n.size(); }
 
  // flatten (a,alpha) --> n
- int operator[](indices_t const& t) const { return map_index_n.at(t); }
+ int operator[](indices_t const& t) const {
+  try {
+   return map_index_n.at(t);
+  } catch(std::out_of_range &) {
+   std::stringstream msg;
+   msg << "Operator with indices (";
+   int u = 0;
+   for(auto const& i : t) { if (u++) msg << ","; msg << i; }
+   msg << ") does not belong to this fundamental set!";
+   TRIQS_RUNTIME_ERROR << msg.str();
+  }
+ }
 
  // iterator on the tuples
  // for (auto & x : fops) { x.linear_index is linear_index, while x.index is the C multi-index.

--- a/triqs/operators/many_body_operator.hpp
+++ b/triqs/operators/many_body_operator.hpp
@@ -287,19 +287,13 @@ namespace utility {
    if (triqs::utility::is_zero(it->second)) m.erase(it);
   }
 
-  struct print_visitor : public boost::static_visitor<> {
-   std::ostream& os;
-   print_visitor(std::ostream& os_) : os(os_) {}
-   template <typename T> void operator()(T const& x) const { os << x; }
-  };
-
   friend std::ostream& operator<<(std::ostream& os, canonical_ops_t const& op) {
    if (op.dagger) os << "^+";
    os << "(";
    int u = 0;
    for (auto const& i : op.indices) {
     if (u++) os << ",";
-    boost::apply_visitor(print_visitor{os}, i);
+    os << i;
    }
    return os << ")";
   }


### PR DESCRIPTION
During a recent debugging session I realized that the first (and last) place, where invalid indices of a `many_body_operator` can be detected, is `fundamental_operator_set::operator[]`. This function may throw an instance of `std::out_of_range` with an empty message, which gives no clue about the actual problem.