### PR TITLE
[gfs] closest_mesh_pt functionality for cartesian product mesh.

### DIFF
--- a/triqs/gfs.hpp
+++ b/triqs/gfs.hpp
@@ -58,6 +58,7 @@
 #include "./gfs/functions/functions2.hpp"
 #include "./gfs/functions/imfreq.hpp"
 #include "./gfs/functions/imtime.hpp"
+#include "./gfs/functions/product.hpp"
 #include "./gfs/functions/legendre.hpp"
 #include "./gfs/functions/density.hpp"
 

--- a/triqs/gfs/functions/product.hpp
+++ b/triqs/gfs/functions/product.hpp
@@ -21,26 +21,22 @@
 #pragma once
 
 namespace triqs {
-namespace gfs {
+ namespace gfs {
 
- //-------------------------------------------------------
- // rebinning
- // ------------------------------------------------------
+  //-------------------------------------------------------
+  // closest mesh point on the grid
+  // ------------------------------------------------------
 
- gf<imtime> rebinning_tau(gf_const_view<imtime> const &g, int new_n_tau);
+  template <typename... Ms, typename Target> struct gf_closest_point<cartesian_product<Ms...>, Target> {
+   using index_t = typename gf_mesh<cartesian_product<Ms...>>::index_t;
 
- //-------------------------------------------------------
- // closest mesh point on the grid
- // ------------------------------------------------------
+   template <typename M, typename... T, size_t... Is> static index_t _impl(M const& m, closest_pt_wrap<T...> const& p, std14::index_sequence<Is...>) {
+    return index_t(gf_closest_point<Ms, Target>::invoke(std::get<Is>(m), closest_pt_wrap<T>{std::get<Is>(p.value_tuple)})...);
+   }
 
- template <typename Target> struct gf_closest_point<imtime, Target> {
-  // index_t is int
-  template <typename M, typename T> static int invoke(M const &mesh, closest_pt_wrap<T> const &p) {
-   double x = double(p.value) + 0.5 * mesh.delta();
-   int n = std::floor(x / mesh.delta());
-   return n;
-  }
- };
+   template <typename M, typename... T> static index_t invoke(M const& m, closest_pt_wrap<T...> const& p) {
+    return _impl(m, p, std14::index_sequence_for<T...>{});
+   }
+  };
+ }
 }
-}
-

--- a/triqs/gfs/gf/gf.hxx
+++ b/triqs/gfs/gf/gf.hxx
@@ -33,8 +33,8 @@ namespace triqs {
  namespace gfs {
 
   // forward
-  namespace details { 
-  template <typename G, typename... Args> decltype(auto) partial_eval(G *g, Args const &... args);
+  namespace details {
+   template <typename G, typename... Args> decltype(auto) partial_eval(G* g, Args const&... args);
   }
 
   /*----------------------------------------------------------
@@ -66,24 +66,20 @@ namespace triqs {
 
   template <typename M, typename T> struct is_gf<gf_const_view<M, T>, M> : std::true_type {};
 
-  template <typename G, typename M> struct is_gf<G &, M> : is_gf<G, M> {};
-  template <typename G, typename M> struct is_gf<G const &, M> : is_gf<G, M> {};
-  template <typename G, typename M> struct is_gf<G &&, M> : is_gf<G, M> {};
+  template <typename G, typename M> struct is_gf<G&, M> : is_gf<G, M> {};
+  template <typename G, typename M> struct is_gf<G const&, M> : is_gf<G, M> {};
+  template <typename G, typename M> struct is_gf<G&&, M> : is_gf<G, M> {};
 
   /// ---------------------------  implementation  ---------------------------------
 
   namespace details {
    // FIXME : replace by if constexpr when possible
-   template <typename A> void _rebind_helper(A &x, A const &y) { x.rebind(y); }
-   inline void _rebind_helper(dcomplex &x, dcomplex const &y) { x = y; }
-   inline void _rebind_helper(double &x, double const &y) { x = y; }
+   template <typename A> void _rebind_helper(A& x, A const& y) { x.rebind(y); }
+   inline void _rebind_helper(dcomplex& x, dcomplex const& y) { x = y; }
+   inline void _rebind_helper(double& x, double const& y) { x = y; }
   }
   struct impl_tag {};
   struct impl_tag2 {};
-
-  
-   
-  
 
   // ----------------------  gf -----------------------------------------
   /**
@@ -140,14 +136,14 @@ namespace triqs {
    // ------------- Accessors -----------------------------
 
    /// Access the  mesh
-   mesh_t const &mesh() const { return _mesh; }
-   domain_t const &domain() const { return _mesh.domain(); }
+   mesh_t const& mesh() const { return _mesh; }
+   domain_t const& domain() const { return _mesh.domain(); }
 
    /// Direct access to the data array
-   data_t &data() { return _data; }
+   data_t& data() { return _data; }
 
    /// Const version
-   data_t const &data() const { return _data; }
+   data_t const& data() const { return _data; }
 
    /// Shape of the target
    auto target_shape() const { return _data.shape().template front_mpop<arity>(); } // drop arity dims
@@ -156,15 +152,15 @@ namespace triqs {
    auto data_shape() const { return _data.shape(); }
 
    ///
-   zero_t const &get_zero() const { return _zero; }
+   zero_t const& get_zero() const { return _zero; }
 
    /// Access to the singularity
-   singularity_t &singularity() { return _singularity; }
+   singularity_t& singularity() { return _singularity; }
 
    /// Const version
-   singularity_t const &singularity() const { return _singularity; }
+   singularity_t const& singularity() const { return _singularity; }
 
-   indices_t const &indices() const { return _indices; }
+   indices_t const& indices() const { return _indices; }
 
    private:
    mesh_t _mesh;
@@ -185,17 +181,17 @@ namespace triqs {
    private:
    // build a zero from a slice of data
    // MUST be static since it is used in constructors... (otherwise bug in clang)
-   template <typename T> static zero_t __make_zero(T, data_t const &d) {
+   template <typename T> static zero_t __make_zero(T, data_t const& d) {
     auto r = zero_regular_t{d.shape().template front_mpop<arity>()};
     r()    = 0;
     return r;
    }
-   static zero_t __make_zero(scalar_valued, data_t const &d) { return 0; } // special case
-   static zero_t _make_zero(data_t const &d) { return __make_zero(Target{}, d); }
+   static zero_t __make_zero(scalar_valued, data_t const& d) { return 0; } // special case
+   static zero_t _make_zero(data_t const& d) { return __make_zero(Target{}, d); }
    zero_t _remake_zero() { return _zero = _make_zero(_data); } // NOT in constructor...
 
    template <typename G>
-   gf(impl_tag2, G &&x)
+   gf(impl_tag2, G&& x)
       : _mesh(x.mesh())
       , _data(x.data())
       , _zero(_make_zero(_data))
@@ -204,7 +200,7 @@ namespace triqs {
       , name(x.name) {}
 
    template <typename M, typename D, typename S>
-   gf(impl_tag, M &&m, D &&dat, S &&sing, indices_t ind)
+   gf(impl_tag, M&& m, D&& dat, S&& sing, indices_t ind)
       : _mesh(std::forward<M>(m))
       , _data(std::forward<D>(dat))
       , _zero(_make_zero(_data))
@@ -215,19 +211,17 @@ namespace triqs {
    }
 
    public:
-
    /// Construct an empty Green function (with empty array).
    gf() {} // all arrays of zero size (empty)
 
-
    /// Copy constructor
-   gf(gf const &x)
+   gf(gf const& x)
       : _mesh(x.mesh()), _data(x.data()), _zero(x._zero), _singularity(x.singularity()), _indices(x.indices()), name(x.name) {}
 
    /// Move constructor
-   gf(gf &&) = default;
+   gf(gf&&) = default;
 
-   void swap_impl(gf &b) noexcept {
+   void swap_impl(gf& b) noexcept {
     using std::swap;
     swap(this->_mesh, b._mesh);
     swap(this->_data, b._data);
@@ -239,15 +233,14 @@ namespace triqs {
 
    using singularity_factory = gf_singularity_factory<_singularity_regular_t>;
 
-
    private:
    using target_shape_t = arrays::mini_vector<int, Target::rank - is_tail_valued(Target{})>;
 
-   template <typename U> static auto make_data_shape(U, mesh_t const &m, target_shape_t const &shap) {
+   template <typename U> static auto make_data_shape(U, mesh_t const& m, target_shape_t const& shap) {
     return join(m.size_of_components(), shap);
    }
 
-   template <typename U> static auto make_data_shape(tail_valued<U>, mesh_t const &m, target_shape_t const &shap) {
+   template <typename U> static auto make_data_shape(tail_valued<U>, mesh_t const& m, target_shape_t const& shap) {
     return join(mini_vector<int, 2>{int(m.size()), __tail<matrix_valued>::_size()}, shap); // shap.front_append(m.size());
    }
 
@@ -257,27 +250,27 @@ namespace triqs {
       : gf(impl_tag{}, std::move(m), std::move(dat), std::move(si), std::move(ind)) {}
 
    // Construct from mesh, target_shape, memory order
-   gf(mesh_t m, target_shape_t shape, arrays::memory_layout<arity + Target::rank> const &ml, indices_t const &ind = indices_t{})
+   gf(mesh_t m, target_shape_t shape, arrays::memory_layout<arity + Target::rank> const& ml, indices_t const& ind = indices_t{})
       : gf(impl_tag{}, std::move(m), data_t(make_data_shape(Target{}, m, shape), ml), singularity_factory::make(m, shape), ind) {
     if (this->_indices.empty()) this->_indices = indices_t(shape);
    }
 
    // Construct from mesh, target_shape, memory order
-   gf(mesh_t m, target_shape_t shape = target_shape_t{}, indices_t const &ind = indices_t{}, std::string _name = {})
+   gf(mesh_t m, target_shape_t shape = target_shape_t{}, indices_t const& ind = indices_t{}, std::string _name = {})
       : gf(impl_tag{}, std::move(m), data_t(make_data_shape(Target{}, m, shape)), singularity_factory::make(m, shape), ind) {
     if (this->_indices.empty()) this->_indices = indices_t(shape);
     name                                       = std::move(_name);
    }
 
    /// From a gf_view of the same kind
-   gf(gf_view<Var, Target> const &g) : gf(impl_tag2{}, g) {}
+   gf(gf_view<Var, Target> const& g) : gf(impl_tag2{}, g) {}
 
    /// From a const_gf_view of the same kind
-   gf(gf_const_view<Var, Target> const &g) : gf(impl_tag2{}, g) {}
+   gf(gf_const_view<Var, Target> const& g) : gf(impl_tag2{}, g) {}
 
    /// Construct from anything which models ImmutableGreenFunction.
    // TODO: We would like to refine this, G should have the same mesh, target, at least ...
-   template <typename G> gf(G const &x, std14::enable_if_t<ImmutableGreenFunction<G>::value> *dummy = 0) : gf() { *this = x; }
+   template <typename G> gf(G const& x, std14::enable_if_t<ImmutableGreenFunction<G>::value>* dummy = 0) : gf() { *this = x; }
 
    /// Construct from the mpi lazy class of the implementation class, cf mpi section
    // NB : type must be the same, e.g. g2(mpi_reduce(g1)) will work only if mesh, Target, Singularity are the same...
@@ -286,16 +279,16 @@ namespace triqs {
    /// ---------------  swap --------------------
 
    /// implement the swap
-   friend void swap(gf &a, gf &b) noexcept { a.swap_impl(b); }
+   friend void swap(gf& a, gf& b) noexcept { a.swap_impl(b); }
 
    /// ---------------  Operator = --------------------
 
    /// Copy assignment
-   gf &operator=(gf const &rhs) { return *this = gf(rhs); } // use move =
+   gf& operator=(gf const& rhs) { return *this = gf(rhs); } // use move =
    //
-   gf &operator=(gf &rhs) { return *this = gf(rhs); } // use move =
+   gf& operator=(gf& rhs) { return *this = gf(rhs); } // use move =
    /// Move assignment
-   gf &operator=(gf &&rhs) noexcept {
+   gf& operator=(gf&& rhs) noexcept {
     this->swap_impl(rhs);
     return *this;
    }
@@ -313,12 +306,13 @@ namespace triqs {
     * The assignment resizes the mesh and the data, invalidating all pointers on them.
     *
     */
-   template <typename RHS> gf &operator=(RHS &&rhs) {
+   template <typename RHS> gf& operator=(RHS&& rhs) {
     _mesh = rhs.mesh();
     _data.resize(rhs.data_shape());
     _remake_zero();
-    for (auto const &w : _mesh) (*this)[w] = rhs[w];
-    _singularity                           = rhs.singularity();
+    for (auto const& w : _mesh)
+     (*this)[w]  = rhs[w];
+    _singularity = rhs.singularity();
     // to be implemented : there is none in the gf_expr in particular....
     // indices and name are not affected by it ???
     return *this;
@@ -326,12 +320,10 @@ namespace triqs {
 
    // other = late, cf MPI
 
-
    public:
    // ------------- apply_on_data -----------------------------
 
-   
-   template <typename Fdata, typename Fsing, typename Find> auto apply_on_data(Fdata &&fd, Fsing &&fs, Find &&fi)  {
+   template <typename Fdata, typename Fsing, typename Find> auto apply_on_data(Fdata&& fd, Fsing&& fs, Find&& fi) {
     auto d2  = fd(_data);
     using t2 = std14::conditional_t<is_tail_valued(Target()), tail_valued<target_from_array<decltype(d2), arity + 1>>,
                                     target_from_array<decltype(d2), arity>>;
@@ -339,11 +331,11 @@ namespace triqs {
     return gv_t{_mesh, d2, typename gv_t::singularity_t{fs(_singularity)}, fi(_indices)};
    }
 
-   template <typename Fdata, typename Fsing> auto apply_on_data(Fdata &&fd, Fsing &&fs)  {
-    return apply_on_data(std::forward<Fdata>(fd), std::forward<Fsing>(fs), [](auto &) { return indices_t{}; });
+   template <typename Fdata, typename Fsing> auto apply_on_data(Fdata&& fd, Fsing&& fs) {
+    return apply_on_data(std::forward<Fdata>(fd), std::forward<Fsing>(fs), [](auto&) { return indices_t{}; });
    }
-   
-   template <typename Fdata, typename Fsing, typename Find> auto apply_on_data(Fdata &&fd, Fsing &&fs, Find &&fi) const {
+
+   template <typename Fdata, typename Fsing, typename Find> auto apply_on_data(Fdata&& fd, Fsing&& fs, Find&& fi) const {
     auto d2  = fd(_data);
     using t2 = std14::conditional_t<is_tail_valued(Target()), tail_valued<target_from_array<decltype(d2), arity + 1>>,
                                     target_from_array<decltype(d2), arity>>;
@@ -351,8 +343,8 @@ namespace triqs {
     return gv_t{_mesh, d2, typename gv_t::singularity_t{fs(_singularity)}, fi(_indices)};
    }
 
-   template <typename Fdata, typename Fsing> auto apply_on_data(Fdata &&fd, Fsing &&fs) const {
-    return apply_on_data(std::forward<Fdata>(fd), std::forward<Fsing>(fs), [](auto &) { return indices_t{}; });
+   template <typename Fdata, typename Fsing> auto apply_on_data(Fdata&& fd, Fsing&& fs) const {
+    return apply_on_data(std::forward<Fdata>(fd), std::forward<Fsing>(fs), [](auto&) { return indices_t{}; });
    }
 
    // ------------- All the call operators without lazy arguments -----------------------------
@@ -371,45 +363,41 @@ namespace triqs {
            ((sizeof...(Args) != evaluator_t::arity) && (evaluator_t::arity != -1)) // if -1 : no check
        ,
        std::result_of<evaluator_t(gf, Args...)> // what is the result type of call
-       >::type                                       // end of lazy_disable_if
-   operator()(Args &&... args) const {
+       >::type                                  // end of lazy_disable_if
+   operator()(Args&&... args) const {
     return evaluator_t()(*this, std::forward<Args>(args)...);
    }
 
    // ------------- Call with lazy arguments -----------------------------
 
    // Calls with at least one lazy argument : we make a clef expression, cf clef documentation
-   template <typename... Args> clef::make_expr_call_t<gf &, Args...> operator()(Args &&... args) & {
+   template <typename... Args> clef::make_expr_call_t<gf&, Args...> operator()(Args&&... args) & {
     return clef::make_expr_call(*this, std::forward<Args>(args)...);
    }
 
-   template <typename... Args> clef::make_expr_call_t<gf const &, Args...> operator()(Args &&... args) const & {
+   template <typename... Args> clef::make_expr_call_t<gf const&, Args...> operator()(Args&&... args) const & {
     return clef::make_expr_call(*this, std::forward<Args>(args)...);
    }
 
-   template <typename... Args> clef::make_expr_call_t<gf, Args...> operator()(Args &&... args) && {
+   template <typename... Args> clef::make_expr_call_t<gf, Args...> operator()(Args&&... args) && {
     return clef::make_expr_call(std::move(*this), std::forward<Args>(args)...);
    }
 
    // ------------- All the [] operators without lazy arguments -----------------------------
 
    // pass a index_t of the mesh
-   decltype(auto) operator[](mesh_index_t const &arg) {
-    return dproxy_t::invoke(_data, _mesh.index_to_linear(arg));
-   }
-   decltype(auto) operator[](mesh_index_t const &arg) const {
-    return dproxy_t::invoke(_data, _mesh.index_to_linear(arg));
-   }
+   decltype(auto) operator[](mesh_index_t const& arg) { return dproxy_t::invoke(_data, _mesh.index_to_linear(arg)); }
+   decltype(auto) operator[](mesh_index_t const& arg) const { return dproxy_t::invoke(_data, _mesh.index_to_linear(arg)); }
 
    // pass a mesh_point of the mesh
-   decltype(auto) operator[](mesh_point_t const &x) {
+   decltype(auto) operator[](mesh_point_t const& x) {
 #ifdef TRIQS_DEBUG
     if (this->_mesh != x.mesh()) TRIQS_RUNTIME_ERROR << "gf[ ] : mesh point's mesh and gf's mesh mismatch";
 #endif
     return dproxy_t::invoke(_data, x.linear_index());
    }
 
-   decltype(auto) operator[](mesh_point_t const &x) const {
+   decltype(auto) operator[](mesh_point_t const& x) const {
 #ifdef TRIQS_DEBUG
     if (this->_mesh != x.mesh()) TRIQS_RUNTIME_ERROR << "gf[ ] : mesh point's mesh and gf's mesh mismatch";
 #endif
@@ -417,69 +405,69 @@ namespace triqs {
    }
 
    // pass an abtract closest_point. We extract the value of the domain from p, call the gf_closest_point trait
-   template <typename... U> decltype(auto) operator[](closest_pt_wrap<U...> const &p) {
-    return dproxy_t::invoke(_data, _mesh.index_to_linear(gf_closest_point<Var, Target>::invoke(this, p)));
+   template <typename... U> decltype(auto) operator[](closest_pt_wrap<U...> const& p) {
+    return dproxy_t::invoke(_data, _mesh.index_to_linear(gf_closest_point<Var, Target>::invoke(this->mesh(), p)));
    }
-   template <typename... U> decltype(auto) operator[](closest_pt_wrap<U...> const &p) const {
-    return dproxy_t::invoke(_data, _mesh.index_to_linear(gf_closest_point<Var, Target>::invoke(this, p)));
+   template <typename... U> decltype(auto) operator[](closest_pt_wrap<U...> const& p) const {
+    return dproxy_t::invoke(_data, _mesh.index_to_linear(gf_closest_point<Var, Target>::invoke(this->mesh(), p)));
    }
 
    // ------------- [] with lazy arguments -----------------------------
 
-   template <typename Arg> clef::make_expr_subscript_t<gf const &, Arg> operator[](Arg &&arg) const & {
+   template <typename Arg> clef::make_expr_subscript_t<gf const&, Arg> operator[](Arg&& arg) const & {
     return clef::make_expr_subscript(*this, std::forward<Arg>(arg));
    }
 
-   template <typename Arg> clef::make_expr_subscript_t<gf &, Arg> operator[](Arg &&arg) & {
+   template <typename Arg> clef::make_expr_subscript_t<gf&, Arg> operator[](Arg&& arg) & {
     return clef::make_expr_subscript(*this, std::forward<Arg>(arg));
    }
 
-   template <typename Arg> clef::make_expr_subscript_t<gf, Arg> operator[](Arg &&arg) && {
+   template <typename Arg> clef::make_expr_subscript_t<gf, Arg> operator[](Arg&& arg) && {
     return clef::make_expr_subscript(std::move(*this), std::forward<Arg>(arg));
    }
 
    // --------------------- A direct access to the grid point --------------------------
 
-   template <typename... Args> decltype(auto) get_from_linear_index(Args &&... args) {
+   template <typename... Args> decltype(auto) get_from_linear_index(Args&&... args) {
     return dproxy_t::invoke(_data, linear_mesh_index_t(std::forward<Args>(args)...));
    }
 
-   template <typename... Args> decltype(auto) get_from_linear_index(Args &&... args) const {
+   template <typename... Args> decltype(auto) get_from_linear_index(Args&&... args) const {
     return dproxy_t::invoke(_data, linear_mesh_index_t(std::forward<Args>(args)...));
    }
 
-   template <typename... Args> decltype(auto) on_mesh(Args &&... args) {
+   template <typename... Args> decltype(auto) on_mesh(Args&&... args) {
     return dproxy_t::invoke(_data, _mesh.index_to_linear(mesh_index_t(std::forward<Args>(args)...)));
    }
 
-   template <typename... Args> decltype(auto) on_mesh(Args &&... args) const {
+   template <typename... Args> decltype(auto) on_mesh(Args&&... args) const {
     return dproxy_t::invoke(_data, _mesh.index_to_linear(mesh_index_t(std::forward<Args>(args)...)));
    }
 
    // --------------------- on mesh (g) : the call before [] -------------------------
    // This is a workaround the the lack of multi argument [] in C++
-/*
-   // mesh points should be treated slighly differently : take their index....
-   template <typename... T> decltype(auto) on_mesh(mesh_point<T> const &... args) { return on_mesh(args.index()...); }
-   template <typename... T> decltype(auto) on_mesh(mesh_point<T> const &... args) const { return on_mesh(args.index()...); }
+   /*
+      // mesh points should be treated slighly differently : take their index....
+      template <typename... T> decltype(auto) on_mesh(mesh_point<T> const &... args) { return on_mesh(args.index()...); }
+      template <typename... T> decltype(auto) on_mesh(mesh_point<T> const &... args) const { return on_mesh(args.index()...); }
 
-   // The on_mesh little adaptor ....
-   private:
-   template <typename G> struct _on_mesh_wrapper {
-    G &f;
-    template <typename... Args>
-    auto operator()(Args &&... args) const
-        -> std14::enable_if_t<!triqs::clef::is_any_lazy<Args...>::value, decltype(f.on_mesh(std::forward<Args>(args)...))> {
-     return f.on_mesh(std::forward<Args>(args)...);
-    }
-    TRIQS_CLEF_IMPLEMENT_LAZY_CALL();
-   };
+      // The on_mesh little adaptor ....
+      private:
+      template <typename G> struct _on_mesh_wrapper {
+       G &f;
+       template <typename... Args>
+       auto operator()(Args &&... args) const
+           -> std14::enable_if_t<!triqs::clef::is_any_lazy<Args...>::value, decltype(f.on_mesh(std::forward<Args>(args)...))> {
+        return f.on_mesh(std::forward<Args>(args)...);
+       }
+       TRIQS_CLEF_IMPLEMENT_LAZY_CALL();
+      };
 
-   public:
-   // TRIQS_DEPRECATED("Use [][][] instead")
-   _on_mesh_wrapper<gf const> friend on_mesh(gf const &f) { return {f}; }
-   _on_mesh_wrapper<gf> friend on_mesh(gf &f) { return {f}; }
-*/
+      public:
+      // TRIQS_DEPRECATED("Use [][][] instead")
+      _on_mesh_wrapper<gf const> friend on_mesh(gf const &f) { return {f}; }
+      _on_mesh_wrapper<gf> friend on_mesh(gf &f) { return {f}; }
+   */
    public:
    // --------------------- [][][][] ------------------------
    // This is a workaround the the lack of multi argument [] in C++
@@ -487,33 +475,35 @@ namespace triqs {
    /**
     *
     */
-   template <typename T> decltype(auto) operator[](T const &x) {
-    return triqs::utility::make_lazy_bracket<arity>([this](auto &&... y) ->decltype(auto){ return details::partial_eval(this, y...); }, x);
+   template <typename T> decltype(auto) operator[](T const& x) {
+    return triqs::utility::make_lazy_bracket<arity>(
+        [this](auto&&... y) -> decltype(auto) { return details::partial_eval(this, y...); }, x);
    }
 
    /**
     *
     */
-   template <typename T> decltype(auto) operator[](T const &x) const {
-    return triqs::utility::make_lazy_bracket<arity>([this](auto &&... y) ->decltype(auto){ return details::partial_eval(this, y...); }, x);
+   template <typename T> decltype(auto) operator[](T const& x) const {
+    return triqs::utility::make_lazy_bracket<arity>(
+        [this](auto&&... y) -> decltype(auto) { return details::partial_eval(this, y...); }, x);
    }
 
    //----------------------------- HDF5 -----------------------------
 
    /// HDF5 name
-   friend std::string get_triqs_hdf5_data_scheme(gf const &g) { return "Gf" + gf_h5_name<Var, Target>::invoke(); }
+   friend std::string get_triqs_hdf5_data_scheme(gf const& g) { return "Gf" + gf_h5_name<Var, Target>::invoke(); }
 
    friend struct gf_h5_rw<Var, Target>;
 
    /// Write into HDF5
-   friend void h5_write(h5::group fg, std::string const &subgroup_name, gf const &g) {
+   friend void h5_write(h5::group fg, std::string const& subgroup_name, gf const& g) {
     auto gr = fg.create_group(subgroup_name);
     gr.write_triqs_hdf5_data_scheme(g);
     gf_h5_rw<Var, Target>::write(gr, g);
    }
 
    /// Read from HDF5
-   friend void h5_read(h5::group fg, std::string const &subgroup_name, gf &g) {
+   friend void h5_read(h5::group fg, std::string const& subgroup_name, gf& g) {
     auto gr = fg.open_group(subgroup_name);
     // Check the attribute or throw
     auto tag_file     = gr.read_triqs_hdf5_data_scheme();
@@ -528,24 +518,21 @@ namespace triqs {
    //-----------------------------  BOOST Serialization -----------------------------
    friend class boost::serialization::access;
    /// The serialization as required by Boost
-   template <class Archive> void serialize(Archive &ar, const unsigned int version) {
-    ar &_data;
-    ar &_singularity;
-    ar &_mesh;
-    ar &_indices;
-    ar &name;
+   template <class Archive> void serialize(Archive& ar, const unsigned int version) {
+    ar& _data;
+    ar& _singularity;
+    ar& _mesh;
+    ar& _indices;
+    ar& name;
    }
 
    //----------------------------- print  -----------------------------
 
    /// IO
-   friend std::ostream &operator<<(std::ostream &out, gf const &x) { return out << "gf"; }
+   friend std::ostream& operator<<(std::ostream& out, gf const& x) { return out << "gf"; }
 
    //----------------------------- MPI  -----------------------------
 
-   
-
-   
    /**
      * Initiate (lazy) MPI Bcast
      *
@@ -559,14 +546,13 @@ namespace triqs {
      * @return Returns a lazy object describing the object and the MPI operation to be performed.
      *
      */
-   
-   friend void mpi_broadcast(gf &g, mpi::communicator c = {}, int root = 0) {
+
+   friend void mpi_broadcast(gf& g, mpi::communicator c = {}, int root = 0) {
     // Shall we bcast mesh ?
     mpi_broadcast(g.data(), c, root);
     mpi_broadcast(g.singularity(), c, root);
    }
 
-   
    /**
      * Initiate (lazy) MPI Reduce
      *
@@ -580,13 +566,12 @@ namespace triqs {
      * @return Returns a lazy object describing the object and the MPI operation to be performed.
      *
      */
-   
-   friend mpi_lazy<mpi::tag::reduce, const_view_type> mpi_reduce(gf const &a, mpi::communicator c = {}, int root = 0,
+
+   friend mpi_lazy<mpi::tag::reduce, const_view_type> mpi_reduce(gf const& a, mpi::communicator c = {}, int root = 0,
                                                                  bool all = false, MPI_Op op = MPI_SUM) {
     return {a(), c, root, all, op};
    }
 
-   
    /**
      * Initiate (lazy) MPI AllReduce
      *
@@ -600,13 +585,12 @@ namespace triqs {
      * @return Returns a lazy object describing the object and the MPI operation to be performed.
      *
      */
-   
-   friend mpi_lazy<mpi::tag::reduce, const_view_type> mpi_all_reduce(gf const &a, mpi::communicator c = {}, int root = 0,
+
+   friend mpi_lazy<mpi::tag::reduce, const_view_type> mpi_all_reduce(gf const& a, mpi::communicator c = {}, int root = 0,
                                                                      MPI_Op op = MPI_SUM) {
     return {a(), c, root, true, op};
    }
 
-   
    /**
      * Initiate (lazy) MPI Scatter
      *
@@ -620,12 +604,11 @@ namespace triqs {
      * @return Returns a lazy object describing the object and the MPI operation to be performed.
      *
      */
-   
-   friend mpi_lazy<mpi::tag::scatter, const_view_type> mpi_scatter(gf const &a, mpi::communicator c = {}, int root = 0) {
+
+   friend mpi_lazy<mpi::tag::scatter, const_view_type> mpi_scatter(gf const& a, mpi::communicator c = {}, int root = 0) {
     return {a(), c, root, true};
    }
 
-   
    /**
      * Initiate (lazy) MPI Gather
      *
@@ -639,13 +622,12 @@ namespace triqs {
      * @return Returns a lazy object describing the object and the MPI operation to be performed.
      *
      */
-   
-   friend mpi_lazy<mpi::tag::gather, const_view_type> mpi_gather(gf const &a, mpi::communicator c = {}, int root = 0,
+
+   friend mpi_lazy<mpi::tag::gather, const_view_type> mpi_gather(gf const& a, mpi::communicator c = {}, int root = 0,
                                                                  bool all = false) {
     return {a(), c, root, all};
    }
 
-   
    /**
      * Initiate (lazy) MPI AllGather
      *
@@ -659,11 +641,10 @@ namespace triqs {
      * @return Returns a lazy object describing the object and the MPI operation to be performed.
      *
      */
-   
-   friend mpi_lazy<mpi::tag::gather, const_view_type> mpi_all_gather(gf const &a, mpi::communicator c = {}, int root = 0) {
+
+   friend mpi_lazy<mpi::tag::gather, const_view_type> mpi_all_gather(gf const& a, mpi::communicator c = {}, int root = 0) {
     return {a(), c, root, true};
    }
-
 
    //-------------  corresponding operator = overload
 
@@ -672,8 +653,8 @@ namespace triqs {
     * @param l The lazy object returned by mpi_reduce
     */
    void operator=(mpi_lazy<mpi::tag::reduce, gf_const_view<Var, Target>> l) {
-    _mesh = l.rhs.mesh();
-    _data = arrays::mpi_reduce(l.rhs.data(), l.c, l.root, l.all, l.op); // arrays:: necessary on gcc 5. why ??
+    _mesh        = l.rhs.mesh();
+    _data        = arrays::mpi_reduce(l.rhs.data(), l.c, l.root, l.all, l.op); // arrays:: necessary on gcc 5. why ??
     _singularity = mpi_reduce(l.rhs.singularity(), l.c, l.root, l.all, l.op);
    }
 
@@ -682,8 +663,8 @@ namespace triqs {
      * @param l The lazy object returned by mpi_reduce
      */
    void operator=(mpi_lazy<mpi::tag::scatter, gf_const_view<Var, Target>> l) {
-    _mesh = mpi_scatter(l.rhs.mesh(), l.c, l.root);
-    _data = mpi_scatter(l.rhs.data(), l.c, l.root, true);
+    _mesh                                  = mpi_scatter(l.rhs.mesh(), l.c, l.root);
+    _data                                  = mpi_scatter(l.rhs.data(), l.c, l.root, true);
     if (l.c.rank() == l.root) _singularity = l.rhs.singularity();
     mpi_broadcast(_singularity, l.c, l.root);
    }
@@ -693,13 +674,11 @@ namespace triqs {
      * @param l The lazy object returned by mpi_reduce
      */
    void operator=(mpi_lazy<mpi::tag::gather, gf_const_view<Var, Target>> l) {
-    _mesh = mpi_gather(l.rhs.mesh(), l.c, l.root);
-    _data = mpi_gather(l.rhs.data(), l.c, l.root, l.all);
+    _mesh                                             = mpi_gather(l.rhs.mesh(), l.c, l.root);
+    _data                                             = mpi_gather(l.rhs.data(), l.c, l.root, l.all);
     if (l.all || (l.c.rank() == l.root)) _singularity = l.rhs.singularity();
    }
   };
-   
-  
 
   // ----------------------  gf_view -----------------------------------------
   /**
@@ -756,14 +735,14 @@ namespace triqs {
    // ------------- Accessors -----------------------------
 
    /// Access the  mesh
-   mesh_t const &mesh() const { return _mesh; }
-   domain_t const &domain() const { return _mesh.domain(); }
+   mesh_t const& mesh() const { return _mesh; }
+   domain_t const& domain() const { return _mesh.domain(); }
 
    /// Direct access to the data array
-   data_t &data() { return _data; }
+   data_t& data() { return _data; }
 
    /// Const version
-   data_t const &data() const { return _data; }
+   data_t const& data() const { return _data; }
 
    /// Shape of the target
    auto target_shape() const { return _data.shape().template front_mpop<arity>(); } // drop arity dims
@@ -772,15 +751,15 @@ namespace triqs {
    auto data_shape() const { return _data.shape(); }
 
    ///
-   zero_t const &get_zero() const { return _zero; }
+   zero_t const& get_zero() const { return _zero; }
 
    /// Access to the singularity
-   singularity_t &singularity() { return _singularity; }
+   singularity_t& singularity() { return _singularity; }
 
    /// Const version
-   singularity_t const &singularity() const { return _singularity; }
+   singularity_t const& singularity() const { return _singularity; }
 
-   indices_t const &indices() const { return _indices; }
+   indices_t const& indices() const { return _indices; }
 
    private:
    mesh_t _mesh;
@@ -801,17 +780,17 @@ namespace triqs {
    private:
    // build a zero from a slice of data
    // MUST be static since it is used in constructors... (otherwise bug in clang)
-   template <typename T> static zero_t __make_zero(T, data_t const &d) {
+   template <typename T> static zero_t __make_zero(T, data_t const& d) {
     auto r = zero_regular_t{d.shape().template front_mpop<arity>()};
     r()    = 0;
     return r;
    }
-   static zero_t __make_zero(scalar_valued, data_t const &d) { return 0; } // special case
-   static zero_t _make_zero(data_t const &d) { return __make_zero(Target{}, d); }
+   static zero_t __make_zero(scalar_valued, data_t const& d) { return 0; } // special case
+   static zero_t _make_zero(data_t const& d) { return __make_zero(Target{}, d); }
    zero_t _remake_zero() { return _zero = _make_zero(_data); } // NOT in constructor...
 
    template <typename G>
-   gf_view(impl_tag2, G &&x)
+   gf_view(impl_tag2, G&& x)
       : _mesh(x.mesh())
       , _data(x.data())
       , _zero(_make_zero(_data))
@@ -820,7 +799,7 @@ namespace triqs {
       , name(x.name) {}
 
    template <typename M, typename D, typename S>
-   gf_view(impl_tag, M &&m, D &&dat, S &&sing, indices_t ind)
+   gf_view(impl_tag, M&& m, D&& dat, S&& sing, indices_t ind)
       : _mesh(std::forward<M>(m))
       , _data(std::forward<D>(dat))
       , _zero(_make_zero(_data))
@@ -831,15 +810,14 @@ namespace triqs {
    }
 
    public:
-
    /// Copy constructor
-   gf_view(gf_view const &x)
+   gf_view(gf_view const& x)
       : _mesh(x.mesh()), _data(x.data()), _zero(x._zero), _singularity(x.singularity()), _indices(x.indices()), name(x.name) {}
 
    /// Move constructor
-   gf_view(gf_view &&) = default;
+   gf_view(gf_view&&) = default;
 
-   void swap_impl(gf_view &b) noexcept {
+   void swap_impl(gf_view& b) noexcept {
     using std::swap;
     swap(this->_mesh, b._mesh);
     swap(this->_data, b._data);
@@ -851,43 +829,42 @@ namespace triqs {
 
    using singularity_factory = gf_singularity_factory<_singularity_regular_t>;
 
-
    public:
    // ---------------  Constructors --------------------
 
-   // 
+   //
    gf_view() = default;
 
    // Allow to construct a view from a gf with a different evaluator, except const_views ...
    /// Makes a view
-   gf_view(gf_const_view<Var, Target> const &g) = delete;
+   gf_view(gf_const_view<Var, Target> const& g) = delete;
 
    /// Makes a view
-   gf_view(gf<Var, Target> const &g) = delete;
+   gf_view(gf<Var, Target> const& g) = delete;
 
    /// Makes a view
-   gf_view(gf<Var, Target> &g) : gf_view(impl_tag2{}, g) {}
+   gf_view(gf<Var, Target>& g) : gf_view(impl_tag2{}, g) {}
 
    /// Makes a view
-   gf_view(gf<Var, Target> &&g) noexcept : gf_view(impl_tag2{}, std::move(g)) {} // from a gf &&
+   gf_view(gf<Var, Target>&& g) noexcept : gf_view(impl_tag2{}, std::move(g)) {} // from a gf &&
 
    /// Construct from mesh, data, ....
    template <typename D>
-   gf_view(mesh_t m, D &&dat, singularity_t const &t, indices_t const &ind = indices_t{})
+   gf_view(mesh_t m, D&& dat, singularity_t const& t, indices_t const& ind = indices_t{})
       : gf_view(impl_tag{}, std::move(m), std::forward<D>(dat), t, ind) {}
 
-   // Construct from mesh, data. Only for partial_eval 
+   // Construct from mesh, data. Only for partial_eval
    template <typename D>
-   gf_view(mesh_t m, D const &dat)
+   gf_view(mesh_t m, D const& dat)
       : gf_view(impl_tag{}, std::move(m), dat, singularity_factory::make(m, dat.shape().template front_mpop<arity>()), {}) {}
 
    // ---------------  swap --------------------
    /// Swap
-   friend void swap(gf_view &a, gf_view &b) noexcept { a.swap_impl(b); }
+   friend void swap(gf_view& a, gf_view& b) noexcept { a.swap_impl(b); }
 
    // ---------------  Rebind --------------------
    /// Rebind
-   void rebind(gf_view<Var, Target> const &X) noexcept {
+   void rebind(gf_view<Var, Target> const& X) noexcept {
     this->_mesh = X._mesh;
     this->_data.rebind(X._data);
     details::_rebind_helper(_zero, X._zero);
@@ -898,7 +875,7 @@ namespace triqs {
 
    // ---------------  operator =  --------------------
    /// Copy the data, without resizing the view.
-   gf_view &operator=(gf_view const &rhs) {
+   gf_view& operator=(gf_view const& rhs) {
     triqs_gf_view_assign_delegation(*this, rhs);
     return *this;
    }
@@ -908,17 +885,15 @@ namespace triqs {
     *
     * @tparam RHS WRITE A LIST OF POSSIBLES ...
     */
-   template <typename RHS> gf_view &operator=(RHS const &rhs) {
+   template <typename RHS> gf_view& operator=(RHS const& rhs) {
     triqs_gf_view_assign_delegation(*this, rhs);
     return *this;
    }
 
-
    public:
    // ------------- apply_on_data -----------------------------
 
-   
-   template <typename Fdata, typename Fsing, typename Find> auto apply_on_data(Fdata &&fd, Fsing &&fs, Find &&fi)  {
+   template <typename Fdata, typename Fsing, typename Find> auto apply_on_data(Fdata&& fd, Fsing&& fs, Find&& fi) {
     auto d2  = fd(_data);
     using t2 = std14::conditional_t<is_tail_valued(Target()), tail_valued<target_from_array<decltype(d2), arity + 1>>,
                                     target_from_array<decltype(d2), arity>>;
@@ -926,11 +901,11 @@ namespace triqs {
     return gv_t{_mesh, d2, typename gv_t::singularity_t{fs(_singularity)}, fi(_indices)};
    }
 
-   template <typename Fdata, typename Fsing> auto apply_on_data(Fdata &&fd, Fsing &&fs)  {
-    return apply_on_data(std::forward<Fdata>(fd), std::forward<Fsing>(fs), [](auto &) { return indices_t{}; });
+   template <typename Fdata, typename Fsing> auto apply_on_data(Fdata&& fd, Fsing&& fs) {
+    return apply_on_data(std::forward<Fdata>(fd), std::forward<Fsing>(fs), [](auto&) { return indices_t{}; });
    }
-   
-   template <typename Fdata, typename Fsing, typename Find> auto apply_on_data(Fdata &&fd, Fsing &&fs, Find &&fi) const {
+
+   template <typename Fdata, typename Fsing, typename Find> auto apply_on_data(Fdata&& fd, Fsing&& fs, Find&& fi) const {
     auto d2  = fd(_data);
     using t2 = std14::conditional_t<is_tail_valued(Target()), tail_valued<target_from_array<decltype(d2), arity + 1>>,
                                     target_from_array<decltype(d2), arity>>;
@@ -938,8 +913,8 @@ namespace triqs {
     return gv_t{_mesh, d2, typename gv_t::singularity_t{fs(_singularity)}, fi(_indices)};
    }
 
-   template <typename Fdata, typename Fsing> auto apply_on_data(Fdata &&fd, Fsing &&fs) const {
-    return apply_on_data(std::forward<Fdata>(fd), std::forward<Fsing>(fs), [](auto &) { return indices_t{}; });
+   template <typename Fdata, typename Fsing> auto apply_on_data(Fdata&& fd, Fsing&& fs) const {
+    return apply_on_data(std::forward<Fdata>(fd), std::forward<Fsing>(fs), [](auto&) { return indices_t{}; });
    }
 
    // ------------- All the call operators without lazy arguments -----------------------------
@@ -959,44 +934,40 @@ namespace triqs {
        ,
        std::result_of<evaluator_t(gf_view, Args...)> // what is the result type of call
        >::type                                       // end of lazy_disable_if
-   operator()(Args &&... args) const {
+   operator()(Args&&... args) const {
     return evaluator_t()(*this, std::forward<Args>(args)...);
    }
 
    // ------------- Call with lazy arguments -----------------------------
 
    // Calls with at least one lazy argument : we make a clef expression, cf clef documentation
-   template <typename... Args> clef::make_expr_call_t<gf_view &, Args...> operator()(Args &&... args) & {
+   template <typename... Args> clef::make_expr_call_t<gf_view&, Args...> operator()(Args&&... args) & {
     return clef::make_expr_call(*this, std::forward<Args>(args)...);
    }
 
-   template <typename... Args> clef::make_expr_call_t<gf_view const &, Args...> operator()(Args &&... args) const & {
+   template <typename... Args> clef::make_expr_call_t<gf_view const&, Args...> operator()(Args&&... args) const & {
     return clef::make_expr_call(*this, std::forward<Args>(args)...);
    }
 
-   template <typename... Args> clef::make_expr_call_t<gf_view, Args...> operator()(Args &&... args) && {
+   template <typename... Args> clef::make_expr_call_t<gf_view, Args...> operator()(Args&&... args) && {
     return clef::make_expr_call(std::move(*this), std::forward<Args>(args)...);
    }
 
    // ------------- All the [] operators without lazy arguments -----------------------------
 
    // pass a index_t of the mesh
-   decltype(auto) operator[](mesh_index_t const &arg) {
-    return dproxy_t::invoke(_data, _mesh.index_to_linear(arg));
-   }
-   decltype(auto) operator[](mesh_index_t const &arg) const {
-    return dproxy_t::invoke(_data, _mesh.index_to_linear(arg));
-   }
+   decltype(auto) operator[](mesh_index_t const& arg) { return dproxy_t::invoke(_data, _mesh.index_to_linear(arg)); }
+   decltype(auto) operator[](mesh_index_t const& arg) const { return dproxy_t::invoke(_data, _mesh.index_to_linear(arg)); }
 
    // pass a mesh_point of the mesh
-   decltype(auto) operator[](mesh_point_t const &x) {
+   decltype(auto) operator[](mesh_point_t const& x) {
 #ifdef TRIQS_DEBUG
     if (this->_mesh != x.mesh()) TRIQS_RUNTIME_ERROR << "gf[ ] : mesh point's mesh and gf's mesh mismatch";
 #endif
     return dproxy_t::invoke(_data, x.linear_index());
    }
 
-   decltype(auto) operator[](mesh_point_t const &x) const {
+   decltype(auto) operator[](mesh_point_t const& x) const {
 #ifdef TRIQS_DEBUG
     if (this->_mesh != x.mesh()) TRIQS_RUNTIME_ERROR << "gf[ ] : mesh point's mesh and gf's mesh mismatch";
 #endif
@@ -1004,69 +975,69 @@ namespace triqs {
    }
 
    // pass an abtract closest_point. We extract the value of the domain from p, call the gf_closest_point trait
-   template <typename... U> decltype(auto) operator[](closest_pt_wrap<U...> const &p) {
-    return dproxy_t::invoke(_data, _mesh.index_to_linear(gf_closest_point<Var, Target>::invoke(this, p)));
+   template <typename... U> decltype(auto) operator[](closest_pt_wrap<U...> const& p) {
+    return dproxy_t::invoke(_data, _mesh.index_to_linear(gf_closest_point<Var, Target>::invoke(this->mesh(), p)));
    }
-   template <typename... U> decltype(auto) operator[](closest_pt_wrap<U...> const &p) const {
-    return dproxy_t::invoke(_data, _mesh.index_to_linear(gf_closest_point<Var, Target>::invoke(this, p)));
+   template <typename... U> decltype(auto) operator[](closest_pt_wrap<U...> const& p) const {
+    return dproxy_t::invoke(_data, _mesh.index_to_linear(gf_closest_point<Var, Target>::invoke(this->mesh(), p)));
    }
 
    // ------------- [] with lazy arguments -----------------------------
 
-   template <typename Arg> clef::make_expr_subscript_t<gf_view const &, Arg> operator[](Arg &&arg) const & {
+   template <typename Arg> clef::make_expr_subscript_t<gf_view const&, Arg> operator[](Arg&& arg) const & {
     return clef::make_expr_subscript(*this, std::forward<Arg>(arg));
    }
 
-   template <typename Arg> clef::make_expr_subscript_t<gf_view &, Arg> operator[](Arg &&arg) & {
+   template <typename Arg> clef::make_expr_subscript_t<gf_view&, Arg> operator[](Arg&& arg) & {
     return clef::make_expr_subscript(*this, std::forward<Arg>(arg));
    }
 
-   template <typename Arg> clef::make_expr_subscript_t<gf_view, Arg> operator[](Arg &&arg) && {
+   template <typename Arg> clef::make_expr_subscript_t<gf_view, Arg> operator[](Arg&& arg) && {
     return clef::make_expr_subscript(std::move(*this), std::forward<Arg>(arg));
    }
 
    // --------------------- A direct access to the grid point --------------------------
 
-   template <typename... Args> decltype(auto) get_from_linear_index(Args &&... args) {
+   template <typename... Args> decltype(auto) get_from_linear_index(Args&&... args) {
     return dproxy_t::invoke(_data, linear_mesh_index_t(std::forward<Args>(args)...));
    }
 
-   template <typename... Args> decltype(auto) get_from_linear_index(Args &&... args) const {
+   template <typename... Args> decltype(auto) get_from_linear_index(Args&&... args) const {
     return dproxy_t::invoke(_data, linear_mesh_index_t(std::forward<Args>(args)...));
    }
 
-   template <typename... Args> decltype(auto) on_mesh(Args &&... args) {
+   template <typename... Args> decltype(auto) on_mesh(Args&&... args) {
     return dproxy_t::invoke(_data, _mesh.index_to_linear(mesh_index_t(std::forward<Args>(args)...)));
    }
 
-   template <typename... Args> decltype(auto) on_mesh(Args &&... args) const {
+   template <typename... Args> decltype(auto) on_mesh(Args&&... args) const {
     return dproxy_t::invoke(_data, _mesh.index_to_linear(mesh_index_t(std::forward<Args>(args)...)));
    }
 
    // --------------------- on mesh (g) : the call before [] -------------------------
    // This is a workaround the the lack of multi argument [] in C++
-/*
-   // mesh points should be treated slighly differently : take their index....
-   template <typename... T> decltype(auto) on_mesh(mesh_point<T> const &... args) { return on_mesh(args.index()...); }
-   template <typename... T> decltype(auto) on_mesh(mesh_point<T> const &... args) const { return on_mesh(args.index()...); }
+   /*
+      // mesh points should be treated slighly differently : take their index....
+      template <typename... T> decltype(auto) on_mesh(mesh_point<T> const &... args) { return on_mesh(args.index()...); }
+      template <typename... T> decltype(auto) on_mesh(mesh_point<T> const &... args) const { return on_mesh(args.index()...); }
 
-   // The on_mesh little adaptor ....
-   private:
-   template <typename G> struct _on_mesh_wrapper {
-    G &f;
-    template <typename... Args>
-    auto operator()(Args &&... args) const
-        -> std14::enable_if_t<!triqs::clef::is_any_lazy<Args...>::value, decltype(f.on_mesh(std::forward<Args>(args)...))> {
-     return f.on_mesh(std::forward<Args>(args)...);
-    }
-    TRIQS_CLEF_IMPLEMENT_LAZY_CALL();
-   };
+      // The on_mesh little adaptor ....
+      private:
+      template <typename G> struct _on_mesh_wrapper {
+       G &f;
+       template <typename... Args>
+       auto operator()(Args &&... args) const
+           -> std14::enable_if_t<!triqs::clef::is_any_lazy<Args...>::value, decltype(f.on_mesh(std::forward<Args>(args)...))> {
+        return f.on_mesh(std::forward<Args>(args)...);
+       }
+       TRIQS_CLEF_IMPLEMENT_LAZY_CALL();
+      };
 
-   public:
-   // TRIQS_DEPRECATED("Use [][][] instead")
-   _on_mesh_wrapper<gf_view const> friend on_mesh(gf_view const &f) { return {f}; }
-   _on_mesh_wrapper<gf_view> friend on_mesh(gf_view &f) { return {f}; }
-*/
+      public:
+      // TRIQS_DEPRECATED("Use [][][] instead")
+      _on_mesh_wrapper<gf_view const> friend on_mesh(gf_view const &f) { return {f}; }
+      _on_mesh_wrapper<gf_view> friend on_mesh(gf_view &f) { return {f}; }
+   */
    public:
    // --------------------- [][][][] ------------------------
    // This is a workaround the the lack of multi argument [] in C++
@@ -1074,33 +1045,35 @@ namespace triqs {
    /**
     *
     */
-   template <typename T> decltype(auto) operator[](T const &x) {
-    return triqs::utility::make_lazy_bracket<arity>([this](auto &&... y) ->decltype(auto){ return details::partial_eval(this, y...); }, x);
+   template <typename T> decltype(auto) operator[](T const& x) {
+    return triqs::utility::make_lazy_bracket<arity>(
+        [this](auto&&... y) -> decltype(auto) { return details::partial_eval(this, y...); }, x);
    }
 
    /**
     *
     */
-   template <typename T> decltype(auto) operator[](T const &x) const {
-    return triqs::utility::make_lazy_bracket<arity>([this](auto &&... y) ->decltype(auto){ return details::partial_eval(this, y...); }, x);
+   template <typename T> decltype(auto) operator[](T const& x) const {
+    return triqs::utility::make_lazy_bracket<arity>(
+        [this](auto&&... y) -> decltype(auto) { return details::partial_eval(this, y...); }, x);
    }
 
    //----------------------------- HDF5 -----------------------------
 
    /// HDF5 name
-   friend std::string get_triqs_hdf5_data_scheme(gf_view const &g) { return "Gf" + gf_h5_name<Var, Target>::invoke(); }
+   friend std::string get_triqs_hdf5_data_scheme(gf_view const& g) { return "Gf" + gf_h5_name<Var, Target>::invoke(); }
 
    friend struct gf_h5_rw<Var, Target>;
 
    /// Write into HDF5
-   friend void h5_write(h5::group fg, std::string const &subgroup_name, gf_view const &g) {
+   friend void h5_write(h5::group fg, std::string const& subgroup_name, gf_view const& g) {
     auto gr = fg.create_group(subgroup_name);
     gr.write_triqs_hdf5_data_scheme(g);
     gf_h5_rw<Var, Target>::write(gr, g);
    }
 
    /// Read from HDF5
-   friend void h5_read(h5::group fg, std::string const &subgroup_name, gf_view &g) {
+   friend void h5_read(h5::group fg, std::string const& subgroup_name, gf_view& g) {
     auto gr = fg.open_group(subgroup_name);
     // Check the attribute or throw
     auto tag_file     = gr.read_triqs_hdf5_data_scheme();
@@ -1115,24 +1088,21 @@ namespace triqs {
    //-----------------------------  BOOST Serialization -----------------------------
    friend class boost::serialization::access;
    /// The serialization as required by Boost
-   template <class Archive> void serialize(Archive &ar, const unsigned int version) {
-    ar &_data;
-    ar &_singularity;
-    ar &_mesh;
-    ar &_indices;
-    ar &name;
+   template <class Archive> void serialize(Archive& ar, const unsigned int version) {
+    ar& _data;
+    ar& _singularity;
+    ar& _mesh;
+    ar& _indices;
+    ar& name;
    }
 
    //----------------------------- print  -----------------------------
 
    /// IO
-   friend std::ostream &operator<<(std::ostream &out, gf_view const &x) { return out << "gf_view"; }
+   friend std::ostream& operator<<(std::ostream& out, gf_view const& x) { return out << "gf_view"; }
 
    //----------------------------- MPI  -----------------------------
 
-   
-
-   
    /**
      * Initiate (lazy) MPI Bcast
      *
@@ -1146,14 +1116,13 @@ namespace triqs {
      * @return Returns a lazy object describing the object and the MPI operation to be performed.
      *
      */
-   
-   friend void mpi_broadcast(gf_view &g, mpi::communicator c = {}, int root = 0) {
+
+   friend void mpi_broadcast(gf_view& g, mpi::communicator c = {}, int root = 0) {
     // Shall we bcast mesh ?
     mpi_broadcast(g.data(), c, root);
     mpi_broadcast(g.singularity(), c, root);
    }
 
-   
    /**
      * Initiate (lazy) MPI Reduce
      *
@@ -1167,13 +1136,12 @@ namespace triqs {
      * @return Returns a lazy object describing the object and the MPI operation to be performed.
      *
      */
-   
-   friend mpi_lazy<mpi::tag::reduce, const_view_type> mpi_reduce(gf_view const &a, mpi::communicator c = {}, int root = 0,
+
+   friend mpi_lazy<mpi::tag::reduce, const_view_type> mpi_reduce(gf_view const& a, mpi::communicator c = {}, int root = 0,
                                                                  bool all = false, MPI_Op op = MPI_SUM) {
     return {a(), c, root, all, op};
    }
 
-   
    /**
      * Initiate (lazy) MPI AllReduce
      *
@@ -1187,13 +1155,12 @@ namespace triqs {
      * @return Returns a lazy object describing the object and the MPI operation to be performed.
      *
      */
-   
-   friend mpi_lazy<mpi::tag::reduce, const_view_type> mpi_all_reduce(gf_view const &a, mpi::communicator c = {}, int root = 0,
+
+   friend mpi_lazy<mpi::tag::reduce, const_view_type> mpi_all_reduce(gf_view const& a, mpi::communicator c = {}, int root = 0,
                                                                      MPI_Op op = MPI_SUM) {
     return {a(), c, root, true, op};
    }
 
-   
    /**
      * Initiate (lazy) MPI Scatter
      *
@@ -1207,12 +1174,11 @@ namespace triqs {
      * @return Returns a lazy object describing the object and the MPI operation to be performed.
      *
      */
-   
-   friend mpi_lazy<mpi::tag::scatter, const_view_type> mpi_scatter(gf_view const &a, mpi::communicator c = {}, int root = 0) {
+
+   friend mpi_lazy<mpi::tag::scatter, const_view_type> mpi_scatter(gf_view const& a, mpi::communicator c = {}, int root = 0) {
     return {a(), c, root, true};
    }
 
-   
    /**
      * Initiate (lazy) MPI Gather
      *
@@ -1226,13 +1192,12 @@ namespace triqs {
      * @return Returns a lazy object describing the object and the MPI operation to be performed.
      *
      */
-   
-   friend mpi_lazy<mpi::tag::gather, const_view_type> mpi_gather(gf_view const &a, mpi::communicator c = {}, int root = 0,
+
+   friend mpi_lazy<mpi::tag::gather, const_view_type> mpi_gather(gf_view const& a, mpi::communicator c = {}, int root = 0,
                                                                  bool all = false) {
     return {a(), c, root, all};
    }
 
-   
    /**
      * Initiate (lazy) MPI AllGather
      *
@@ -1246,11 +1211,10 @@ namespace triqs {
      * @return Returns a lazy object describing the object and the MPI operation to be performed.
      *
      */
-   
-   friend mpi_lazy<mpi::tag::gather, const_view_type> mpi_all_gather(gf_view const &a, mpi::communicator c = {}, int root = 0) {
+
+   friend mpi_lazy<mpi::tag::gather, const_view_type> mpi_all_gather(gf_view const& a, mpi::communicator c = {}, int root = 0) {
     return {a(), c, root, true};
    }
-
 
    //-------------  corresponding operator = overload
 
@@ -1259,8 +1223,8 @@ namespace triqs {
     * @param l The lazy object returned by mpi_reduce
     */
    void operator=(mpi_lazy<mpi::tag::reduce, gf_const_view<Var, Target>> l) {
-    _mesh = l.rhs.mesh();
-    _data = arrays::mpi_reduce(l.rhs.data(), l.c, l.root, l.all, l.op); // arrays:: necessary on gcc 5. why ??
+    _mesh        = l.rhs.mesh();
+    _data        = arrays::mpi_reduce(l.rhs.data(), l.c, l.root, l.all, l.op); // arrays:: necessary on gcc 5. why ??
     _singularity = mpi_reduce(l.rhs.singularity(), l.c, l.root, l.all, l.op);
    }
 
@@ -1269,8 +1233,8 @@ namespace triqs {
      * @param l The lazy object returned by mpi_reduce
      */
    void operator=(mpi_lazy<mpi::tag::scatter, gf_const_view<Var, Target>> l) {
-    _mesh = mpi_scatter(l.rhs.mesh(), l.c, l.root);
-    _data = mpi_scatter(l.rhs.data(), l.c, l.root, true);
+    _mesh                                  = mpi_scatter(l.rhs.mesh(), l.c, l.root);
+    _data                                  = mpi_scatter(l.rhs.data(), l.c, l.root, true);
     if (l.c.rank() == l.root) _singularity = l.rhs.singularity();
     mpi_broadcast(_singularity, l.c, l.root);
    }
@@ -1280,13 +1244,11 @@ namespace triqs {
      * @param l The lazy object returned by mpi_reduce
      */
    void operator=(mpi_lazy<mpi::tag::gather, gf_const_view<Var, Target>> l) {
-    _mesh = mpi_gather(l.rhs.mesh(), l.c, l.root);
-    _data = mpi_gather(l.rhs.data(), l.c, l.root, l.all);
+    _mesh                                             = mpi_gather(l.rhs.mesh(), l.c, l.root);
+    _data                                             = mpi_gather(l.rhs.data(), l.c, l.root, l.all);
     if (l.all || (l.c.rank() == l.root)) _singularity = l.rhs.singularity();
    }
   };
-   
-  
 
   // ----------------------  gf_const_view -----------------------------------------
   /**
@@ -1343,14 +1305,14 @@ namespace triqs {
    // ------------- Accessors -----------------------------
 
    /// Access the  mesh
-   mesh_t const &mesh() const { return _mesh; }
-   domain_t const &domain() const { return _mesh.domain(); }
+   mesh_t const& mesh() const { return _mesh; }
+   domain_t const& domain() const { return _mesh.domain(); }
 
    /// Direct access to the data array
-   data_t &data() { return _data; }
+   data_t& data() { return _data; }
 
    /// Const version
-   data_t const &data() const { return _data; }
+   data_t const& data() const { return _data; }
 
    /// Shape of the target
    auto target_shape() const { return _data.shape().template front_mpop<arity>(); } // drop arity dims
@@ -1359,15 +1321,15 @@ namespace triqs {
    auto data_shape() const { return _data.shape(); }
 
    ///
-   zero_t const &get_zero() const { return _zero; }
+   zero_t const& get_zero() const { return _zero; }
 
    /// Access to the singularity
-   singularity_t &singularity() { return _singularity; }
+   singularity_t& singularity() { return _singularity; }
 
    /// Const version
-   singularity_t const &singularity() const { return _singularity; }
+   singularity_t const& singularity() const { return _singularity; }
 
-   indices_t const &indices() const { return _indices; }
+   indices_t const& indices() const { return _indices; }
 
    private:
    mesh_t _mesh;
@@ -1388,17 +1350,17 @@ namespace triqs {
    private:
    // build a zero from a slice of data
    // MUST be static since it is used in constructors... (otherwise bug in clang)
-   template <typename T> static zero_t __make_zero(T, data_t const &d) {
+   template <typename T> static zero_t __make_zero(T, data_t const& d) {
     auto r = zero_regular_t{d.shape().template front_mpop<arity>()};
     r()    = 0;
     return r;
    }
-   static zero_t __make_zero(scalar_valued, data_t const &d) { return 0; } // special case
-   static zero_t _make_zero(data_t const &d) { return __make_zero(Target{}, d); }
+   static zero_t __make_zero(scalar_valued, data_t const& d) { return 0; } // special case
+   static zero_t _make_zero(data_t const& d) { return __make_zero(Target{}, d); }
    zero_t _remake_zero() { return _zero = _make_zero(_data); } // NOT in constructor...
 
    template <typename G>
-   gf_const_view(impl_tag2, G &&x)
+   gf_const_view(impl_tag2, G&& x)
       : _mesh(x.mesh())
       , _data(x.data())
       , _zero(_make_zero(_data))
@@ -1407,7 +1369,7 @@ namespace triqs {
       , name(x.name) {}
 
    template <typename M, typename D, typename S>
-   gf_const_view(impl_tag, M &&m, D &&dat, S &&sing, indices_t ind)
+   gf_const_view(impl_tag, M&& m, D&& dat, S&& sing, indices_t ind)
       : _mesh(std::forward<M>(m))
       , _data(std::forward<D>(dat))
       , _zero(_make_zero(_data))
@@ -1418,15 +1380,14 @@ namespace triqs {
    }
 
    public:
-
    /// Copy constructor
-   gf_const_view(gf_const_view const &x)
+   gf_const_view(gf_const_view const& x)
       : _mesh(x.mesh()), _data(x.data()), _zero(x._zero), _singularity(x.singularity()), _indices(x.indices()), name(x.name) {}
 
    /// Move constructor
-   gf_const_view(gf_const_view &&) = default;
+   gf_const_view(gf_const_view&&) = default;
 
-   void swap_impl(gf_const_view &b) noexcept {
+   void swap_impl(gf_const_view& b) noexcept {
     using std::swap;
     swap(this->_mesh, b._mesh);
     swap(this->_data, b._data);
@@ -1438,42 +1399,42 @@ namespace triqs {
 
    using singularity_factory = gf_singularity_factory<_singularity_regular_t>;
 
-
    // ---------------  Constructors --------------------
 
-   // 
+   //
    gf_const_view() = default;
 
    /// Makes a const view
-   gf_const_view(gf_view<Var, Target> const &g) : gf_const_view(impl_tag2{}, g) {}
+   gf_const_view(gf_view<Var, Target> const& g) : gf_const_view(impl_tag2{}, g) {}
 
    /// Makes a const view
-   gf_const_view(gf<Var, Target> const &g) : gf_const_view(impl_tag2{}, g) {}
+   gf_const_view(gf<Var, Target> const& g) : gf_const_view(impl_tag2{}, g) {}
 
    /// Makes a const view
-   gf_const_view(gf<Var, Target> &g) : gf_const_view(impl_tag2{}, g) {} // from a gf &
+   gf_const_view(gf<Var, Target>& g) : gf_const_view(impl_tag2{}, g) {} // from a gf &
 
    /// Makes a const view
-   gf_const_view(gf<Var, Target> &&g) noexcept : gf_const_view(impl_tag2{}, std::move(g)) {} // from a gf &&
+   gf_const_view(gf<Var, Target>&& g) noexcept : gf_const_view(impl_tag2{}, std::move(g)) {} // from a gf &&
 
    // Construct from mesh, data, ....
    template <typename D>
-   gf_const_view(mesh_t m, D const &dat, singularity_t const &t, indices_t const &ind)
+   gf_const_view(mesh_t m, D const& dat, singularity_t const& t, indices_t const& ind)
       : gf_const_view(impl_tag{}, std::move(m), dat, t, ind) {}
 
-   // Construct from mesh, data. 
+   // Construct from mesh, data.
    template <typename D>
-   gf_const_view(mesh_t m, D const &dat)
-      : gf_const_view(impl_tag{}, std::move(m), dat, singularity_factory::make(m, dat.shape().template front_mpop<arity>()), {}) {}
+   gf_const_view(mesh_t m, D const& dat)
+      : gf_const_view(impl_tag{}, std::move(m), dat, singularity_factory::make(m, dat.shape().template front_mpop<arity>()), {}) {
+   }
 
    // ---------------  swap --------------------
 
    /// Swap
-   friend void swap(gf_const_view &a, gf_const_view &b) noexcept { a.swap_impl(b); }
+   friend void swap(gf_const_view& a, gf_const_view& b) noexcept { a.swap_impl(b); }
 
    // ---------------  Rebind --------------------
    /// Rebind the view
-   void rebind(gf_const_view<Var, Target> const &X) noexcept {
+   void rebind(gf_const_view<Var, Target> const& X) noexcept {
     this->_mesh = X._mesh;
     this->_data.rebind(X._data);
     details::_rebind_helper(_zero, X._zero);
@@ -1483,17 +1444,15 @@ namespace triqs {
    }
 
    /// Rebind on a non const view
-   void rebind(gf_view<Var, Target> const &X) noexcept { rebind(gf_const_view{X}); }
+   void rebind(gf_view<Var, Target> const& X) noexcept { rebind(gf_const_view{X}); }
 
    // ---------------  No = since it is const ... --------------------
-   gf_const_view &operator=(gf_const_view const &) = delete; // a const view can not be assigned to
-
+   gf_const_view& operator=(gf_const_view const&) = delete; // a const view can not be assigned to
 
    public:
    // ------------- apply_on_data -----------------------------
 
-   
-   template <typename Fdata, typename Fsing, typename Find> auto apply_on_data(Fdata &&fd, Fsing &&fs, Find &&fi)  {
+   template <typename Fdata, typename Fsing, typename Find> auto apply_on_data(Fdata&& fd, Fsing&& fs, Find&& fi) {
     auto d2  = fd(_data);
     using t2 = std14::conditional_t<is_tail_valued(Target()), tail_valued<target_from_array<decltype(d2), arity + 1>>,
                                     target_from_array<decltype(d2), arity>>;
@@ -1501,11 +1460,11 @@ namespace triqs {
     return gv_t{_mesh, d2, typename gv_t::singularity_t{fs(_singularity)}, fi(_indices)};
    }
 
-   template <typename Fdata, typename Fsing> auto apply_on_data(Fdata &&fd, Fsing &&fs)  {
-    return apply_on_data(std::forward<Fdata>(fd), std::forward<Fsing>(fs), [](auto &) { return indices_t{}; });
+   template <typename Fdata, typename Fsing> auto apply_on_data(Fdata&& fd, Fsing&& fs) {
+    return apply_on_data(std::forward<Fdata>(fd), std::forward<Fsing>(fs), [](auto&) { return indices_t{}; });
    }
-   
-   template <typename Fdata, typename Fsing, typename Find> auto apply_on_data(Fdata &&fd, Fsing &&fs, Find &&fi) const {
+
+   template <typename Fdata, typename Fsing, typename Find> auto apply_on_data(Fdata&& fd, Fsing&& fs, Find&& fi) const {
     auto d2  = fd(_data);
     using t2 = std14::conditional_t<is_tail_valued(Target()), tail_valued<target_from_array<decltype(d2), arity + 1>>,
                                     target_from_array<decltype(d2), arity>>;
@@ -1513,8 +1472,8 @@ namespace triqs {
     return gv_t{_mesh, d2, typename gv_t::singularity_t{fs(_singularity)}, fi(_indices)};
    }
 
-   template <typename Fdata, typename Fsing> auto apply_on_data(Fdata &&fd, Fsing &&fs) const {
-    return apply_on_data(std::forward<Fdata>(fd), std::forward<Fsing>(fs), [](auto &) { return indices_t{}; });
+   template <typename Fdata, typename Fsing> auto apply_on_data(Fdata&& fd, Fsing&& fs) const {
+    return apply_on_data(std::forward<Fdata>(fd), std::forward<Fsing>(fs), [](auto&) { return indices_t{}; });
    }
 
    // ------------- All the call operators without lazy arguments -----------------------------
@@ -1533,45 +1492,41 @@ namespace triqs {
            ((sizeof...(Args) != evaluator_t::arity) && (evaluator_t::arity != -1)) // if -1 : no check
        ,
        std::result_of<evaluator_t(gf_const_view, Args...)> // what is the result type of call
-       >::type                                       // end of lazy_disable_if
-   operator()(Args &&... args) const {
+       >::type                                             // end of lazy_disable_if
+   operator()(Args&&... args) const {
     return evaluator_t()(*this, std::forward<Args>(args)...);
    }
 
    // ------------- Call with lazy arguments -----------------------------
 
    // Calls with at least one lazy argument : we make a clef expression, cf clef documentation
-   template <typename... Args> clef::make_expr_call_t<gf_const_view &, Args...> operator()(Args &&... args) & {
+   template <typename... Args> clef::make_expr_call_t<gf_const_view&, Args...> operator()(Args&&... args) & {
     return clef::make_expr_call(*this, std::forward<Args>(args)...);
    }
 
-   template <typename... Args> clef::make_expr_call_t<gf_const_view const &, Args...> operator()(Args &&... args) const & {
+   template <typename... Args> clef::make_expr_call_t<gf_const_view const&, Args...> operator()(Args&&... args) const & {
     return clef::make_expr_call(*this, std::forward<Args>(args)...);
    }
 
-   template <typename... Args> clef::make_expr_call_t<gf_const_view, Args...> operator()(Args &&... args) && {
+   template <typename... Args> clef::make_expr_call_t<gf_const_view, Args...> operator()(Args&&... args) && {
     return clef::make_expr_call(std::move(*this), std::forward<Args>(args)...);
    }
 
    // ------------- All the [] operators without lazy arguments -----------------------------
 
    // pass a index_t of the mesh
-   decltype(auto) operator[](mesh_index_t const &arg) {
-    return dproxy_t::invoke(_data, _mesh.index_to_linear(arg));
-   }
-   decltype(auto) operator[](mesh_index_t const &arg) const {
-    return dproxy_t::invoke(_data, _mesh.index_to_linear(arg));
-   }
+   decltype(auto) operator[](mesh_index_t const& arg) { return dproxy_t::invoke(_data, _mesh.index_to_linear(arg)); }
+   decltype(auto) operator[](mesh_index_t const& arg) const { return dproxy_t::invoke(_data, _mesh.index_to_linear(arg)); }
 
    // pass a mesh_point of the mesh
-   decltype(auto) operator[](mesh_point_t const &x) {
+   decltype(auto) operator[](mesh_point_t const& x) {
 #ifdef TRIQS_DEBUG
     if (this->_mesh != x.mesh()) TRIQS_RUNTIME_ERROR << "gf[ ] : mesh point's mesh and gf's mesh mismatch";
 #endif
     return dproxy_t::invoke(_data, x.linear_index());
    }
 
-   decltype(auto) operator[](mesh_point_t const &x) const {
+   decltype(auto) operator[](mesh_point_t const& x) const {
 #ifdef TRIQS_DEBUG
     if (this->_mesh != x.mesh()) TRIQS_RUNTIME_ERROR << "gf[ ] : mesh point's mesh and gf's mesh mismatch";
 #endif
@@ -1579,69 +1534,69 @@ namespace triqs {
    }
 
    // pass an abtract closest_point. We extract the value of the domain from p, call the gf_closest_point trait
-   template <typename... U> decltype(auto) operator[](closest_pt_wrap<U...> const &p) {
-    return dproxy_t::invoke(_data, _mesh.index_to_linear(gf_closest_point<Var, Target>::invoke(this, p)));
+   template <typename... U> decltype(auto) operator[](closest_pt_wrap<U...> const& p) {
+    return dproxy_t::invoke(_data, _mesh.index_to_linear(gf_closest_point<Var, Target>::invoke(this->mesh(), p)));
    }
-   template <typename... U> decltype(auto) operator[](closest_pt_wrap<U...> const &p) const {
-    return dproxy_t::invoke(_data, _mesh.index_to_linear(gf_closest_point<Var, Target>::invoke(this, p)));
+   template <typename... U> decltype(auto) operator[](closest_pt_wrap<U...> const& p) const {
+    return dproxy_t::invoke(_data, _mesh.index_to_linear(gf_closest_point<Var, Target>::invoke(this->mesh(), p)));
    }
 
    // ------------- [] with lazy arguments -----------------------------
 
-   template <typename Arg> clef::make_expr_subscript_t<gf_const_view const &, Arg> operator[](Arg &&arg) const & {
+   template <typename Arg> clef::make_expr_subscript_t<gf_const_view const&, Arg> operator[](Arg&& arg) const & {
     return clef::make_expr_subscript(*this, std::forward<Arg>(arg));
    }
 
-   template <typename Arg> clef::make_expr_subscript_t<gf_const_view &, Arg> operator[](Arg &&arg) & {
+   template <typename Arg> clef::make_expr_subscript_t<gf_const_view&, Arg> operator[](Arg&& arg) & {
     return clef::make_expr_subscript(*this, std::forward<Arg>(arg));
    }
 
-   template <typename Arg> clef::make_expr_subscript_t<gf_const_view, Arg> operator[](Arg &&arg) && {
+   template <typename Arg> clef::make_expr_subscript_t<gf_const_view, Arg> operator[](Arg&& arg) && {
     return clef::make_expr_subscript(std::move(*this), std::forward<Arg>(arg));
    }
 
    // --------------------- A direct access to the grid point --------------------------
 
-   template <typename... Args> decltype(auto) get_from_linear_index(Args &&... args) {
+   template <typename... Args> decltype(auto) get_from_linear_index(Args&&... args) {
     return dproxy_t::invoke(_data, linear_mesh_index_t(std::forward<Args>(args)...));
    }
 
-   template <typename... Args> decltype(auto) get_from_linear_index(Args &&... args) const {
+   template <typename... Args> decltype(auto) get_from_linear_index(Args&&... args) const {
     return dproxy_t::invoke(_data, linear_mesh_index_t(std::forward<Args>(args)...));
    }
 
-   template <typename... Args> decltype(auto) on_mesh(Args &&... args) {
+   template <typename... Args> decltype(auto) on_mesh(Args&&... args) {
     return dproxy_t::invoke(_data, _mesh.index_to_linear(mesh_index_t(std::forward<Args>(args)...)));
    }
 
-   template <typename... Args> decltype(auto) on_mesh(Args &&... args) const {
+   template <typename... Args> decltype(auto) on_mesh(Args&&... args) const {
     return dproxy_t::invoke(_data, _mesh.index_to_linear(mesh_index_t(std::forward<Args>(args)...)));
    }
 
    // --------------------- on mesh (g) : the call before [] -------------------------
    // This is a workaround the the lack of multi argument [] in C++
-/*
-   // mesh points should be treated slighly differently : take their index....
-   template <typename... T> decltype(auto) on_mesh(mesh_point<T> const &... args) { return on_mesh(args.index()...); }
-   template <typename... T> decltype(auto) on_mesh(mesh_point<T> const &... args) const { return on_mesh(args.index()...); }
+   /*
+      // mesh points should be treated slighly differently : take their index....
+      template <typename... T> decltype(auto) on_mesh(mesh_point<T> const &... args) { return on_mesh(args.index()...); }
+      template <typename... T> decltype(auto) on_mesh(mesh_point<T> const &... args) const { return on_mesh(args.index()...); }
 
-   // The on_mesh little adaptor ....
-   private:
-   template <typename G> struct _on_mesh_wrapper {
-    G &f;
-    template <typename... Args>
-    auto operator()(Args &&... args) const
-        -> std14::enable_if_t<!triqs::clef::is_any_lazy<Args...>::value, decltype(f.on_mesh(std::forward<Args>(args)...))> {
-     return f.on_mesh(std::forward<Args>(args)...);
-    }
-    TRIQS_CLEF_IMPLEMENT_LAZY_CALL();
-   };
+      // The on_mesh little adaptor ....
+      private:
+      template <typename G> struct _on_mesh_wrapper {
+       G &f;
+       template <typename... Args>
+       auto operator()(Args &&... args) const
+           -> std14::enable_if_t<!triqs::clef::is_any_lazy<Args...>::value, decltype(f.on_mesh(std::forward<Args>(args)...))> {
+        return f.on_mesh(std::forward<Args>(args)...);
+       }
+       TRIQS_CLEF_IMPLEMENT_LAZY_CALL();
+      };
 
-   public:
-   // TRIQS_DEPRECATED("Use [][][] instead")
-   _on_mesh_wrapper<gf_const_view const> friend on_mesh(gf_const_view const &f) { return {f}; }
-   _on_mesh_wrapper<gf_const_view> friend on_mesh(gf_const_view &f) { return {f}; }
-*/
+      public:
+      // TRIQS_DEPRECATED("Use [][][] instead")
+      _on_mesh_wrapper<gf_const_view const> friend on_mesh(gf_const_view const &f) { return {f}; }
+      _on_mesh_wrapper<gf_const_view> friend on_mesh(gf_const_view &f) { return {f}; }
+   */
    public:
    // --------------------- [][][][] ------------------------
    // This is a workaround the the lack of multi argument [] in C++
@@ -1649,33 +1604,35 @@ namespace triqs {
    /**
     *
     */
-   template <typename T> decltype(auto) operator[](T const &x) {
-    return triqs::utility::make_lazy_bracket<arity>([this](auto &&... y) ->decltype(auto){ return details::partial_eval(this, y...); }, x);
+   template <typename T> decltype(auto) operator[](T const& x) {
+    return triqs::utility::make_lazy_bracket<arity>(
+        [this](auto&&... y) -> decltype(auto) { return details::partial_eval(this, y...); }, x);
    }
 
    /**
     *
     */
-   template <typename T> decltype(auto) operator[](T const &x) const {
-    return triqs::utility::make_lazy_bracket<arity>([this](auto &&... y) ->decltype(auto){ return details::partial_eval(this, y...); }, x);
+   template <typename T> decltype(auto) operator[](T const& x) const {
+    return triqs::utility::make_lazy_bracket<arity>(
+        [this](auto&&... y) -> decltype(auto) { return details::partial_eval(this, y...); }, x);
    }
 
    //----------------------------- HDF5 -----------------------------
 
    /// HDF5 name
-   friend std::string get_triqs_hdf5_data_scheme(gf_const_view const &g) { return "Gf" + gf_h5_name<Var, Target>::invoke(); }
+   friend std::string get_triqs_hdf5_data_scheme(gf_const_view const& g) { return "Gf" + gf_h5_name<Var, Target>::invoke(); }
 
    friend struct gf_h5_rw<Var, Target>;
 
    /// Write into HDF5
-   friend void h5_write(h5::group fg, std::string const &subgroup_name, gf_const_view const &g) {
+   friend void h5_write(h5::group fg, std::string const& subgroup_name, gf_const_view const& g) {
     auto gr = fg.create_group(subgroup_name);
     gr.write_triqs_hdf5_data_scheme(g);
     gf_h5_rw<Var, Target>::write(gr, g);
    }
 
    /// Read from HDF5
-   friend void h5_read(h5::group fg, std::string const &subgroup_name, gf_const_view &g) {
+   friend void h5_read(h5::group fg, std::string const& subgroup_name, gf_const_view& g) {
     auto gr = fg.open_group(subgroup_name);
     // Check the attribute or throw
     auto tag_file     = gr.read_triqs_hdf5_data_scheme();
@@ -1690,24 +1647,21 @@ namespace triqs {
    //-----------------------------  BOOST Serialization -----------------------------
    friend class boost::serialization::access;
    /// The serialization as required by Boost
-   template <class Archive> void serialize(Archive &ar, const unsigned int version) {
-    ar &_data;
-    ar &_singularity;
-    ar &_mesh;
-    ar &_indices;
-    ar &name;
+   template <class Archive> void serialize(Archive& ar, const unsigned int version) {
+    ar& _data;
+    ar& _singularity;
+    ar& _mesh;
+    ar& _indices;
+    ar& name;
    }
 
    //----------------------------- print  -----------------------------
 
    /// IO
-   friend std::ostream &operator<<(std::ostream &out, gf_const_view const &x) { return out << "gf_const_view"; }
+   friend std::ostream& operator<<(std::ostream& out, gf_const_view const& x) { return out << "gf_const_view"; }
 
    //----------------------------- MPI  -----------------------------
 
-   
-
-   
    /**
      * Initiate (lazy) MPI Bcast
      *
@@ -1721,14 +1675,13 @@ namespace triqs {
      * @return Returns a lazy object describing the object and the MPI operation to be performed.
      *
      */
-   
-   friend void mpi_broadcast(gf_const_view &g, mpi::communicator c = {}, int root = 0) {
+
+   friend void mpi_broadcast(gf_const_view& g, mpi::communicator c = {}, int root = 0) {
     // Shall we bcast mesh ?
     mpi_broadcast(g.data(), c, root);
     mpi_broadcast(g.singularity(), c, root);
    }
 
-   
    /**
      * Initiate (lazy) MPI Reduce
      *
@@ -1742,13 +1695,12 @@ namespace triqs {
      * @return Returns a lazy object describing the object and the MPI operation to be performed.
      *
      */
-   
-   friend mpi_lazy<mpi::tag::reduce, const_view_type> mpi_reduce(gf_const_view const &a, mpi::communicator c = {}, int root = 0,
+
+   friend mpi_lazy<mpi::tag::reduce, const_view_type> mpi_reduce(gf_const_view const& a, mpi::communicator c = {}, int root = 0,
                                                                  bool all = false, MPI_Op op = MPI_SUM) {
     return {a(), c, root, all, op};
    }
 
-   
    /**
      * Initiate (lazy) MPI AllReduce
      *
@@ -1762,13 +1714,12 @@ namespace triqs {
      * @return Returns a lazy object describing the object and the MPI operation to be performed.
      *
      */
-   
-   friend mpi_lazy<mpi::tag::reduce, const_view_type> mpi_all_reduce(gf_const_view const &a, mpi::communicator c = {}, int root = 0,
-                                                                     MPI_Op op = MPI_SUM) {
+
+   friend mpi_lazy<mpi::tag::reduce, const_view_type> mpi_all_reduce(gf_const_view const& a, mpi::communicator c = {},
+                                                                     int root = 0, MPI_Op op = MPI_SUM) {
     return {a(), c, root, true, op};
    }
 
-   
    /**
      * Initiate (lazy) MPI Scatter
      *
@@ -1782,12 +1733,12 @@ namespace triqs {
      * @return Returns a lazy object describing the object and the MPI operation to be performed.
      *
      */
-   
-   friend mpi_lazy<mpi::tag::scatter, const_view_type> mpi_scatter(gf_const_view const &a, mpi::communicator c = {}, int root = 0) {
+
+   friend mpi_lazy<mpi::tag::scatter, const_view_type> mpi_scatter(gf_const_view const& a, mpi::communicator c = {},
+                                                                   int root = 0) {
     return {a(), c, root, true};
    }
 
-   
    /**
      * Initiate (lazy) MPI Gather
      *
@@ -1801,13 +1752,12 @@ namespace triqs {
      * @return Returns a lazy object describing the object and the MPI operation to be performed.
      *
      */
-   
-   friend mpi_lazy<mpi::tag::gather, const_view_type> mpi_gather(gf_const_view const &a, mpi::communicator c = {}, int root = 0,
+
+   friend mpi_lazy<mpi::tag::gather, const_view_type> mpi_gather(gf_const_view const& a, mpi::communicator c = {}, int root = 0,
                                                                  bool all = false) {
     return {a(), c, root, all};
    }
 
-   
    /**
      * Initiate (lazy) MPI AllGather
      *
@@ -1821,11 +1771,11 @@ namespace triqs {
      * @return Returns a lazy object describing the object and the MPI operation to be performed.
      *
      */
-   
-   friend mpi_lazy<mpi::tag::gather, const_view_type> mpi_all_gather(gf_const_view const &a, mpi::communicator c = {}, int root = 0) {
+
+   friend mpi_lazy<mpi::tag::gather, const_view_type> mpi_all_gather(gf_const_view const& a, mpi::communicator c = {},
+                                                                     int root = 0) {
     return {a(), c, root, true};
    }
-
   };
 
 /*------------------------------------------------------------------------------------------------------
@@ -1833,31 +1783,37 @@ namespace triqs {
  *-----------------------------------------------------------------------------------------------------*/
 
 #ifdef __cpp_if_constexpr
-  template <typename M, typename T, typename RHS> void triqs_gf_view_assign_delegation(gf_view<M, T> g, RHS const &rhs) {
-   if constexpr (arrays::is_scalar_v<RHS>) {
-    for (auto const &w : g.mesh()) g[w] = rhs;
-    g.singularity()                     = rhs;
-   } else {
+  template <typename M, typename T, typename RHS> void triqs_gf_view_assign_delegation(gf_view<M, T> g, RHS const& rhs) {
+   if
+    constexpr(arrays::is_scalar_v<RHS>) {
+     for (auto const& w : g.mesh())
+      g[w]           = rhs;
+     g.singularity() = rhs;
+    }
+   else {
     if (!(g.mesh() == rhs.mesh()))
      TRIQS_RUNTIME_ERROR << "Gf Assignment in View : incompatible mesh" << g.mesh() << " vs " << rhs.mesh();
-    for (auto const &w : g.mesh()) g[w] = rhs[w];
-    g.singularity()                     = rhs.singularity();
+    for (auto const& w : g.mesh())
+     g[w]           = rhs[w];
+    g.singularity() = rhs.singularity();
    }
   }
 #else
   // delegate = so that I can overload it for specific RHS...
   template <typename M, typename T, typename RHS>
-  std14::enable_if_t<!arrays::is_scalar<RHS>::value> triqs_gf_view_assign_delegation(gf_view<M, T> g, RHS const &rhs) {
+  std14::enable_if_t<!arrays::is_scalar<RHS>::value> triqs_gf_view_assign_delegation(gf_view<M, T> g, RHS const& rhs) {
    if (!(g.mesh() == rhs.mesh()))
     TRIQS_RUNTIME_ERROR << "Gf Assignment in View : incompatible mesh" << g.mesh() << " vs " << rhs.mesh();
-   for (auto const &w : g.mesh()) g[w] = rhs[w];
-   g.singularity()                     = rhs.singularity();
+   for (auto const& w : g.mesh())
+    g[w]           = rhs[w];
+   g.singularity() = rhs.singularity();
   }
 
   template <typename M, typename T, typename RHS>
-  std14::enable_if_t<arrays::is_scalar<RHS>::value> triqs_gf_view_assign_delegation(gf_view<M, T> g, RHS const &rhs) {
-   for (auto const &w : g.mesh()) g[w] = rhs;
-   g.singularity()                     = rhs;
+  std14::enable_if_t<arrays::is_scalar<RHS>::value> triqs_gf_view_assign_delegation(gf_view<M, T> g, RHS const& rhs) {
+   for (auto const& w : g.mesh())
+    g[w]           = rhs;
+   g.singularity() = rhs;
   }
 #endif
  }
@@ -1867,5 +1823,5 @@ namespace triqs {
  *-----------------------------------------------------------------------------------------------------*/
 namespace std {
  template <typename Var, typename Target>
- void swap(triqs::gfs::gf_view<Var, Target> &a, triqs::gfs::gf_view<Var, Target> &b) = delete;
+ void swap(triqs::gfs::gf_view<Var, Target>& a, triqs::gfs::gf_view<Var, Target>& b) = delete;
 }

--- a/triqs/gfs/gf/gf.mako.hpp
+++ b/triqs/gfs/gf/gf.mako.hpp
@@ -535,10 +535,10 @@ namespace triqs {
 
    // pass an abtract closest_point. We extract the value of the domain from p, call the gf_closest_point trait
    template <typename... U> decltype(auto) operator[](closest_pt_wrap<U...> const &p) {
-    return dproxy_t::invoke(_data, _mesh.index_to_linear(gf_closest_point<Var, Target>::invoke(this, p)));
+    return dproxy_t::invoke(_data, _mesh.index_to_linear(gf_closest_point<Var, Target>::invoke(this->mesh(), p)));
    }
    template <typename... U> decltype(auto) operator[](closest_pt_wrap<U...> const &p) const {
-    return dproxy_t::invoke(_data, _mesh.index_to_linear(gf_closest_point<Var, Target>::invoke(this, p)));
+    return dproxy_t::invoke(_data, _mesh.index_to_linear(gf_closest_point<Var, Target>::invoke(this->mesh(), p)));
    }
 
    // ------------- [] with lazy arguments -----------------------------


### PR DESCRIPTION
Added the closest_mesh_pt functionality for cartesian_product meshes.
E.g. for
```c++
gf<cartesian_product<imtime,imtime,imtime>> G;
```
write 
```c++
G[closest_mesh_pt(tau1, tau2, tau3)]
```