### PR TITLE
Tailfit complex fix + improvements (master)

### DIFF
--- a/pytriqs/gf/local/gf_desc.py
+++ b/pytriqs/gf/local/gf_desc.py
@@ -454,13 +454,13 @@ for py_type, has_tail in [("GfImFreq", True) ,("GfImFreqNoTail",False)]:
               doc = """Fills self with the legendre transform of gl""")
 
   g.add_method(name = "fit_tail",
-              signature = "void(tail_view known_moments, int max_moment, int n_min, int n_max, bool replace_by_fit = true)",
-              calling_pattern = "fit_tail(self_c, *known_moments, max_moment, n_min, n_max, replace_by_fit)",
+              signature = "void(tail_view known_moments, int max_moment, int n_min, int n_max, bool replace_by_fit = true, double error_omega = 0.0)",
+              calling_pattern = "fit_tail(self_c, *known_moments, max_moment, n_min, n_max, replace_by_fit, error_omega)",
               doc = """Set the tail by fitting""")
 
   g.add_method(name = "fit_tail",
-              signature = "void(tail_view known_moments, int max_moment, int neg_n_min, int neg_n_max, int pos_n_min, int pos_n_max, bool replace_by_fit = true)",
-              calling_pattern = "fit_tail(self_c, *known_moments, max_moment, neg_n_min, neg_n_max, pos_n_min, pos_n_max, replace_by_fit)",
+              signature = "void(tail_view known_moments, int max_moment, int neg_n_min, int neg_n_max, int pos_n_min, int pos_n_max, bool replace_by_fit = true, double error_omega = 0.0)",
+              calling_pattern = "fit_tail(self_c, *known_moments, max_moment, neg_n_min, neg_n_max, pos_n_min, pos_n_max, replace_by_fit, error_omega)",
               doc = """Set the tail by fitting""")
 
 # Pure python methods

--- a/pytriqs/gf/local/tools.py
+++ b/pytriqs/gf/local/tools.py
@@ -92,7 +92,7 @@ def dyson(**kwargs):
 
 # Fit tails for Sigma_iw and G_iw.
 # Either give window to fix in terms of matsubara frequencies index (fit_min_n/fit_max_n) or value (fit_min_w/fit_max_w).
-def tail_fit(Sigma_iw,G0_iw=None,G_iw=None,fit_min_n=None,fit_max_n=None,fit_min_w=None,fit_max_w=None,fit_max_moment=None,fit_known_moments=None):
+def tail_fit(Sigma_iw,G0_iw=None,G_iw=None,fit_min_n=None,fit_max_n=None,fit_min_w=None,fit_max_w=None,fit_max_moment=None,fit_known_moments=None,error_omega=0.0):
     """
     Fit the tails of Sigma_iw and optionally G_iw.
 
@@ -137,9 +137,9 @@ def tail_fit(Sigma_iw,G0_iw=None,G_iw=None,fit_min_n=None,fit_max_n=None,fit_min
 
     # Now fit the tails of Sigma_iw and G_iw
     try:
-        for name, sig in Sigma_iw: sig.fit_tail(fit_known_moments[name], fit_max_moment, fit_min_n, fit_max_n)
+        for name, sig in Sigma_iw: sig.fit_tail(fit_known_moments[name], fit_max_moment, fit_min_n, fit_max_n, error_omega=error_omega)
     except RuntimeError:
-        for name, sig in Sigma_iw: sig.fit_tail(fit_known_moments[name], fit_max_moment, -fit_max_n-1, -fit_min_n-1, fit_min_n, fit_max_n)
+        for name, sig in Sigma_iw: sig.fit_tail(fit_known_moments[name], fit_max_moment, -fit_max_n-1, -fit_min_n-1, fit_min_n, fit_max_n, error_omega=error_omega)
     if (G_iw is not None) and (G0_iw is not None):
         for name, g in G_iw: g.tail = inverse( inverse(G0_iw[name].tail) - Sigma_iw[name].tail )
 

--- a/pytriqs/gf/local/tools.py
+++ b/pytriqs/gf/local/tools.py
@@ -136,7 +136,10 @@ def tail_fit(Sigma_iw,G0_iw=None,G_iw=None,fit_min_n=None,fit_max_n=None,fit_min
     if fit_max_moment is None: fit_max_moment = 3
 
     # Now fit the tails of Sigma_iw and G_iw
-    for name, sig in Sigma_iw: sig.fit_tail(fit_known_moments[name], fit_max_moment, fit_min_n, fit_max_n)
+    try:
+        for name, sig in Sigma_iw: sig.fit_tail(fit_known_moments[name], fit_max_moment, fit_min_n, fit_max_n)
+    except RuntimeError:
+        for name, sig in Sigma_iw: sig.fit_tail(fit_known_moments[name], fit_max_moment, -fit_max_n-1, -fit_min_n-1, fit_min_n, fit_max_n)
     if (G_iw is not None) and (G0_iw is not None):
         for name, g in G_iw: g.tail = inverse( inverse(G0_iw[name].tail) - Sigma_iw[name].tail )
 

--- a/triqs/gfs/singularity/fit_tail.hpp
+++ b/triqs/gfs/singularity/fit_tail.hpp
@@ -39,7 +39,7 @@ namespace triqs { namespace gfs {
 
   @return the tail obtained by fitting
  */
- tail fit_real_tail_impl(gf_view<imfreq> gf, const tail_view known_moments, int max_moment, int n_min, int n_max) ;
+ tail fit_real_tail_impl(gf_view<imfreq> gf, const tail_view known_moments, int max_moment, int n_min, int n_max, double error_omega = 0.0) ;
 
  /// routine for fitting the tail (singularity) of a complex Matsubara Green's function
  /**
@@ -55,7 +55,7 @@ namespace triqs { namespace gfs {
 
   @return the tail obtained by fitting
  */
- tail fit_complex_tail_impl(gf_view<imfreq> gf, const tail_view known_moments, int max_moment, int n_min1, int n_max1,int n_min2, int n_max2) ;
+ tail fit_complex_tail_impl(gf_view<imfreq> gf, const tail_view known_moments, int max_moment, int n_min1, int n_max1,int n_min2, int n_max2, double error_omega = 0.0) ;
 
  ///Fit the tail of a real (in tau) gf
  /**
@@ -68,7 +68,7 @@ namespace triqs { namespace gfs {
   @note Based on [[fit_tail_impl]]. Works for functions with positive only or all Matsubara frequencies.
  */
  void fit_tail(gf_view<imfreq> gf, tail_view known_moments, int max_moment, int n_min, int n_max,
-   bool replace_by_fit = false) ;
+   bool replace_by_fit = false, double error_omega = 0.0) ;
 
  ///Fit the tail of a complex (in tau) gf
  /**
@@ -83,7 +83,7 @@ namespace triqs { namespace gfs {
   @note Based on [[fit_tail_impl]]. Works for functions with positive only or all Matsubara frequencies.
  */
  void fit_tail(gf_view<imfreq> gf, tail_view known_moments, int max_moment, int neg_n_min, int neg_n_max,
-   int pos_n_min, int pos_n_max, bool replace_by_fit = false);
+   int pos_n_min, int pos_n_max, bool replace_by_fit = false, double error_omega = 0.0);
 
  ///Fit the tail of a block_gf
  /**
@@ -105,7 +105,7 @@ namespace triqs { namespace gfs {
   @note Based on [[fit_tail_impl]]
  */
  void fit_tail(gf_view<block_index, gf<imfreq>> block_gf, tail_view known_moments, int max_moment, int n_min,
-   int n_max, bool replace_by_fit = false) ;
+   int n_max, bool replace_by_fit = false, double error_omega = 0.0) ;
 
  ///Fit the tail of a gf (scalar-valued)
  /**
@@ -126,12 +126,12 @@ namespace triqs { namespace gfs {
         -if n_min<0 (and n_max<0), replace all frequencies w_n <= w_n{n_max}
   @note Based on [[fit_tail_impl]]
  */
- void fit_tail(gf_view<imfreq, scalar_valued> gf, tail_view known_moments, int max_moment, int n_min, int n_max, bool replace_by_fit = false) ;
- void fit_tail(gf_view<imfreq, scalar_valued> gf, tail_view known_moments, int max_moment, int neg_n_min, int neg_n_max,int pos_n_min, int pos_n_max, bool replace_by_fit = false) ;
+ void fit_tail(gf_view<imfreq, scalar_valued> gf, tail_view known_moments, int max_moment, int n_min, int n_max, bool replace_by_fit = false, double error_omega = 0.0) ;
+ void fit_tail(gf_view<imfreq, scalar_valued> gf, tail_view known_moments, int max_moment, int neg_n_min, int neg_n_max,int pos_n_min, int pos_n_max, bool replace_by_fit = false, double error_omega = 0.0) ;
 
  ///fit tail of tensor_valued Gf, rank 3
  template<typename S>
- array<triqs::gfs::tail, 3> fit_tail(gf_const_view<imfreq, tensor_valued<3>,S> g, array_const_view<triqs::gfs::tail,3> known_moments, int max_moment, int n_min, int n_max){
+ array<triqs::gfs::tail, 3> fit_tail(gf_const_view<imfreq, tensor_valued<3>,S> g, array_const_view<triqs::gfs::tail,3> known_moments, int max_moment, int n_min, int n_max, double error_omega = 0.0){
 
   gf<imfreq, scalar_valued> g_scal(g.mesh());
   array<triqs::gfs::tail, 3> tail(known_moments.shape());
@@ -139,7 +139,7 @@ namespace triqs { namespace gfs {
    for(int v=0;v<known_moments.shape()[1];v++) 
     for(int w=0;w<known_moments.shape()[2];w++) {
      for(auto const & om : g_scal.mesh()) g_scal[om] = g[om](u,v,w);
-     fit_tail(g_scal,known_moments(u,v,w), max_moment, n_min, n_max);
+     fit_tail(g_scal,known_moments(u,v,w), max_moment, n_min, n_max, error_omega);
      tail(u,v,w) = g_scal.singularity();
     }
   return tail;

--- a/triqs/gfs/singularity/fit_tail.hpp
+++ b/triqs/gfs/singularity/fit_tail.hpp
@@ -55,7 +55,7 @@ namespace triqs { namespace gfs {
 
   @return the tail obtained by fitting
  */
- tail fit_complex_tail_impl(gf_view<imfreq> gf, const tail_view known_moments, int max_moment, int n_min, int n_max) ;
+ tail fit_complex_tail_impl(gf_view<imfreq> gf, const tail_view known_moments, int max_moment, int n_min1, int n_max1,int n_min2, int n_max2) ;
 
  ///Fit the tail of a real (in tau) gf
  /**


### PR DESCRIPTION
Qualitatively, this is the same pull request as #481 but based on the master branch.

- This fixes a bug in the tail fitting routines for complex Green's function objects. In that case, two windows have to be given (already now), one for positive and one for negative Matsubara frequencies. Currently, the fit coefficients of the two windows are averaged, which is incorrect and leads to physically wrong tail fits. In this fix, the two windows are fitted in one go.
- Typically, the error of the self-energy roughly goes like omega_n^2, however during the fitting a constant error is assumed. This introduces a parameter `omega_error` that is the exponent of the Matsubara frequency-dependence of the error; setting `omega_error=2` gives the quadratic behavior mentioned. The default is `omega_error = 0`, i.e. the current behavior with constant error.