### PR TITLE
Change NPY_CHAR to NPY_STRING

### DIFF
--- a/triqs/arrays/python/numpy_extractor.hpp
+++ b/triqs/arrays/python/numpy_extractor.hpp
@@ -46,7 +46,7 @@ namespace triqs { namespace arrays { namespace numpy_interface  {
   static const char* name() { return AS_STRING(C); }                                                                              \
  }
   CONVERT(bool, NPY_BOOL);
- CONVERT(char, NPY_CHAR);
+ CONVERT(char, NPY_STRING);
  CONVERT(signed char, NPY_BYTE);
  CONVERT(unsigned char, NPY_UBYTE);
  CONVERT(short, NPY_SHORT);


### PR DESCRIPTION
I recompiled my triqs from master and started seeing a lot of deprecation warnings regarding NPY_CHAR. This small patch fixes it.

NPY_CHAR was deprecated in numpy 1.7 but its complete deprecation started
being enforced in numpy 1.13