### PR TITLE
[pygf] bugfix pytriqs.gf.local removed

### DIFF
--- a/pytriqs/dos/hilbert_transform.py
+++ b/pytriqs/dos/hilbert_transform.py
@@ -20,7 +20,6 @@
 #
 ################################################################################
 
-from pytriqs.gf.local import *
 import types, string, inspect, itertools
 from operator import isSequenceType
 from pytriqs.dos import DOS, DOSFromFunction


### PR DESCRIPTION
Running the tests (dos, brillouin_zone, g_k_om) fails in hilbert_transform.py that tries to import the no longer existing python module pytriqs.gf.local. 