### PR TITLE
Fix compilation with gcc-7

### DIFF
--- a/cmake/FindLibClang.cmake
+++ b/cmake/FindLibClang.cmake
@@ -22,6 +22,7 @@ else()
 SET(TRIAL_LIBRARY_PATHS
  /usr/lib 
  /usr/lib/x86_64-linux-gnu
+ /usr/lib/llvm-4.0/lib
  /usr/lib/llvm-3.9/lib
  /usr/lib/llvm-3.8/lib
  /usr/lib/llvm-3.6/lib

--- a/triqs/arrays/block_matrix.hpp
+++ b/triqs/arrays/block_matrix.hpp
@@ -24,6 +24,7 @@
 #include <vector>
 #include <algorithm>
 #include <triqs/utility/is_complex.hpp>
+#include <triqs/mpi/vector.hpp>
 #include <triqs/arrays/matrix.hpp>
 #include <triqs/arrays/h5.hpp>
 #include <boost/serialization/access.hpp>


### PR DESCRIPTION
Fix for compilation problems with gcc-7. Error message below.

@parcollet  Please confirm

```In file included from /home/nwentzel/Dropbox/Coding/triqs.master.src/build/pytriqs/arrays/block_matrix_wrap.cpp:5:0:                         
/home/nwentzel/Dropbox/Coding/triqs.master.src/triqs/arrays/block_matrix.hpp: In function ‘void triqs::arrays::mpi_broadcast(triqs::arrays::block_matrix<T>&, triqs::mpi::communicator, int)’:
/home/nwentzel/Dropbox/Coding/triqs.master.src/triqs/arrays/block_matrix.hpp:142:40: error: no matching function for call to ‘mpi_broadcast(std::vector<std::__cxx11::basic_string<char> >&, triqs::mpi::communicator&, int&)’
    mpi_broadcast(m.block_names, c, root);                                                                           
                                        ^                                                                                                    
In file included from /home/nwentzel/Dropbox/Coding/triqs.master.src/triqs/utility/././exceptions.hpp:24:0,
                 from /home/nwentzel/Dropbox/Coding/triqs.master.src/triqs/utility/./mini_vector.hpp:25,   
                 from /home/nwentzel/Dropbox/Coding/triqs.master.src/triqs/utility/tuple_tools.hpp:26,                                       
                 from /home/nwentzel/Dropbox/Coding/triqs.master.src/triqs/./clef/./clef.c14.hpp:24,                                         
                 from /home/nwentzel/Dropbox/Coding/triqs.master.src/triqs/./clef/clef.hpp:22,               
                 from /home/nwentzel/Dropbox/Coding/triqs.master.src/triqs/clef.hpp:1,                                                       
                 from /home/nwentzel/Dropbox/Coding/triqs.master.src/triqs/arrays/indexmaps/cuboid/./../../impl/common.hpp:24,               
                 from /home/nwentzel/Dropbox/Coding/triqs.master.src/triqs/arrays/indexmaps/cuboid/./../common.hpp:23,                       
                 from /home/nwentzel/Dropbox/Coding/triqs.master.src/triqs/arrays/indexmaps/cuboid/./domain.hpp:22,
                 from /home/nwentzel/Dropbox/Coding/triqs.master.src/triqs/arrays/indexmaps/cuboid/map.hpp:22,       
                 from /home/nwentzel/Dropbox/Coding/triqs.master.src/triqs/arrays/matrix.hpp:22,                
                 from /home/nwentzel/Dropbox/Coding/triqs.master.src/triqs/arrays/block_matrix.hpp:27,        
                 from /home/nwentzel/Dropbox/Coding/triqs.master.src/build/pytriqs/arrays/block_matrix_wrap.cpp:5:
/home/nwentzel/Dropbox/Coding/triqs.master.src/triqs/utility/././../mpi/base.hpp:171:51: note: candidate: template<class T> std::c14::enable_if_t<triqs::mpi::is_basic<T>::value, void> triqs::mpi::mpi_broadcast(T&, triqs::mpi::communicator, int)
  template <typename T> REQUIRES_IS_BASIC(T, void) mpi_broadcast(T &a, communicator c = {}, int root = 0) {
                                                   ^~~~~~~~~~~~~                                                         
/home/nwentzel/Dropbox/Coding/triqs.master.src/triqs/utility/././../mpi/base.hpp:171:51: note:   template argument deduction/substitution failed:
make[2]: *** [pytriqs/arrays/CMakeFiles/block_matrix.dir/build.make:70: pytriqs/arrays/CMakeFiles/block_matrix.dir/block_matrix_wrap.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:279: pytriqs/arrays/CMakeFiles/block_matrix.dir/all] Error 2                        
make[1]: *** Waiting for unfinished jobs....
```