### PR TITLE
[c++2py] Optionally override 'Type' and 'Default' fields of parameter's doc

### DIFF
--- a/pytriqs/c++2py/mako/parameters.rst
+++ b/pytriqs/c++2py/mako/parameters.rst
@@ -3,6 +3,19 @@
 <%
   def doc_format(member_list) : 
    h= ['Parameter Name', 'Type', 'Default', 'Documentation']
+   # Doc post-processing
+   for m in member_list:
+       m.doc, doc_lines = "", [l.lstrip() for l in m.doc.splitlines()]
+       for l in doc_lines:
+           if l.startswith('type:'):
+              # Override 'Type' field
+              m.ctype = l[5:].lstrip()
+              continue
+           if l.startswith('default:'):
+              # Override 'Default' field
+              m.initializer = l[8:].lstrip()
+              continue
+           m.doc += l + ' '
    n_lmax = max(len(h[0]), max(len(m.name) for m in member_list))
    type_lmax = max(len(h[1]), max(len(m.ctype) for m in member_list))
    opt_lmax = max(len(h[2]), max(len(m.initializer) for m in member_list if m.initializer))


### PR DESCRIPTION
With this patch one can use two special tags 'type:' and 'default:' when documenting a member of the parameter class. For example,
```c++

 /// Quantum numbers
 /// type: list(Operator)
 /// default: []
 std::vector<real_operator_t> quantum_numbers = std::vector<real_operator_t>{};
```
or
```c++
 /// Verbosity level
 /// default: 3 on MPI rank 0, 0 otherwise.
 int verbosity = ((boost::mpi::communicator().rank() == 0) ? 3 : 0); // silence the slave nodes
```
Automatically extracted expressions like `((boost::mpi::communicator().rank() == 0) ? 3 : 0)` may look quite ugly and break formatting of the documentation page.