### PR TITLE
[c++2py] New converter for std::tuple.

### DIFF
--- a/pytriqs/c++2py/mako/xxx_desc.py
+++ b/pytriqs/c++2py/mako/xxx_desc.py
@@ -27,6 +27,8 @@
         'std::string' : 'string',
         'std::function' : 'function',
         'std::pair' : 'pair',
+        'std::tuple' : 'tuple',
+        'boost::variant' : 'variant'
         }
 
     used_module_list, converters_list = [], set()
@@ -60,6 +62,7 @@
         analyse(f.rtype)
 
     used_module_list = set(used_module_list) # makes unique
+    converters_list = set(converters_list)
     using_list = [using_needed_for_modules[m] for m in used_module_list]
 
     def cls(t) :

--- a/test/pytriqs/wrap_test/a.hpp
+++ b/test/pytriqs/wrap_test/a.hpp
@@ -196,6 +196,22 @@ inline std::set<int> set_to_set(std::set<std::string> const &s) {
  return ss;
 }
 
+inline std::tuple<> tuple_to_tuple_0(std::tuple<> const& t) {
+ return std::make_tuple();
+}
+
+inline std::tuple<int> tuple_to_tuple_1(std::tuple<int> const& t) {
+ return std::make_tuple(2*std::get<0>(t));
+}
+
+inline std::tuple<int,double> tuple_to_tuple_2(std::tuple<int,double> const& t) {
+ return std::make_tuple(2*std::get<0>(t),1/std::get<1>(t));
+}
+
+inline std::tuple<int,double,std::string> tuple_to_tuple_3(std::tuple<int,double,std::string> const& t) {
+ return std::make_tuple(2*std::get<0>(t),1/std::get<1>(t),"*" + std::get<2>(t) + "*");
+}
+
 inline std::function<int(int,int)>  make_fnt_ii() {
  return [](int i, int j) { return i + 2*j;}; 
 }

--- a/test/pytriqs/wrap_test/my_module_desc.py
+++ b/test/pytriqs/wrap_test/my_module_desc.py
@@ -11,6 +11,7 @@ module.add_include("<triqs/python_tools/converters/function.hpp>")
 module.add_include("<triqs/python_tools/converters/gf.hpp>")
 module.add_include("<triqs/python_tools/converters/map.hpp>")
 module.add_include("<triqs/python_tools/converters/set.hpp>")
+module.add_include("<triqs/python_tools/converters/tuple.hpp>")
 module.add_include("<triqs/../test/pytriqs/wrap_test/a.hpp>")
 
 # one class
@@ -120,6 +121,12 @@ module.add_function (name = "use_fnt_iid", signature = "void(std::function<int(i
 module.add_function (name = "map_to_mapvec", signature = "std::map<std::string,std::vector<int>>(std::map<std::string,int> m)", doc = "DOC of print_map")
 
 module.add_function (name = "set_to_set", signature = "std::set<int>(std::set<std::string> s)", doc = "DOC of set_to_set")
+
+for i in range(0,4):
+    name = "tuple_to_tuple_%i"%i
+    tt = ','.join(('int','double','std::string')[:i])
+    signature = "std::tuple<%s>(std::tuple<%s> t)" % (tt,tt)
+    module.add_function(name = name, signature = signature, doc = "DOC of tuple_to_tuple_%i"%i)
 
 def f1(x,y):
     print " I am in f1 ", x,y

--- a/test/pytriqs/wrap_test/wrap_a.output
+++ b/test/pytriqs/wrap_test/wrap_a.output
@@ -20,6 +20,10 @@ use_fnt iid
 45
 {'a': [1, 3, 5], 'b': [2, 3, 5], 'sjkdf': [5, 3, 5]}
 set([1, 3, 4])
+[]
+[18]
+[18, 0.4]
+[18, 0.4, '*hi*']
  rereading from hdf5   I am an A with x= 6.9
 'cmy_module\n__reduce_reconstructor__Ac\np0\n(I1\nF3.0\ntp1\nRp2\n.'
  I am an A with x= 3

--- a/test/pytriqs/wrap_test/wrap_a.py
+++ b/test/pytriqs/wrap_test/wrap_a.py
@@ -37,6 +37,11 @@ print map_to_mapvec({'a':1, "b":2, "sjkdf":5})
 
 print set_to_set(set(['abcd','2','345','klmn']))
 
+print tuple_to_tuple_0([])
+print tuple_to_tuple_1((9,))
+print tuple_to_tuple_2((9,2.5))
+print tuple_to_tuple_3((9,2.5,'hi'))
+
 from pytriqs.archive import *
 import pytriqs.archive.hdf_archive_schemes
 

--- a/triqs/python_tools/converters/tuple.hpp
+++ b/triqs/python_tools/converters/tuple.hpp
@@ -1,0 +1,69 @@
+#pragma once
+#include "../wrapper_tools.hpp"
+#include <tuple>
+
+namespace triqs {
+namespace py_tools {
+
+ template <typename... Types> struct py_converter<std::tuple<Types...>> {
+
+ private:
+  using tuple_t = std::tuple<Types...>;
+
+  // c2py implementation
+  template<int N, typename T, typename... Tail> static void c2py_impl(PyObject *list, tuple_t const& t, bool& ok) {
+   int res = PyList_Append(list,py_converter<T>::c2py(std::get<N>(t)));
+   ok = (res != -1);
+   if(ok) c2py_impl<N+1,Tail...>(list,t,ok);
+  }
+  template<int> static void c2py_impl(PyObject *list, tuple_t const& t, bool& ok) {}
+
+  // is_convertible implementation
+  template<int N, typename T, typename... Tail> static bool is_convertible_impl(PyObject *seq, bool raise_exception) {
+   return py_converter<T>::is_convertible(PySequence_Fast_GET_ITEM(seq, N), raise_exception) &&
+          is_convertible_impl<N+1,Tail...>(seq, raise_exception);
+  }
+  template<int> static bool is_convertible_impl(PyObject *seq, bool raise_exception){ return true; }
+
+  // py2c implementation
+  template<int N, typename T, typename... Tail> static std::tuple<T,Tail...> py2c_impl(PyObject *seq) {
+   return std::tuple_cat(std::make_tuple(py_converter<T>::py2c(PySequence_Fast_GET_ITEM(seq, N))),
+                         py2c_impl<N+1,Tail...>(seq));
+  }
+  template<int> static std::tuple<> py2c_impl(PyObject *seq) { return std::make_tuple(); }
+
+ public:
+  static PyObject *c2py(tuple_t const &t) {
+   PyObject *list = PyList_New(0);
+   bool ok = true;
+   c2py_impl<0,Types...>(list,t,ok);
+   if(!ok) {
+     Py_DECREF(list);
+     return NULL;
+   }
+   return list;
+  }
+
+  static bool is_convertible(PyObject *ob, bool raise_exception) {
+   if (PySequence_Check(ob)) {
+    pyref seq = PySequence_Fast(ob, "expected a sequence");
+    // Sizes must match! Could we relax this condition to '<'?
+    if (PySequence_Fast_GET_SIZE((PyObject *)seq) != std::tuple_size<tuple_t>::value) goto _false;
+    if (!is_convertible_impl<0,Types...>((PyObject *)seq, raise_exception)) goto _false;
+    return true;
+   }
+  _false:
+   if (raise_exception) {
+    PyErr_SetString(PyExc_TypeError, "Cannot convert to std::tuple");
+   }
+   return false;
+  }
+
+  static tuple_t py2c(PyObject *ob) {
+   pyref seq = PySequence_Fast(ob, "expected a sequence");
+   return py2c_impl<0,Types...>((PyObject *)seq);
+  }
+ };
+}
+}
+

--- a/triqs/python_tools/converters/tuple.hpp
+++ b/triqs/python_tools/converters/tuple.hpp
@@ -12,7 +12,8 @@ namespace py_tools {
 
   // c2py implementation
   template<int N, typename T, typename... Tail> static void c2py_impl(PyObject *list, tuple_t const& t, bool& ok) {
-   int res = PyList_Append(list,py_converter<T>::c2py(std::get<N>(t)));
+   pyref e = py_converter<T>::c2py(std::get<N>(t));
+   int res = PyList_Append(list,e);
    ok = (res != -1);
    if(ok) c2py_impl<N+1,Tail...>(list,t,ok);
   }


### PR DESCRIPTION
* Converts any Python sequence of length N>=0 to std::tuple<...> with the same number of elements.
* Converts std::tuple<...> to a Python list.
* No bits of Boost are used, only the standard C++11 library.
* Wrapping test is updated.