### PR TITLE
[many_body_operator]

### DIFF
--- a/triqs/operators/many_body_operator.hpp
+++ b/triqs/operators/many_body_operator.hpp
@@ -126,7 +126,7 @@ namespace operators {
 
   struct _cdress; 
   many_body_operator_generic(_cdress const& term) {
-     monomials.insert({term.monomial, term.coef}); 
+   normalize_and_insert(term.monomial, term.coef, monomials); 
   }
 
   template <typename S> many_body_operator_generic& operator=(many_body_operator_generic<S> const& x) {

--- a/triqs/operators/many_body_operator.hpp
+++ b/triqs/operators/many_body_operator.hpp
@@ -124,6 +124,11 @@ namespace operators {
    if (!is_zero(x)) monomials.insert({{}, x});
   }
 
+  struct _cdress; 
+  many_body_operator_generic(_cdress const& term) {
+     monomials.insert({term.monomial, term.coef}); 
+  }
+
   template <typename S> many_body_operator_generic& operator=(many_body_operator_generic<S> const& x) {
    static_assert(std::is_constructible<scalar_t, S>::value, "Assignment is impossible");
    monomials.clear();


### PR DESCRIPTION
Added additional constructor to many_body_operator to allow for e.g.

```c++
many_body_operator h_int;
...
many_body_operator h_dens; 
for (auto const &term : h_int)
    if ( is_density_interaction(term) ) h_dens = h_int_dens + term;
```

@krivenko What do you think?
Maybe add a check if the monomial is ordered correctly?