### PR TITLE
Unstable

### DIFF
--- a/pytriqs/gf/meshes_desc.py
+++ b/pytriqs/gf/meshes_desc.py
@@ -162,10 +162,7 @@ def make_mesh_stripped(py_type, c_tag,
             comparisons = "== !="
            )
 
-    #m.add_method("long index_to_linear(%s i)"%index_type, doc = "index -> linear index")
     m.add_len(calling_pattern = "int result = self_c.size()", doc = "Size of the mesh")
-    #c_cast_type = "dcomplex" if not (c_tag == "brillouin_zone" or c_tag=="cyclic_lattice") else "triqs::arrays::vector<double>"
-    #m.add_iterator(c_cast_type = c_cast_type)
 
     m.add_method_copy()
     m.add_method_copy_from()

--- a/pytriqs/gf/meshes_desc.py
+++ b/pytriqs/gf/meshes_desc.py
@@ -163,7 +163,7 @@ def make_mesh_stripped(py_type, c_tag,
            )
 
     #m.add_method("long index_to_linear(%s i)"%index_type, doc = "index -> linear index")
-    #m.add_len(calling_pattern = "int result = self_c.size()", doc = "Size of the mesh")
+    m.add_len(calling_pattern = "int result = self_c.size()", doc = "Size of the mesh")
     #c_cast_type = "dcomplex" if not (c_tag == "brillouin_zone" or c_tag=="cyclic_lattice") else "triqs::arrays::vector<double>"
     #m.add_iterator(c_cast_type = c_cast_type)
 

--- a/pytriqs/gf/meshes_desc.py
+++ b/pytriqs/gf/meshes_desc.py
@@ -97,7 +97,6 @@ module.add_class(m)
 ##   MeshLegendre
 ########################
 
-
 # the domain
 dom = class_( py_type = "GfLegendreDomain",
         c_type = "legendre_domain",
@@ -124,7 +123,6 @@ module.add_class(m)
 ##   MeshDiscrete
 ########################
 
-
 # the domain
 dom = class_( py_type = "GfDiscreteDomainSimple",
         c_type = "discrete_domain_simple",
@@ -137,6 +135,46 @@ module.add_class(dom)
 # the mesh
 m = make_mesh( py_type = "MeshDiscrete", c_tag = "discrete")
 m.add_constructor(signature = "(int n_max)")
+
+module.add_class(m)
+
+########################
+##   MeshPoly3
+########################
+
+# the mesh
+m = make_mesh( py_type = "MeshPolyOne", c_tag = "poly_one")
+m.add_constructor(signature = "(double beta, statistic_enum S, long n)")
+
+module.add_class(m)
+
+# -- by hand wrapping of poly3 since it is an underlying cartesian_product mesh
+
+def make_mesh_stripped(py_type, c_tag,
+              #index_type='long'
+              ) :
+    m = class_( py_type = py_type,
+            c_type = "gf_mesh<%s>"%c_tag,
+            c_type_absolute = "triqs::gfs::gf_mesh<triqs::gfs::%s>"%c_tag,
+            hdf5 = True,
+            serializable= "tuple",
+            is_printable= True,
+            comparisons = "== !="
+           )
+
+    #m.add_method("long index_to_linear(%s i)"%index_type, doc = "index -> linear index")
+    #m.add_len(calling_pattern = "int result = self_c.size()", doc = "Size of the mesh")
+    #c_cast_type = "dcomplex" if not (c_tag == "brillouin_zone" or c_tag=="cyclic_lattice") else "triqs::arrays::vector<double>"
+    #m.add_iterator(c_cast_type = c_cast_type)
+
+    m.add_method_copy()
+    m.add_method_copy_from()
+
+    return m
+
+# the mesh
+m = make_mesh_stripped( py_type = "MeshPoly3", c_tag = "poly3")
+m.add_constructor(signature = "(double beta, statistic_enum S, long order)")
 
 module.add_class(m)
 

--- a/pytriqs/gf/meshes_desc.py
+++ b/pytriqs/gf/meshes_desc.py
@@ -121,6 +121,26 @@ m.add_property(name = "statistic",
 module.add_class(m)
 
 ########################
+##   MeshDiscrete
+########################
+
+
+# the domain
+dom = class_( py_type = "GfDiscreteDomainSimple",
+        c_type = "discrete_domain_simple",
+        c_type_absolute = "triqs::gfs::discrete_domain_simple",
+        serializable= "tuple",
+       )
+dom.add_constructor(signature = "(int n_max)")
+module.add_class(dom)
+
+# the mesh
+m = make_mesh( py_type = "MeshDiscrete", c_tag = "discrete")
+m.add_constructor(signature = "(int n_max)")
+
+module.add_class(m)
+
+########################
 ##   MeshReFreq
 ########################
 

--- a/test/triqs/gfs/gf_poly.cpp
+++ b/test/triqs/gfs/gf_poly.cpp
@@ -1,0 +1,29 @@
+#include <triqs/test_tools/gfs.hpp>
+#include <triqs/gfs.hpp>
+
+using namespace triqs::gfs;
+
+TEST(Gf, Poly) {
+
+ long n_max = 24;
+ double beta = 10.0;
+ 
+ auto gpoly = gf<poly3, tensor_valued<4>>{{beta, Fermion, n_max}, {1, 1, 1, 1}};
+
+ for( auto mp : gpoly.mesh() ) {
+   gpoly[mp] = 1.2345;
+ }
+
+ std::string filename = "data_gf_poly.h5";
+ 
+ triqs::h5::file out_file(filename, 'w');
+ h5_write(out_file, "gpoly", gpoly);
+
+ decltype(gpoly) gpoly_ref;
+ triqs::h5::file in_file(filename, 'r');
+ h5_read(in_file, "gpoly", gpoly_ref);
+
+ EXPECT_GF_NEAR(gpoly, gpoly_ref);
+ 
+}
+MAKE_MAIN;

--- a/triqs/gfs/meshes.hpp
+++ b/triqs/gfs/meshes.hpp
@@ -41,6 +41,7 @@
 #include "./meshes/retime.hpp"
 #include "./meshes/refreq.hpp"
 #include "./meshes/legendre.hpp"
+#include "./meshes/poly.hpp"
 #include "./domains/R.hpp"
 #include "../lattice/gf_mesh_brillouin_zone.hpp"
 #include "../lattice/gf_mesh_cyclic_lattice.hpp"

--- a/triqs/gfs/meshes/poly.hpp
+++ b/triqs/gfs/meshes/poly.hpp
@@ -1,0 +1,144 @@
+/*******************************************************************************
+ *
+ * TRIQS: a Toolbox for Research in Interacting Quantum Systems
+ *
+ * Copyright (C) 2017, H. U.R. Strand, O. Parcollet
+ *
+ * TRIQS is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * TRIQS is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * TRIQS. If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+
+#pragma once
+
+#include <triqs/gfs.hpp>
+#include <triqs/arrays.hpp>
+#include <triqs/gfs/gf/defs.hpp> // neded for get_n_variables template def
+#include <triqs/gfs/meshes/product.hpp>  // neded for cartesian_product (contain specializ of get_n_variables)
+
+namespace triqs {
+  namespace gfs {
+
+    // -------------------------------------------------------------------------
+
+    /// Simple discrete domain without any naming features, c.f. triqs::gfs::discrete_domain
+    class discrete_domain_simple {
+      int n_max;
+
+      public:
+      using point_t = int;
+      int size() const { return n_max; };
+      discrete_domain_simple(int n_max = 1) : n_max(n_max) {}
+      bool operator==(discrete_domain_simple const &x) const { return (n_max == x.n_max); }
+
+      /// Write into HDF5
+      friend void h5_write(h5::group fg, std::string subgroup_name, discrete_domain_simple const & d) {
+	h5::group gr = fg.create_group(subgroup_name);
+	h5_write(gr, "n_max", d.n_max);
+      }
+      
+      /// Read from HDF5
+      friend void h5_read(h5::group fg, std::string subgroup_name, discrete_domain_simple & d) {
+	h5::group gr = fg.open_group(subgroup_name);
+	int n_max;
+	h5_read(gr, "n_max", n_max);
+	d = discrete_domain_simple(n_max);
+      }
+
+      //  BOOST Serialization
+      friend class boost::serialization::access;
+      template <class Archive> void serialize(Archive& ar, const unsigned int version) {
+	ar& TRIQS_MAKE_NVP("n_max", n_max);
+      }
+      
+    };
+    
+    // -------------------------------------------------------------------------
+
+    struct discrete {};
+
+    /// MeshDiscrete: gf_mesh<discrete> for usage in cartesian products with legendre meshes
+    template <> struct gf_mesh<discrete> : discrete_mesh<discrete_domain_simple> {
+      using B = discrete_mesh<discrete_domain_simple>;
+      using var_t = discrete;
+
+      gf_mesh() = default;
+      gf_mesh(int n_max) : B{n_max} {}
+
+      friend std::string get_triqs_hdf5_data_scheme(gf_mesh const &) { return "MeshDiscrete";}
+  
+      friend void h5_write(h5::group fg, std::string const &subgroup_name, gf_mesh const &m) {
+	h5_write_impl(fg, subgroup_name, m, "MeshDiscrete");
+      }
+  
+      friend void h5_read(h5::group fg, std::string const & subgroup_name, gf_mesh &m) {
+	h5_read_impl(fg, subgroup_name, m, "MeshDiscrete");
+      }   
+    };
+
+    // -------------------------------------------------------------------------
+
+    struct poly_one {};
+
+    template <> struct gf_mesh<poly_one> : discrete_mesh<legendre_domain> {
+      using B = discrete_mesh<legendre_domain>;
+      using var_t = poly_one;
+      
+      gf_mesh() = default;
+      gf_mesh(double beta, statistic_enum S, long n) : B(B::domain_t{beta, S, static_cast<size_t>(n)}) {}
+
+      friend std::string get_triqs_hdf5_data_scheme(gf_mesh const &) { return "MeshPolyOne";}
+  
+      friend void h5_write(h5::group fg, std::string const &subgroup_name, gf_mesh const &m) {
+	h5_write_impl(fg, subgroup_name, m, "MeshPolyOne");
+      }
+  
+      friend void h5_read(h5::group fg, std::string const & subgroup_name, gf_mesh &m) {
+	h5_read_impl(fg, subgroup_name, m, "MeshPolyOne");
+      }   
+    };
+
+    // -------------------------------------------------------------------------
+
+    struct poly2 {};
+
+    template <> struct gf_mesh<poly2> : gf_mesh<cartesian_product<discrete, poly_one>> {
+      using B = gf_mesh<cartesian_product<discrete, poly_one>>;
+
+      gf_mesh() = default;
+      gf_mesh(double beta, statistic_enum S, long n) : B{{2}, {beta, S, n}} {}
+    };
+
+    // GET RID OF THIS TRAIT ?
+    template <> struct get_n_variables<poly2> { static const int value = 2; };
+    
+    // -------------------------------------------------------------------------
+
+    struct poly3 {};
+
+    template <> struct gf_mesh<poly3> : gf_mesh<cartesian_product<discrete, poly_one>> {
+      using B = gf_mesh<cartesian_product<discrete, poly_one>>;
+      
+      gf_mesh() = default;
+      gf_mesh(double beta, statistic_enum S, long order) : order(order),
+        B{{6}, {beta, S, (order * (order * order + 3 * order + 2)) / 6}} {}
+
+      public:
+      int order;
+    };
+
+    // GET RID OF THIS TRAIT ?
+    template <> struct get_n_variables<poly3> { static const int value = 2; };
+    
+  } // namespace gfs
+} // namespace triqs


### PR DESCRIPTION
Bug report to @parcollet :

The `pytriqs.gf.gf` assumes that only things being a `MeshProduct` is a `MeshProduct`. This is not the case with the `gf_mesh<poly3>` mesh that produces this wrapping error:

```
%%triqs             
#include <triqs/gfs.hpp>
using namespace triqs::gfs;

gf<poly3, tensor_valued<4>> generator() {
    int order = 2;
    double beta = 1.234;
    return gf<poly3, tensor_valued<4>>{{beta, Fermion, order}, {1, 1, 1, 1}};
}
```
```
gpoly = generator()
```
```
---------------------------------------------------------------------------
AssertionError                            Traceback (most recent call last)
<ipython-input-3-b0838bfb6bc9> in <module>()
----> 1 gpoly = generator()

/Users/hugstr/apps/triqs_devel/lib/python2.7/site-packages/pytriqs/gf/gf.pyc in __init__(self, **kw)
    186             self.__check_invariants()
    187 
--> 188         delegate(self, **kw)
    189 
    190     def __check_invariants_tail(self):

/Users/hugstr/apps/triqs_devel/lib/python2.7/site-packages/pytriqs/gf/gf.pyc in delegate(self, mesh, data, target_shape, singularity, indices, name, is_real, _singularity_maker)
    164             if self._indices is not None:
    165                 d,i =  self._data.shape[self._rank:], tuple(len(x) for x in self._indices.data)
--> 166                 assert (d == i), "Indices are of incorrect size. Data size is %s while indices size is %s"%(d,i)
    167             # Now indices are set, and are always a GfIndices object, with the
    168             # correct size

AssertionError: Indices are of incorrect size. Data size is (4, 1, 1, 1, 1) while indices size is (1, 1, 1, 1)
```

Please see below for the notebook to reproduce the bug:

[notebook_example.zip](https://github.com/TRIQS/triqs/files/976228/notebook_example.zip)
