### PR TITLE
Tailfit complex fix + improvements (unstable)

### DIFF
--- a/pytriqs/gf/gf_fnt_desc.py
+++ b/pytriqs/gf/gf_fnt_desc.py
@@ -78,9 +78,9 @@ m.add_function("gf_view<imfreq, matrix_valued> make_real_in_tau(gf_view<imfreq, 
                doc = "Ensures that the Fourier transform of the Gf, in tau, is real, hence G(-i \omega_n)* =G(i \omega_n)")
 
 # fit_tail
-m.add_function("void fit_tail(gf_view<imfreq, matrix_valued> g, tail_view known_moments, int max_moment, int n_min, int n_max, bool replace_by_fit = true)", 
+m.add_function("void fit_tail(gf_view<imfreq, matrix_valued> g, tail_view known_moments, int max_moment, int n_min, int n_max, bool replace_by_fit = true, double error_omega = 0.0)",
                 doc = """Set the tail by fitting""")
-m.add_function("void fit_tail(gf_view<imfreq, matrix_valued> g, tail_view known_moments, int max_moment, int neg_n_min, int neg_n_max, int pos_n_min, int pos_n_max, bool replace_by_fit = true)", 
+m.add_function("void fit_tail(gf_view<imfreq, matrix_valued> g, tail_view known_moments, int max_moment, int neg_n_min, int neg_n_max, int pos_n_min, int pos_n_max, bool replace_by_fit = true, double error_omega = 0.0)",
                 doc = """Set the tail by fitting""")
   
 # GfImTime specific functions

--- a/pytriqs/gf/tools.py
+++ b/pytriqs/gf/tools.py
@@ -152,7 +152,10 @@ def tail_fit(Sigma_iw,G0_iw=None,G_iw=None,fit_min_n=None,fit_max_n=None,fit_min
     if fit_max_moment is None: fit_max_moment = 3
 
     # Now fit the tails of Sigma_iw and G_iw
-    for name, sig in Sigma_iw: sig.fit_tail(fit_known_moments[name], fit_max_moment, fit_min_n, fit_max_n)
+    try:
+        for name, sig in Sigma_iw: sig.fit_tail(fit_known_moments[name], fit_max_moment, fit_min_n, fit_max_n)
+    except RuntimeError:
+        for name, sig in Sigma_iw: sig.fit_tail(fit_known_moments[name], fit_max_moment, -fit_max_n-1, -fit_min_n-1, fit_min_n, fit_max_n)
     if (G_iw is not None) and (G0_iw is not None):
         for name, g in G_iw: g.tail = inverse( inverse(G0_iw[name].tail) - Sigma_iw[name].tail )
 

--- a/pytriqs/gf/tools.py
+++ b/pytriqs/gf/tools.py
@@ -108,7 +108,7 @@ def dyson(**kwargs):
 
 # Fit tails for Sigma_iw and G_iw.
 # Either give window to fix in terms of matsubara frequencies index (fit_min_n/fit_max_n) or value (fit_min_w/fit_max_w).
-def tail_fit(Sigma_iw,G0_iw=None,G_iw=None,fit_min_n=None,fit_max_n=None,fit_min_w=None,fit_max_w=None,fit_max_moment=None,fit_known_moments=None):
+def tail_fit(Sigma_iw,G0_iw=None,G_iw=None,fit_min_n=None,fit_max_n=None,fit_min_w=None,fit_max_w=None,fit_max_moment=None,fit_known_moments=None,error_omega=0.0):
     """
     Fit the tails of Sigma_iw and optionally G_iw.
 
@@ -153,9 +153,9 @@ def tail_fit(Sigma_iw,G0_iw=None,G_iw=None,fit_min_n=None,fit_max_n=None,fit_min
 
     # Now fit the tails of Sigma_iw and G_iw
     try:
-        for name, sig in Sigma_iw: sig.fit_tail(fit_known_moments[name], fit_max_moment, fit_min_n, fit_max_n)
+        for name, sig in Sigma_iw: sig.fit_tail(fit_known_moments[name], fit_max_moment, fit_min_n, fit_max_n, error_omega=error_omega)
     except RuntimeError:
-        for name, sig in Sigma_iw: sig.fit_tail(fit_known_moments[name], fit_max_moment, -fit_max_n-1, -fit_min_n-1, fit_min_n, fit_max_n)
+        for name, sig in Sigma_iw: sig.fit_tail(fit_known_moments[name], fit_max_moment, -fit_max_n-1, -fit_min_n-1, fit_min_n, fit_max_n, error_omega=error_omega)
     if (G_iw is not None) and (G0_iw is not None):
         for name, g in G_iw: g.tail = inverse( inverse(G0_iw[name].tail) - Sigma_iw[name].tail )
 

--- a/triqs/gfs/singularity/fit_tail.cpp
+++ b/triqs/gfs/singularity/fit_tail.cpp
@@ -98,11 +98,13 @@ namespace triqs { namespace gfs {
   return res; // return tail
  }
 
- __tail<matrix_valued> fit_complex_tail_impl(gf_view<imfreq> gf, __tail_const_view<matrix_valued> known_moments, int max_moment, int n_min, int n_max) {
+ __tail<matrix_valued> fit_complex_tail_impl(gf_view<imfreq> gf, __tail_const_view<matrix_valued> known_moments, int max_moment, int n_min1, int n_max1,int n_min2, int n_max2) {
 
   // precondition : check that n_max is not too large
-  n_max = std::min(n_max, int(gf.mesh().last_index()));
-  n_min = std::max(n_min, int(gf.mesh().first_index()));
+  n_max1 = std::min(n_max1, int(gf.mesh().last_index()));
+  n_max2 = std::min(n_max2, int(gf.mesh().last_index()));
+  n_min1 = std::max(n_min1, int(gf.mesh().first_index()));
+  n_min2 = std::max(n_min2, int(gf.mesh().first_index()));
 
   const int known_moments_omin = known_moments.backwd_omin();
   const int known_moments_omax = known_moments.largest_non_nan() -0;
@@ -116,11 +118,13 @@ namespace triqs { namespace gfs {
   // if known_moments_size==0, the lowest order to be obtained from the fit is determined by order_min() in known_moments
   // if known_moments_size!=0, the lowest order is the one following order_max() in known_moments
   int omin = known_moments_size == 0 ? known_moments_omin : known_moments_omax + 0;
-  int n_freq = n_max - n_min + 1;
-  if (n_freq < 0) TRIQS_RUNTIME_ERROR << "n_max - n_min + 1 <0";
+  int n_freq1 = n_max1 - n_min1 + 1;
+  int n_freq2 = n_max2 - n_min2 + 1;
+  if (n_freq1 < 0) TRIQS_RUNTIME_ERROR << "n_max1 - n_min1 + 1 <0";
+  if (n_freq2 < 0) TRIQS_RUNTIME_ERROR << "n_max2 - n_min2 + 1 <0";
 
-  arrays::matrix<double> A(n_freq, n_unknown_moments, FORTRAN_LAYOUT);
-  arrays::matrix<double> B(n_freq, 1, FORTRAN_LAYOUT);
+  arrays::matrix<double> A(n_freq1+n_freq2, n_unknown_moments, FORTRAN_LAYOUT);
+  arrays::matrix<double> B(n_freq1+n_freq2, 1, FORTRAN_LAYOUT);
   arrays::vector<double> S(n_unknown_moments);
   const double rcond = 0.0;
   int rank;
@@ -131,8 +135,25 @@ namespace triqs { namespace gfs {
 
     // IMAGINARY PART
     // k is a label for the matsubara frequency
-    for (int k = 0; k < n_freq; k++) {
-     auto n = n_min + k;
+    for (int k = 0; k < n_freq1; k++) {
+     auto n = n_min1 + k;
+     auto iw = std::complex<double>(gf.mesh().index_to_point(n));
+
+     // construct data to be fitted - subtract known tail if present
+     B(k, 0) = imag(gf.data()(gf.mesh().index_to_linear(n), i, j));
+     if (known_moments_size > 0)
+      B(k, 0) -= imag(evaluate(slice_target_sing(known_moments, arrays::range(i, i + 1), arrays::range(j, j + 1)), iw)(0, 0));
+
+     // set design matrix
+     // if the order is odd the fit yields the real coefficient of the moment
+     // if the order is even the fit yields the imaginary coefficient of the moment
+     for (int l = 0; l < n_unknown_moments; l++) {
+      int order = omin + l;
+      A(k, l) = imag( (order%2==1 ? 1.0 : dcomplex{0,1})*std::pow(iw, -1.0 * order) );
+     }
+    }
+    for (int k = n_freq1; k < n_freq1+n_freq2; k++) {
+     auto n = n_min2 + k - n_freq1;
      auto iw = std::complex<double>(gf.mesh().index_to_point(n));
 
      // construct data to be fitted - subtract known tail if present
@@ -156,8 +177,26 @@ namespace triqs { namespace gfs {
 
     // REAL PART
     // k is a label for the matsubara frequency
-    for (int k = 0; k < n_freq; k++) {
-     auto n = n_min + k;
+    for (int k = 0; k < n_freq1; k++) {
+     auto n = n_min1 + k;
+     auto iw = std::complex<double>(gf.mesh().index_to_point(n));
+
+     // construct data to be fitted - subtract known tail if present
+     B(k, 0) = real(gf.data()(gf.mesh().index_to_linear(n), i, j));
+     if (known_moments_size > 0)
+      B(k, 0) -= real(evaluate(slice_target_sing(known_moments, arrays::range(i, i + 1), arrays::range(j, j + 1)), iw)(0, 0));
+
+     // set design matrix
+     // if the order is even the fit yields the real coefficient of the moment
+     // if the order is odd the fit yields the imaginary coefficient of the moment
+     for (int l = 0; l < n_unknown_moments; l++) {
+      int order = omin + l;
+      A(k, l) = real( (order%2==0 ? 1.0 : dcomplex{0,1})*std::pow(iw, -1.0 * order) );
+     }
+    }
+
+    for (int k = n_freq1; k < n_freq1+n_freq2; k++) {
+     auto n = n_min2 + k - n_freq1;
      auto iw = std::complex<double>(gf.mesh().index_to_point(n));
 
      // construct data to be fitted - subtract known tail if present
@@ -212,12 +251,11 @@ namespace triqs { namespace gfs {
   if (neg_n_max >= 0) TRIQS_RUNTIME_ERROR << "neg_n_max ("<< neg_n_max <<") must be smaller than 0";
   if (neg_n_min >= neg_n_max) TRIQS_RUNTIME_ERROR << "neg_n_min ("<<neg_n_min <<") must be smaller than neg_n_max ("<<neg_n_max<<")";
 
-  gf.singularity()  = fit_complex_tail_impl(gf, known_moments, max_moment, neg_n_min, neg_n_max);
-  gf.singularity() += fit_complex_tail_impl(gf, known_moments, max_moment, pos_n_min, pos_n_max);
-  gf.singularity() *= 0.5;
+  gf.singularity()  = fit_complex_tail_impl(gf, known_moments, max_moment, neg_n_min, neg_n_max,pos_n_min,pos_n_max);
+
   if (replace_by_fit) { // replace data in the fitting range by the values from the fitted tail
    for (auto iw : gf.mesh()) {
-    if ((iw.n >= neg_n_min and iw.n <= neg_n_max) or (iw.n >= pos_n_min and iw.n <= pos_n_max)) gf[iw] = evaluate(gf.singularity(), iw);
+    if (iw.n <= neg_n_max or iw.n >= pos_n_min) gf[iw] = evaluate(gf.singularity(), iw);
    }
   }
  }
@@ -227,6 +265,13 @@ namespace triqs { namespace gfs {
    // for(auto &gf : block_gf) fit_tail(gf, known_moments, max_moment, n_min, n_max, replace_by_fit);
    for (int i = 0; i < block_gf.size(); i++)
     fit_tail(block_gf[i], known_moments, max_moment, n_min, n_max, replace_by_fit);
+  }
+
+ void fit_tail(block_gf_view<imfreq> block_gf, __tail_view<matrix_valued> known_moments, int max_moment, int neg_n_min,
+               int neg_n_max, int pos_n_min, int pos_n_max, bool replace_by_fit) {
+   // for(auto &gf : block_gf) fit_tail(gf, known_moments, max_moment, n_min, n_max, replace_by_fit);
+   for (int i = 0; i < block_gf.size(); i++)
+    fit_tail(block_gf[i], known_moments, max_moment, neg_n_min, neg_n_max, pos_n_min, pos_n_max, replace_by_fit);
   }
 
   void fit_tail(gf_view<imfreq, scalar_valued> gf, __tail_const_view<scalar_valued> known_moments, int max_moment, int n_min,

--- a/triqs/gfs/singularity/fit_tail.hpp
+++ b/triqs/gfs/singularity/fit_tail.hpp
@@ -55,7 +55,7 @@ namespace triqs { namespace gfs {
 
   @return the tail obtained by fitting
  */
- __tail<matrix_valued> fit_complex_tail_impl(gf_view<imfreq> gf, __tail_const_view<matrix_valued> known_moments, int max_moment, int n_min, int n_max) ;
+ __tail<matrix_valued> fit_complex_tail_impl(gf_view<imfreq> gf, __tail_const_view<matrix_valued> known_moments, int max_moment, int n_min1, int n_max1,int n_min2, int n_max2) ;
 
  ///Fit the tail of a real (in tau) gf
  /**

--- a/triqs/gfs/singularity/fit_tail.hpp
+++ b/triqs/gfs/singularity/fit_tail.hpp
@@ -39,7 +39,7 @@ namespace triqs { namespace gfs {
 
   @return the tail obtained by fitting
  */
- __tail<matrix_valued> fit_real_tail_impl(gf_view<imfreq> gf, __tail_const_view<matrix_valued> known_moments, int max_moment, int n_min, int n_max) ;
+ __tail<matrix_valued> fit_real_tail_impl(gf_view<imfreq> gf, __tail_const_view<matrix_valued> known_moments, int max_moment, int n_min, int n_max, double error_omega = 0.0) ;
 
  /// routine for fitting the tail (singularity) of a complex Matsubara Green's function
  /**
@@ -55,7 +55,7 @@ namespace triqs { namespace gfs {
 
   @return the tail obtained by fitting
  */
- __tail<matrix_valued> fit_complex_tail_impl(gf_view<imfreq> gf, __tail_const_view<matrix_valued> known_moments, int max_moment, int n_min1, int n_max1,int n_min2, int n_max2) ;
+ __tail<matrix_valued> fit_complex_tail_impl(gf_view<imfreq> gf, __tail_const_view<matrix_valued> known_moments, int max_moment, int n_min1, int n_max1,int n_min2, int n_max2, double error_omega = 0.0) ;
 
  ///Fit the tail of a real (in tau) gf
  /**
@@ -68,7 +68,7 @@ namespace triqs { namespace gfs {
   @note Based on [[fit_tail_impl]]. Works for functions with positive only or all Matsubara frequencies.
  */
  void fit_tail(gf_view<imfreq> gf, __tail_const_view<matrix_valued> known_moments, int max_moment, int n_min, int n_max,
-   bool replace_by_fit = false) ;
+   bool replace_by_fit = false, double error_omega = 0.0) ;
 
  ///Fit the tail of a complex (in tau) gf
  /**
@@ -83,7 +83,7 @@ namespace triqs { namespace gfs {
   @note Based on [[fit_tail_impl]]. Works for functions with positive only or all Matsubara frequencies.
  */
  void fit_tail(gf_view<imfreq> gf, __tail_const_view<matrix_valued> known_moments, int max_moment, int neg_n_min, int neg_n_max,
-   int pos_n_min, int pos_n_max, bool replace_by_fit = false);
+   int pos_n_min, int pos_n_max, bool replace_by_fit = false, double error_omega = 0.0);
 
  ///Fit the tail of a block_gf
  /**
@@ -105,7 +105,7 @@ namespace triqs { namespace gfs {
   @note Based on [[fit_tail_impl]]
  */
  void fit_tail(block_gf_view<imfreq> block_gf, __tail_const_view<matrix_valued> known_moments, int max_moment, int n_min,
-   int n_max, bool replace_by_fit = false) ;
+   int n_max, bool replace_by_fit = false, double error_omega = 0.0) ;
 
  ///Fit the tail of a gf (scalar-valued)
  /**
@@ -126,10 +126,10 @@ namespace triqs { namespace gfs {
         -if n_min<0 (and n_max<0), replace all frequencies w_n <= w_n{n_max}
   @note Based on [[fit_tail_impl]]
  */
- void fit_tail(gf_view<imfreq, scalar_valued> gf, __tail_const_view<scalar_valued> known_moments, int max_moment, int n_min, int n_max, bool replace_by_fit = false) ;
- void fit_tail(gf_view<imfreq, scalar_valued> gf, __tail_const_view<scalar_valued> known_moments, int max_moment, int neg_n_min, int neg_n_max,int pos_n_min, int pos_n_max, bool replace_by_fit = false) ;
+ void fit_tail(gf_view<imfreq, scalar_valued> gf, __tail_const_view<scalar_valued> known_moments, int max_moment, int n_min, int n_max, bool replace_by_fit = false, double error_omega = 0.0) ;
+ void fit_tail(gf_view<imfreq, scalar_valued> gf, __tail_const_view<scalar_valued> known_moments, int max_moment, int neg_n_min, int neg_n_max,int pos_n_min, int pos_n_max, bool replace_by_fit = false, double error_omega = 0.0) ;
 
  ///fit tail of tensor_valued Gf, rank 3
- array<__tail<scalar_valued>, 3> fit_tail(gf_const_view<imfreq, tensor_valued<3>> g, array_const_view<__tail<scalar_valued>,3> known_moments, int max_moment, int n_min, int n_max);
+ array<__tail<scalar_valued>, 3> fit_tail(gf_const_view<imfreq, tensor_valued<3>> g, array_const_view<__tail<scalar_valued>,3> known_moments, int max_moment, int n_min, int n_max, double error_omega = 0.0);
 
 }} // namespace


### PR DESCRIPTION
- This fixes a bug in the tail fitting routines for complex Green's function objects. In that case, two windows have to be given (already now), one for positive and one for negative Matsubara frequencies. Currently, the fit coefficients of the two windows are averaged, which is incorrect and leads to physically wrong tail fits. In this fix, the two windows are fitted in one go.
- Typically, the error of the self-energy roughly goes like omega_n^2, however during the fitting a constant error is assumed. This pull request introduces a parameter `omega_error` that is the exponent of the Matsubara frequency-dependence of the error; setting `omega_error=2` gives the quadratic behavior mentioned. The default is `omega_error = 0`, i.e. the current behavior with constant error.