### PR TITLE
Remove Find(NFFT) from Triqs CMakeLists.txt and make FindNFFT.cmake standalone

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -336,17 +336,6 @@ include_directories(SYSTEM ${FFTW_INCLUDE_DIR})
 set(TRIQS_LIBRARY_FFTW ${FFTW_LIBRARIES})
 set(TRIQS_INCLUDE_FFTW ${FFTW_INCLUDE_DIR})
 
-# NFFT
-message( STATUS "-------- NFFT detection (optional) -------------")
-find_package(NFFT)
-IF(NFFT_FOUND)
-include_directories(SYSTEM ${NFFT_INCLUDE_DIR})
-#link_libraries( ${NFFT_LIBRARIES})
-set(TRIQS_LIBRARY_FFTW ${TRIQS_LIBRARY_FFTW} ${NFFT_LIBRARIES})
-set(TRIQS_INCLUDE_FFTW ${TRIQS_INCLUDE_FFTW} ${NFFT_INCLUDE_DIR})
-set(TRIQS_CXX_DEFINITIONS ${TRIQS_CXX_DEFINITIONS} -DHAVE_NFFT )
-ENDIF(NFFT_FOUND)
-
 # remove the possible horrible pthread bug on os X !!( on gcc, old, before clang... is it really needed now ???)
 # check for clang compiler ?? on gcc, os X snow leopard, it MUST be set
 # since _REENTRANT is mysteriously set and this leads to random stalling of the code....
@@ -518,10 +507,10 @@ if (Build_Documentation)
 endif (Build_Documentation)
 
 #------------------------
-# FindTRIQS needs to be configured and installed
+# FindTRIQS and FindNFFT need to be installed
 #------------------------
 
-install (FILES ${CMAKE_SOURCE_DIR}/cmake/FindTRIQS.cmake DESTINATION share/triqs/cmake)
+install (FILES ${CMAKE_SOURCE_DIR}/cmake/FindTRIQS.cmake ${CMAKE_SOURCE_DIR}/cmake/FindNFFT.cmake DESTINATION share/triqs/cmake)
 
 #------------------------
 # TRIQS cmake file and config.h

--- a/cmake/FindNFFT.cmake
+++ b/cmake/FindNFFT.cmake
@@ -36,7 +36,7 @@ FIND_LIBRARY(NFFT_LIBRARIES nfft3 ${TRIAL_LIBRARY_PATHS} DOC "NFFT library")
 mark_as_advanced(NFFT_INCLUDE_DIR)
 mark_as_advanced(NFFT_LIBRARIES)
 
-file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/nfft_api_test.cpp "#include \"nfft3.h\"\nint main(){ nfft_plan p; return p.nfft_plan; }")
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/nfft_api_test.cpp "#include \"nfft3.h\"\nint main(){ nfft_plan p; return p.nfft_flags; }")
 try_compile(NFFT_OLD_API ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_BINARY_DIR}/nfft_api_test.cpp COMPILE_DEFINITIONS -I${NFFT_INCLUDE_DIR} )
 file(REMOVE ${CMAKE_CURRENT_BINARY_DIR}/a.out ${CMAKE_CURRENT_BINARY_DIR}/nfft_api_test.cpp)
 

--- a/cmake/FindNFFT.cmake
+++ b/cmake/FindNFFT.cmake
@@ -5,8 +5,10 @@
 
 #
 # This module looks for nfft.
-# It sets up : NFFT_INCLUDE_DIR, NFFT_LIBRARIES
+# It sets up : NFFT_INCLUDE_DIR, NFFT_LIBRARIES, NFFT_OLD_API
 # 
+
+INCLUDE( FindPackageHandleStandardArgs ) 
 
 SET(TRIAL_PATHS
  $ENV{NFFT_ROOT}/include
@@ -33,6 +35,10 @@ FIND_LIBRARY(NFFT_LIBRARIES nfft3 ${TRIAL_LIBRARY_PATHS} DOC "NFFT library")
 
 mark_as_advanced(NFFT_INCLUDE_DIR)
 mark_as_advanced(NFFT_LIBRARIES)
+
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/nfft_api_test.cpp "#include \"nfft3.h\"\nint main(){ nfft_plan p; return p.nfft_plan; }")
+try_compile(NFFT_OLD_API ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_BINARY_DIR}/nfft_api_test.cpp COMPILE_DEFINITIONS -I${NFFT_INCLUDE_DIR} )
+file(REMOVE ${CMAKE_CURRENT_BINARY_DIR}/a.out ${CMAKE_CURRENT_BINARY_DIR}/nfft_api_test.cpp)
 
 FIND_PACKAGE_HANDLE_STANDARD_ARGS(NFFT DEFAULT_MSG NFFT_LIBRARIES NFFT_INCLUDE_DIR)
 


### PR DESCRIPTION
Nfft should be found by applications that require it, not with triqs.

Adjustments to FindNFFT.cmake:
 -check for API change and make it standalone

Install FindNFFT.cmake alongside triqs