### PR TITLE
[cmake] Check common environment in Cmake Find Modules. 

### DIFF
--- a/cmake/FindFFTW.cmake
+++ b/cmake/FindFFTW.cmake
@@ -11,6 +11,11 @@
 SET(TRIAL_PATHS
  $ENV{FFTW_ROOT}/include
  ${FFTW_ROOT}/include
+ ENV CPATH
+ ENV C_INCLUDE_PATH
+ ENV CPLUS_INCLUDE_PATH
+ ENV OBJC_INCLUDE_PATH
+ ENV OBJCPLUS_INCLUDE_PATH
  /usr/include
  /usr/local/include
  /opt/local/include
@@ -19,12 +24,15 @@ SET(TRIAL_PATHS
 FIND_PATH(FFTW_INCLUDE_DIR fftw3.h ${TRIAL_PATHS} DOC "Include for FFTW")
 
 SET(TRIAL_LIBRARY_PATHS
+ $ENV{FFTW_ROOT}/lib
+ ${FFTW_ROOT}/lib
+ ${FFTW_INCLUDE_DIR}/../lib
+ ENV LIBRARY_PATH
+ ENV LD_LIBRARY_PATH
  /usr/lib 
  /usr/local/lib
  /opt/local/lib
  /sw/lib
- $ENV{FFTW_ROOT}/lib
- ${FFTW_ROOT}/lib
  )
 
 SET(FFTW_LIBRARIES "FFTW_LIBRARIES-NOTFOUND" CACHE STRING "FFTW library")

--- a/cmake/FindGSL.cmake
+++ b/cmake/FindGSL.cmake
@@ -11,6 +11,11 @@
 SET(TRIAL_PATHS
  $ENV{GSL_ROOT}/include
  ${GSL_ROOT}/include
+ ENV CPATH
+ ENV C_INCLUDE_PATH
+ ENV CPLUS_INCLUDE_PATH
+ ENV OBJC_INCLUDE_PATH
+ ENV OBJCPLUS_INCLUDE_PATH
  /usr/include
  /usr/local/include
  /opt/local/include
@@ -19,12 +24,15 @@ SET(TRIAL_PATHS
 FIND_PATH(GSL_INCLUDE_DIR gsl/gsl_math.h ${TRIAL_PATHS} DOC "Include for GSL")
 
 SET(TRIAL_LIBRARY_PATHS
+ $ENV{GSL_ROOT}/lib
+ ${GSL_ROOT}/lib
+ ${GSL_INCLUDE_DIR}/../lib
+ ENV LIBRARY_PATH
+ ENV LD_LIBRARY_PATH
  /usr/lib 
  /usr/local/lib
  /opt/local/lib
  /sw/lib
- $ENV{GSL_ROOT}/lib
- ${GSL_ROOT}/lib
  )
 
 SET(GSL_LIBRARIES "GSL_LIBRARIES-NOTFOUND" CACHE STRING "GSL library")

--- a/cmake/FindNFFT.cmake
+++ b/cmake/FindNFFT.cmake
@@ -13,6 +13,11 @@ INCLUDE( FindPackageHandleStandardArgs )
 SET(TRIAL_PATHS
  $ENV{NFFT_ROOT}/include
  ${NFFT_ROOT}/include
+ ENV CPATH
+ ENV C_INCLUDE_PATH
+ ENV CPLUS_INCLUDE_PATH
+ ENV OBJC_INCLUDE_PATH
+ ENV OBJCPLUS_INCLUDE_PATH
  /usr/include
  /usr/local/include
  /opt/local/include
@@ -21,12 +26,15 @@ SET(TRIAL_PATHS
 FIND_PATH(NFFT_INCLUDE_DIR nfft3.h ${TRIAL_PATHS} DOC "Include for NFFT")
 
 SET(TRIAL_LIBRARY_PATHS
+ $ENV{NFFT_ROOT}/lib
+ ${NFFT_ROOT}/lib
+ ${NFFT_INCLUDE_DIR}/../lib
+ ENV LIBRARY_PATH
+ ENV LD_INCLUDE_PATH
  /usr/lib 
  /usr/local/lib
  /opt/local/lib
  /sw/lib
- $ENV{NFFT_ROOT}/lib
- ${NFFT_ROOT}/lib
  )
 
 SET(NFFT_LIBRARIES "NFFT_LIBRARIES-NOTFOUND" CACHE STRING "NFFT library")

--- a/cmake/FindTRIQS.cmake
+++ b/cmake/FindTRIQS.cmake
@@ -16,6 +16,11 @@ get_filename_component(TRIQS_PATH ${TRIQS_PATH} ABSOLUTE)
 SET(TRIAL_PATHS
  $ENV{TRIQS_PATH}/include/triqs
  ${TRIQS_PATH}/include/triqs
+ ENV CPATH
+ ENV C_INCLUDE_PATH
+ ENV CPLUS_INCLUDE_PATH
+ ENV OBJC_INCLUDE_PATH
+ ENV OBJCPLUS_INCLUDE_PATH
  /usr/include/triqs
  /usr/local/include/triqs
  /opt/local/include/triqs
@@ -24,12 +29,15 @@ SET(TRIAL_PATHS
 FIND_PATH(TRIQS_INCLUDE_DIR triqs_config.h ${TRIAL_PATHS} DOC "Include triqs")
 
 SET(TRIAL_LIBRARY_PATHS
+ $ENV{TRIQS_PATH}/lib
+ ${TRIQS_PATH}/lib
+ ${TRIQS_INCLUDE_DIR}/../lib
+ ENV LIBRARY_PATH
+ ENV LD_LIBRARY_PATH
  /usr/lib 
  /usr/local/lib
  /opt/local/lib
  /sw/lib
- $ENV{TRIQS_PATH}/lib
- ${TRIQS_PATH}/lib
  )
 
 SET(TRIQS_LIBRARIES "TRIQS_LIBRARIES-NOTFOUND" CACHE STRING "TRIQS library")
@@ -39,6 +47,8 @@ FIND_LIBRARY(TRIQS_LIBRARIES triqs ${TRIAL_LIBRARY_PATHS} DOC "TRIQS library")
 SET(TRIAL_PATHS
  $ENV{TRIQS_PATH}/share/triqs/cmake
  ${TRIQS_PATH}/share/triqs/cmake
+ ${TRIQS_INCLUDE_DIR}/../share/triqs/cmake
+ ${TRIQS_LIBRARIES}/../share/triqs/cmake
  /usr/share/triqs/cmake
  /usr/local/share/triqs/cmake
  /opt/local/share/triqs/cmake


### PR DESCRIPTION
In the find modules for the c/c++ libraries the common environment
variables should be checked! Compare e.g.
https://gcc.gnu.org/onlinedocs/gcc-6.3.0/gcc/Environment-Variables.html
https://clang.llvm.org/docs/CommandGuide/clang.html#environment
Further, made the order between the header and library searches more
consistent to not accidentally mix headers/libs of two installations.

@mferrero  Do you agree?