### PR TITLE
((WIP do not merge)) [clef] products of matsubara frequencies

### DIFF
--- a/test/triqs/gfs/multivar/bug_gf_clef_arithmetic.cpp
+++ b/test/triqs/gfs/multivar/bug_gf_clef_arithmetic.cpp
@@ -1,0 +1,53 @@
+#include <triqs/test_tools/gfs.hpp>
+using namespace triqs::clef;
+using namespace triqs::lattice;
+
+TEST(Gf, AutoAssignMatrixGf2_product) {
+
+ double beta = 2.3;
+ auto g2 = gf<cartesian_product<imfreq, imfreq>, matrix_valued>{{{beta, Fermion, 10}, {beta, Fermion, 10}}, {2, 2}};
+
+ placeholder<0> i_;
+ placeholder<1> j_;
+ placeholder<3> om_;
+ placeholder<4> nu_;
+
+ g2(om_, nu_)(i_, j_) << i_ + j_ + om_ * nu_;
+
+ // CHECK
+ for (int i = 0; i < 2; ++i)
+  for (int j = 0; j < 2; ++j)
+   for (int om = 0; om < 10; ++om)
+    for (int nu = 0; nu < 10; ++nu) {
+     auto xom = ((2 * om + 1) * M_PI * 1_j / beta);
+     auto xnu = ((2 * nu + 1) * M_PI * 1_j / beta);
+     EXPECT_CLOSE(g2.data()(10+om, 10 +nu, i, j), i + j + xom * xnu);
+    }
+}
+
+TEST(Gf, AutoAssignMatrixGf2_sum_product) {
+
+ double beta = 2.3;
+ auto g2 = gf<cartesian_product<imfreq, imfreq>, matrix_valued>{{{beta, Fermion, 10}, {beta, Fermion, 10}}, {2, 2}};
+
+ placeholder<0> i_;
+ placeholder<1> j_;
+ placeholder<3> om_;
+ placeholder<4> nu_;
+
+ g2(om_, nu_)(i_, j_) << i_ + j_ + om_ * (nu_ + om_);
+
+ // CHECK
+ for (int i = 0; i < 2; ++i)
+  for (int j = 0; j < 2; ++j)
+   for (int om = 0; om < 10; ++om)
+    for (int nu = 0; nu < 10; ++nu) {
+     auto xom = ((2 * om + 1) * M_PI * 1_j / beta);
+     auto xnu = ((2 * nu + 1) * M_PI * 1_j / beta);
+     EXPECT_CLOSE(g2.data()(10+om, 10 +nu, i, j), i + j + xom * (xnu + xom));
+    }
+}
+
+
+MAKE_MAIN;
+


### PR DESCRIPTION
Clef expressions with multiplication of Matsubara frequency placeholders, e.g.

```c++
g2(om_, nu_)(i_, j_) << i_ + j_ + om_ * (nu_ + om_);
```

does not compile, giving the error:

```
/triqs/triqs/./clef/adapters/../clef.hpp:199:35: error: invalid operands to binary
      expression ('const triqs::gfs::mesh_point<gf_mesh<triqs::gfs::imfreq> >' and 'const
      triqs::gfs::mesh_point<gf_mesh<triqs::gfs::imfreq> >')
 TRIQS_CLEF_OPERATION(multiplies, *);
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
```

Here are two tests that attempts to do frequency products using placeholders. @parcollet is this something fixable?

It is useful for e.g. computing the atomic vertex of the Hubbard-atom.

Best, H