### PR TITLE
[optional] Fixes #462

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -232,7 +232,7 @@ endif()
 # #################################
 # Check availability of <optional>
 # #################################
-try_compile(has_optional_header ${CMAKE_BINARY_DIR} ${CMAKE_SOURCE_DIR}/cmake/has_optional.cpp COMPILE_DEFINITIONS -std=c++1y )
+try_compile(has_optional_header ${CMAKE_BINARY_DIR} ${CMAKE_SOURCE_DIR}/cmake/has_optional.cpp COMPILE_DEFINITIONS ${TRIQS_CXX_DEFINITIONS} )
 if (NOT has_optional_header)
  message(STATUS "Using <experimental/optional> header instead of <optional>")
 else ()

--- a/cmake/has_optional.cpp
+++ b/cmake/has_optional.cpp
@@ -1,2 +1,2 @@
 #include <optional>
-int main() { return 0; }
+int main() { std::optional<int> a; return 0; }


### PR DESCRIPTION
Fixes #462
Relates to #401
We have to check for both, the availability of #include <optional> and
the version of c++ (i.e. -std=c++1y vs c++1z)