### PR TITLE
((WIP do not merge)) [CLEF, gfs] clef mutivar test compilation errors

### DIFF
--- a/test/triqs/gfs/multivar/bug_gf_clef.cpp
+++ b/test/triqs/gfs/multivar/bug_gf_clef.cpp
@@ -1,3 +1,5 @@
+
+#include <complex>
 #include <triqs/test_tools/gfs.hpp>
 using namespace triqs::clef;
 using namespace triqs::lattice;
@@ -24,6 +26,130 @@ TEST(Gf, AutoAssignMatrixGf2) {
      EXPECT_CLOSE(g2.data()(10+om, 10 +nu, i, j), i + j + 2 * xom - 0.3 * xnu);
     }
 }
+
+TEST(Gf, AutoAssignImagTime) {
+
+ int ntau = 10;
+ double beta = 2.3;
+ auto g = gf<cartesian_product<imtime, imtime, imtime>, matrix_valued>{{
+     {beta, Fermion, ntau}, {beta, Fermion, ntau}, {beta, Fermion, ntau}}, {1, 1}};
+
+ placeholder_prime<0> t1;
+ placeholder_prime<1> t2;
+ placeholder_prime<3> t3;
+
+ placeholder<4> a;
+ placeholder<5> b;
+
+ g() = 0.0;
+
+ g(t1, t2, t3)(a, b) << a + b + 2*t1 - 0.3*t2 - 10.*t3;
+
+ // CHECK
+ for (auto const &t1 : std::get<0>(g.mesh())) {
+  for (auto const &t2 : std::get<1>(g.mesh())) {
+   for (auto const &t3 : std::get<2>(g.mesh())) {
+    double ref_val = 2*t1 - 0.3*t2 - 10.*t3;
+    double val = g[closest_mesh_pt(t1, t2, t3)](0,0).real();
+    //std::cout << t1 << ", " << t2 << ", " << t3 << ", " << val << " -- " << ref_val << "\n";
+    EXPECT_CLOSE(val, ref_val);
+   }
+  }
+ }
+}
+
+TEST(Gf, AutoAssignAccumulateImagTime) {
+
+ int ntau = 10;
+ double beta = 2.3;
+ auto g = gf<cartesian_product<imtime, imtime, imtime>, matrix_valued>{{
+     {beta, Fermion, ntau}, {beta, Fermion, ntau}, {beta, Fermion, ntau}}, {1, 1}};
+
+ placeholder_prime<0> t1;
+ placeholder_prime<1> t2;
+ placeholder_prime<3> t3;
+
+ placeholder<4> a;
+ placeholder<5> b;
+
+ g() = 0.0;
+
+ // We want to be able to accumulate to a three time gf using:
+ // g << g + a*b, (instead of g += a*b)
+ 
+ // This does not compile
+ g(t1, t2, t3)(a, b) << g(t1, t2, t3)(a, b) + a + b + 2*t1 - 0.3*t2 - 10.*t3;
+
+ // CHECK
+ for (auto const &t1 : std::get<0>(g.mesh())) {
+  for (auto const &t2 : std::get<1>(g.mesh())) {
+   for (auto const &t3 : std::get<2>(g.mesh())) {
+    double ref_val = 2*t1 - 0.3*t2 - 10.*t3;
+    double val = g[closest_mesh_pt(t1, t2, t3)](0,0).real();
+    //std::cout << t1 << ", " << t2 << ", " << t3 << ", " << val << " -- " << ref_val << "\n";
+    EXPECT_CLOSE(val, ref_val);
+   }
+  }
+ }
+}
+
+TEST(Gf, MixedIndexClefImFreq) {
+
+ int nw = 10;
+ double beta = 2.3;
+ auto g = gf<cartesian_product<imfreq, imfreq, imfreq>, matrix_valued>{{
+     {beta, Boson, nw}, {beta, Fermion, nw}, {beta, Fermion, nw}}, {1, 1}};
+
+ placeholder<0> a;
+ placeholder<1> b;
+
+ g() = 0.0;
+
+ placeholder<2> Omega;
+ placeholder<3> n;
+ placeholder<4> np;
+ 
+ g(Omega, n, np)(a, b) << kronecker(n + np, Omega) * (a + b + 2*Omega - 0.2*n);
+ 
+ // CHECK
+ for (auto const &Omega : std::get<0>(g.mesh())) {
+  for (auto const &n : std::get<1>(g.mesh())) {
+   for (auto const &np : std::get<2>(g.mesh())) {
+    std::complex<double> ref_val = 0.0;
+    if(std::abs(std::complex<double>(n + np - Omega)) < 1e-6)
+     ref_val = 2*Omega - 0.2*n;
+    std::complex<double> val = g(Omega, n, np)(0,0);
+    //std::cout << Omega << ", " << n << ", " << np << ", " << val << " -- " << ref_val << "\n";
+    EXPECT_CLOSE(val, ref_val);
+   }
+  }
+ }
+}
+
+TEST(Gf, MixedIndexClefAssignImFreq) {
+
+ int nw = 10;
+ double beta = 2.3;
+ auto g = gf<cartesian_product<imfreq, imfreq, imfreq>, matrix_valued>{{
+     {beta, Boson, nw}, {beta, Fermion, nw}, {beta, Fermion, nw}}, {1, 1}};
+
+ g() = 0.0;
+
+ auto Omega = std::get<0>(g.mesh())[4];
+ auto n = std::get<1>(g.mesh())[5];
+
+ placeholder<0> a;
+ placeholder<1> b;
+
+ g[{Omega, n, Omega - n}](a, b) << a + b + 2*Omega - 0.2*n; // Does not compile
+
+ std::complex<double> ref_val = 2*Omega - 0.2*n;
+ std::complex<double> val = g[{Omega, n, Omega - n}](0,0); // Does not compile
+ 
+ EXPECT_CLOSE(val, ref_val);
+
+}
+
 
 MAKE_MAIN;
 


### PR DESCRIPTION
Dear @parcollet,

Here are extended tests of the multivar clef functionality that currently do not compile. Please use this when developing/debugging.

Best regards,
Hugo

this pull request is related to issue #441 

The offending lines are
```c++
80 + // This does not compile
81 + g(t1, t2, t3)(a, b) << g(t1, t2, t3)(a, b) + a + b + 2*t1 - 0.3*t2 - 10.*t3;
```
and
```c++
144 + g[{Omega, n, Omega - n}](a, b) << a + b + 2*Omega - 0.2*n; // Does not compile
147 + std::complex<double> val = g[{Omega, n, Omega - n}](0,0); // Does not compile
```