### PR TITLE
[mc] measurement & warmup timers

### DIFF
--- a/triqs/utility/timer_chrono.hpp
+++ b/triqs/utility/timer_chrono.hpp
@@ -1,0 +1,54 @@
+
+/*******************************************************************************
+ *
+ * TRIQS: a Toolbox for Research in Interacting Quantum Systems
+ *
+ * Copyright (C) 2017 by Hugo U.R. Strand
+ *
+ * TRIQS is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * TRIQS is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * TRIQS. If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#pragma once
+
+#include <chrono>
+
+namespace triqs {
+  namespace utility {
+
+    class timer {
+      typedef std::chrono::high_resolution_clock clock_t;
+      typedef clock_t::time_point time_point_t;
+      typedef clock_t::duration duration_t;
+
+      time_point_t start_time;
+      duration_t total_time;
+      bool running;
+
+      public:
+      timer() : total_time(0), running(false) {}
+
+      void start() {
+        running    = true;
+        start_time = clock_t::now();
+      }
+      void stop() {
+        total_time += clock_t::now() - start_time;
+        running = false;
+      }
+      operator double() const {
+	std::chrono::duration<double> total_time_seconds(total_time);
+	return total_time_seconds.count(); }
+    };
+  }
+}

--- a/triqs/utility/timestamp.hpp
+++ b/triqs/utility/timestamp.hpp
@@ -1,0 +1,40 @@
+
+/*******************************************************************************
+ *
+ * TRIQS: a Toolbox for Research in Interacting Quantum Systems
+ *
+ * Copyright (C) 2011 by Hugo U.R. Strand
+ *
+ * TRIQS is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * TRIQS is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * TRIQS. If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#pragma once
+
+#include <iomanip>
+#include <chrono>
+#include <sstream>
+
+namespace triqs {
+  namespace utility {
+
+    std::string inline timestamp() {
+      std::ostringstream s;
+      auto now = std::chrono::system_clock::now();
+      std::time_t now_c = std::chrono::system_clock::to_time_t(now);
+      s << std::put_time(std::localtime(&now_c), "%H:%M:%S");
+      return s.str();
+    }
+
+  } // namespace utility
+} // namespace triqs


### PR DESCRIPTION
This is a fix for issue #334 adding two separate timers for warmup and accumulation, and separate timers for the measurements. This is particularly useful for monitoring the two-particle measurements that dominate the accumulation.

I have also added timestamps to the percentage printout.