### PR TITLE
 Add -march=native to release flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -349,6 +349,7 @@ if(NOT CMAKE_BUILD_TYPE)
  mark_as_advanced(CMAKE_BUILD_TYPE)
 endif(NOT CMAKE_BUILD_TYPE)
 message(STATUS "Build type: " ${CMAKE_BUILD_TYPE})
+set(CMAKE_CXX_FLAGS_RELEASE "-O3 -march=native -DNDEBUG" CACHE STRING " The release flags " FORCE)
 
 # Fortran bindings
 option(BIND_FORTRAN_LOWERCASE "FORTRAN functions are compiled WITHOUT a trailing underscore" OFF)


### PR DESCRIPTION
This should be always used for any triqs setup to allow for architecture specific optimizations.