### PR TITLE
Fixed bug in det_manip

### DIFF
--- a/triqs/det_manip/det_manip.cpp
+++ b/triqs/det_manip/det_manip.cpp
@@ -1,0 +1,62 @@
+#include "./det_manip.hpp"
+
+namespace triqs { namespace det_manip {
+
+complex_as_logphi& complex_as_logphi::operator=(std::complex<double> a) {
+  log=std::log(std::abs(a));
+  phi=std::arg(a);
+  return *this;
+}
+
+complex_as_logphi& complex_as_logphi::operator*=(const complex_as_logphi& a) {
+  log+=a.log;
+  phi+=a.phi;
+  return *this;
+}
+
+complex_as_logphi& complex_as_logphi::operator*=(std::complex<double> a) {
+  log+=std::log(std::abs(a));
+  phi+=std::arg(a);
+  return *this;
+}
+
+complex_as_logphi::operator double() const{
+  double a = std::exp(log);
+  if (not std::isfinite(a)) TRIQS_RUNTIME_ERROR << "det_manip::determinant is underflowing!";
+  //if ( (phi!=0.0) or (phi != PI) )
+  //  TRIQS_RUNTIME_ERROR << "det_manip casting insto double truncates the imaginary part!";
+  return a*real(std::exp(std::complex<double>(0.0,1.0)*phi));
+}
+
+complex_as_logphi::operator std::complex<double>() const {
+  double a = std::exp(log);
+  if (not std::isfinite(a)) TRIQS_RUNTIME_ERROR << "det_manip::determinant is underflowing!";
+  return a*std::exp(std::complex<double>(0.0,1.0)*phi);
+}
+
+complex_as_logphi operator*(complex_as_logphi a, const complex_as_logphi& b) {
+  a*=b; 
+  return a;
+}
+
+complex_as_logphi operator*(complex_as_logphi a, std::complex<double> b) {
+  a*=b;
+  return a;
+}
+
+complex_as_logphi operator*(std::complex<double> b, complex_as_logphi a) {
+  return a*b;
+}
+
+complex_as_logphi operator/(complex_as_logphi a, std::complex<double> b) {
+  b = 1.0/b; 
+  return a*b;
+}
+
+complex_as_logphi operator/(std::complex<double> b, complex_as_logphi a) {
+  a.log *= -1.0;
+  a.phi *= -1.0;
+  return b*a;
+}
+
+}}

--- a/triqs/det_manip/det_manip.hpp
+++ b/triqs/det_manip/det_manip.hpp
@@ -546,7 +546,8 @@ namespace triqs { namespace det_manip {
      w1.ksi = mat_inv(w1.jreal,w1.ireal);
      newdet = det*w1.ksi;
      newsign = ((i + j)%2==0 ? sign : -sign);
-     return (newdet/det)*(newsign*sign); // sign is unity, hence 1/sign == sign
+     //return (newdet/det)*(newsign*sign); // sign is unity, hence 1/sign == sign
+     return (w1.ksi)*(newsign*sign); // sign is unity, hence 1/sign == sign
     }
     //------------------------------------------------------------------------------------------
    private:

--- a/triqs/det_manip/det_manip.hpp
+++ b/triqs/det_manip/det_manip.hpp
@@ -72,8 +72,8 @@ namespace triqs { namespace det_manip {
   using xy_type = typename f_tr::template decay_arg<0>::type;
   using value_type = typename f_tr::result_type;
   //using det_type = std14::conditional_t<std::is_same<value_type,double>::value,float_as_logsign,complex_as_logphi >;
-  using det_type = complex_as_logphi;
-
+  //using det_type = complex_as_logphi;
+  using det_type = value_type;
   static_assert(std::is_floating_point<value_type>::value || triqs::is_complex<value_type>::value,
                 "det_manip : the function must return a floating number or a complex number");
 

--- a/triqs/det_manip/det_manip.hpp
+++ b/triqs/det_manip/det_manip.hpp
@@ -37,70 +37,24 @@ namespace triqs { namespace det_manip {
  namespace blas = arrays::blas; 
 
  struct complex_as_logphi {
-   complex_as_logphi(): log(1.0), phi(1.0) {};
+   complex_as_logphi(): log(0.0), phi(0.0) {};
    complex_as_logphi(double log_, double phi_): log(log_), phi(phi_) {};
    double log;
    double phi;
 
-   complex_as_logphi& operator=(std::complex<double> a) {
-     log=std::log(std::abs(a));
-     phi=std::arg(a);
-     return *this;
-   }
+   complex_as_logphi& operator=(std::complex<double> a);
+   complex_as_logphi& operator*=(const complex_as_logphi& a);
+   complex_as_logphi& operator*=(std::complex<double> a);
 
-   complex_as_logphi& operator*=(const complex_as_logphi& a) {
-     log+=a.log;
-     phi+=a.phi;
-     return *this;
-   }
-
-   complex_as_logphi& operator*=(std::complex<double> a) {
-     log+=std::log(std::abs(a));
-     phi+=std::arg(a);
-     return *this;
-   }
-
-   explicit operator double() const {
-     double a = std::exp(log);
-     if (not std::isfinite(a)) TRIQS_RUNTIME_ERROR << "det_manip::determinant is underflowing!";
-     //if ( (phi!=0.0) or (phi != PI) )
-     //  TRIQS_RUNTIME_ERROR << "det_manip casting insto double truncates the imaginary part!";
-     return a*real(std::exp(std::complex<double>(0.0,1.0)*phi));
-   }
-
-   explicit operator std::complex<double>() const {
-     double a = std::exp(log);
-     if (not std::isfinite(a)) TRIQS_RUNTIME_ERROR << "det_manip::determinant is underflowing!";
-     return a*std::exp(std::complex<double>(0.0,1.0)*phi);
-   }
-
-
+   explicit operator double() const ;
+   explicit operator std::complex<double>() const ;
  }; 
 
- complex_as_logphi operator*(complex_as_logphi a, const complex_as_logphi& b) {
-   a*=b; 
-   return a;
- }
-
- complex_as_logphi operator*(complex_as_logphi a, std::complex<double> b) {
-   a*=b;
-   return a;
- }
-
- complex_as_logphi operator*(std::complex<double> b, complex_as_logphi a) {
-   return a*b;
- }
-
- complex_as_logphi operator/(complex_as_logphi a, std::complex<double> b) {
-   b = 1.0/b; 
-   return a*b;
- }
-
- complex_as_logphi operator/(std::complex<double> b, complex_as_logphi a) {
-   a.log *= -1.0;
-   a.phi *= -1.0;
-   return b*a;
- }
+ complex_as_logphi operator*(complex_as_logphi a, const complex_as_logphi& b);
+ complex_as_logphi operator*(complex_as_logphi a, std::complex<double> b);
+ complex_as_logphi operator*(std::complex<double> b, complex_as_logphi a);
+ complex_as_logphi operator/(complex_as_logphi a, std::complex<double> b);
+ complex_as_logphi operator/(std::complex<double> b, complex_as_logphi a);
 
 
  /**
@@ -328,7 +282,7 @@ namespace triqs { namespace det_manip {
 
     /** det M of the current state of the matrix.  */
     value_type determinant() const {
-      return value_type(det);
+      return sign*value_type(det);
     }
 
     /** Returns M^{-1}(i,j) */

--- a/triqs/utility/time_pt.hpp
+++ b/triqs/utility/time_pt.hpp
@@ -39,7 +39,7 @@ namespace triqs { namespace utility {
 
   private : 
   // too dangerous because of rounding to be left public
-  time_pt(double v, double beta_) { beta = beta_; val = v; n = std::floor(Nmax*(v/beta));}
+  time_pt(double v, double beta_) { beta = beta_; val = v; if (v==beta) n = Nmax; else n = std::floor(Nmax*(v/beta));}
   time_pt(uint64_t n_, double beta_, bool) { beta = beta_; val = beta*(double(n_)/Nmax); n = n_;}
   
   public : 


### PR DESCRIPTION
There is an underflow problem with det_manip because the determinant ratio returned from try_remove, try_remove2, etc. is in the end not calculated directly from inverse matrix elements, but from the actual ratio between the new and the old determinant. When the old determinant is underflowing (is zero), nan is returned.

This is now fixed by skipping the unnecessary step of recalculating the determinant ratio which we already have

newdet = det*ksi
return ksi //instead of return newdet/det

Also, a multiscale complex type (complex_as_logphi) is introduced for the value of det and newdet such that even when the value of determinant is underflowing in some MC steps, it can become finite again. complex_as_logphi stores std::abs and std::arg of value_type (double or complex<double>), but abs as log(abs) such that much lower values can be stored than available in double.