### PR TITLE
Density() function for GfReFreq

### DIFF
--- a/pytriqs/gf/local/gf_desc.py
+++ b/pytriqs/gf/local/gf_desc.py
@@ -602,16 +602,27 @@ for py_type, has_tail in [("GfReFreq", True) ,("GfReFreqNoTail",False)]:
               signature = "void(gf_view<imfreq, matrix_valued, tail> gw, int n_points = 100, double freq_offset = 0.0)",
               calling_pattern = "pade(self_c,*gw,n_points, freq_offset)",
               doc = """TO BE WRITTEN""")
+
   g.add_method(name = "density",
-              signature = "matrix_view<double>()",
-              calling_pattern = "auto result = density(self_c)",
-              doc = "Density, as a matrix, computed from a Matsubara sum")
+              signature = "matrix_view<double>(double beta)",
+              calling_pattern = "auto result = density(self_c, beta)",
+              doc = "Density, as a matrix, computed from real frequency integration")
 
   g.add_method(name = "total_density",
-              signature = "double()",
-              calling_pattern = "auto result = trace(density(self_c))",
+              signature = "double(double beta)",
+              calling_pattern = "auto result = trace(density(self_c, beta))",
               doc = "Trace of density")
 
+  g.add_method(name = "density_zero_T",
+              signature = "matrix_view<double>()",
+              calling_pattern = "auto result = density_zero_T(self_c)",
+              doc = "Density, as a matrix, computed from real frequency integration")
+
+  g.add_method(name = "total_density_zero_T",
+              signature = "double()",
+              calling_pattern = "auto result = trace(density_zero_T(self_c))",
+              doc = "Trace of density")
+  
 # For legacy Python code : authorize g + Matrix
  g.number_protocol['inplace_add'].add_overload(calling_pattern = "+=", signature = "void(gf_view<refreq> x,matrix<std::complex<double>> y)")
  g.number_protocol['inplace_subtract'].add_overload(calling_pattern = "-=", signature = "void(gf_view<refreq> x,matrix<std::complex<double>> y)")

--- a/pytriqs/gf/local/gf_desc.py
+++ b/pytriqs/gf/local/gf_desc.py
@@ -602,6 +602,15 @@ for py_type, has_tail in [("GfReFreq", True) ,("GfReFreqNoTail",False)]:
               signature = "void(gf_view<imfreq, matrix_valued, tail> gw, int n_points = 100, double freq_offset = 0.0)",
               calling_pattern = "pade(self_c,*gw,n_points, freq_offset)",
               doc = """TO BE WRITTEN""")
+  g.add_method(name = "density",
+              signature = "matrix_view<double>()",
+              calling_pattern = "auto result = density(self_c)",
+              doc = "Density, as a matrix, computed from a Matsubara sum")
+
+  g.add_method(name = "total_density",
+              signature = "double()",
+              calling_pattern = "auto result = trace(density(self_c))",
+              doc = "Trace of density")
 
 # For legacy Python code : authorize g + Matrix
  g.number_protocol['inplace_add'].add_overload(calling_pattern = "+=", signature = "void(gf_view<refreq> x,matrix<std::complex<double>> y)")

--- a/test/pytriqs/base/gf_density.py
+++ b/test/pytriqs/base/gf_density.py
@@ -1,0 +1,36 @@
+import numpy as np
+from pytriqs.gf.local import *
+
+np.random.seed(1337)
+
+def fermi(eps, beta):
+    return 1./(1. + np.exp(-beta * eps))
+
+beta = 10.0
+
+g_iw = GfImFreq(beta=beta, indices=[0])
+g_iw << inverse(iOmega_n)
+np.testing.assert_almost_equal(g_iw.density(), 0.5)
+
+for eps in np.random.random(10):
+    g_iw << inverse(iOmega_n + eps)
+    n = np.squeeze(g_iw.density())
+    n_ref = fermi(eps, beta)
+    np.testing.assert_almost_equal(n, n_ref)
+
+# -- Real frequency
+     
+g_w = GfReFreq(indices=[0], window=[-2., 2.])
+
+D, mu = 2., .5
+g_w << inverse(Omega - SemiCircular(D) + mu)
+g_iw << inverse(iOmega_n - SemiCircular(D) + mu)
+
+np.testing.assert_almost_equal(g_iw.density(), g_w.density(beta=beta))
+
+w = np.array([w.real for w in g_w.mesh])
+g = np.squeeze(g_w.data.imag)
+norm = -1./np.pi * np.trapz(g, x=w)
+
+np.testing.assert_almost_equal(norm, 1.)
+

--- a/test/pytriqs/base/gf_density.py
+++ b/test/pytriqs/base/gf_density.py
@@ -8,7 +8,7 @@ def fermi(eps, beta):
 
 beta = 10.0
 
-g_iw = GfImFreq(beta=beta, indices=[0])
+g_iw = GfImFreq(beta=beta, indices=[0], n_points=1000)
 g_iw << inverse(iOmega_n)
 np.testing.assert_almost_equal(g_iw.density(), 0.5)
 
@@ -20,17 +20,25 @@ for eps in np.random.random(10):
 
 # -- Real frequency
      
-g_w = GfReFreq(indices=[0], window=[-2., 2.])
+D = 2.
+eps = 1e-9
 
-D, mu = 2., .5
-g_w << inverse(Omega - SemiCircular(D) + mu)
-g_iw << inverse(iOmega_n - SemiCircular(D) + mu)
+g_w_even = GfReFreq(indices=[0], window=[-2.+eps, 2.-eps], n_points=100000)
+g_w_odd = GfReFreq(indices=[0], window=[-2.+eps, 2.-eps], n_points=100001)
 
-np.testing.assert_almost_equal(g_iw.density(), g_w.density(beta=beta))
+g_iw << SemiCircular(D)
+g_w_even << SemiCircular(D)
+g_w_odd << SemiCircular(D)
 
-w = np.array([w.real for w in g_w.mesh])
-g = np.squeeze(g_w.data.imag)
-norm = -1./np.pi * np.trapz(g, x=w)
+n_iw = g_iw.density()
 
-np.testing.assert_almost_equal(norm, 1.)
+n_w_even = g_w_even.density(beta=beta)
+n_w0_even = g_w_even.density(beta=-1.)
+n_w_odd = g_w_odd.density(beta=beta)
+n_w0_odd = g_w_odd.density(beta=-1.)
+
+np.testing.assert_almost_equal(n_iw, n_w_even)
+np.testing.assert_almost_equal(n_iw, n_w_odd)
+np.testing.assert_almost_equal(n_iw, n_w0_even)
+np.testing.assert_almost_equal(n_iw, n_w0_odd)
 

--- a/triqs/gfs/functions/functions.hpp
+++ b/triqs/gfs/functions/functions.hpp
@@ -48,8 +48,11 @@ namespace gfs {
  // For Real Frequency functions
  // ------------------------------------------------------
 
- arrays::matrix<dcomplex> density(gf_const_view<refreq> g);
- dcomplex density(gf_const_view<refreq, scalar_valued> g);
+ arrays::matrix<dcomplex> density(gf_const_view<refreq> g, double beta);
+ dcomplex density(gf_const_view<refreq, scalar_valued> g, double beta);
+
+ arrays::matrix<dcomplex> density_zero_T(gf_const_view<refreq> g);
+ dcomplex density_zero_T(gf_const_view<refreq, scalar_valued> g);
 
  //-------------------------------------------------------
  // For Legendre functions

--- a/triqs/gfs/functions/functions.hpp
+++ b/triqs/gfs/functions/functions.hpp
@@ -22,6 +22,7 @@
 
 #include "../gf_classes.hpp"
 #include "../imfreq.hpp"
+#include "../refreq.hpp"
 #include "../imtime.hpp"
 #include "../legendre.hpp"
 
@@ -42,6 +43,13 @@ namespace gfs {
  dcomplex density(gf_const_view<imfreq, scalar_valued> g);
 
  arrays::matrix<dcomplex> density(gf_const_view<legendre> g);
+
+ //-------------------------------------------------------
+ // For Real Frequency functions
+ // ------------------------------------------------------
+
+ arrays::matrix<dcomplex> density(gf_const_view<refreq> g);
+ dcomplex density(gf_const_view<refreq, scalar_valued> g);
 
  //-------------------------------------------------------
  // For Legendre functions


### PR DESCRIPTION
This commit implements the density() function for real frequency Greens function.

- The integration from x_min to 0 is performed with the trapezoidal rule.

- If 0 is not a point of the mesh the integration is carried out up to the last negative mesh point x1.
Additionally, the remaining area Ar from x1 to 0 is added. This area is given by
Ar = f(x1) * |x1| + |x1|^2/(2*delta_w) * (f(x2)-f(x1)), where x2 is the first positive mesh point.

Please feel free to alter or improve this commit. In any case I would really appreciate having a density()
function for GfReFreq on the master branch.

Thanks,
Manuel