### PR TITLE
[gf,many_body_operator] Small fixes and additions

### DIFF
--- a/triqs/gfs/block/block_gf.hxx
+++ b/triqs/gfs/block/block_gf.hxx
@@ -25,8 +25,8 @@
 namespace triqs {
   namespace gfs {
 
-    using triqs::utility::factory;
     using triqs::mpi::mpi_reduce;
+    using triqs::utility::factory;
 
     /*----------------------------------------------------------
    *   Declaration of main types : gf, gf_view, gf_const_view
@@ -112,6 +112,9 @@ namespace triqs {
       using mutable_view_type = block_gf_view<Var, Target>;
       using view_type         = block_gf_view<Var, Target>;
       using const_view_type   = block_gf_const_view<Var, Target>;
+
+      /// The associated real type
+      using real_t = block_gf<Var, typename Target::real_t>;
 
       using g_t           = gf<Var, Target>;
       using data_t        = std::vector<g_t>;
@@ -479,6 +482,9 @@ namespace triqs {
       using view_type         = block_gf_view<Var, Target>;
       using const_view_type   = block_gf_const_view<Var, Target>;
 
+      /// The associated real type
+      using real_t = block_gf_view<Var, typename Target::real_t>;
+
       using g_t           = gf_view<Var, Target>;
       using data_t        = std::vector<g_t>;
       using block_names_t = std::vector<std::string>;
@@ -579,7 +585,7 @@ namespace triqs {
         if (l.rhs.size() != this->size())
           TRIQS_RUNTIME_ERROR << "mpi reduction of block_gf : size of RHS is incompatible with the size of the view to be assigned to";
         _block_names = l.rhs.block_names();
-        for (int i = 0; i < size(); ++i) _glist[i]= mpi_reduce(l.rhs.data()[i], l.c, l.root, l.all, l.op);
+        for (int i = 0; i < size(); ++i) _glist[i] = mpi_reduce(l.rhs.data()[i], l.c, l.root, l.all, l.op);
         // here we need to enumerate the vector, the mpi_reduce produce a vector<gf>, NOT a gf_view,
         // we can not overload the = of vector for better API.
       }
@@ -837,6 +843,9 @@ namespace triqs {
       using mutable_view_type = block_gf_view<Var, Target>;
       using view_type         = block_gf_const_view<Var, Target>;
       using const_view_type   = block_gf_const_view<Var, Target>;
+
+      /// The associated real type
+      using real_t = block_gf_const_view<Var, typename Target::real_t>;
 
       using g_t           = gf_const_view<Var, Target>;
       using data_t        = std::vector<g_t>;
@@ -1146,6 +1155,9 @@ namespace triqs {
       using mutable_view_type = block2_gf_view<Var, Target>;
       using view_type         = block2_gf_view<Var, Target>;
       using const_view_type   = block2_gf_const_view<Var, Target>;
+
+      /// The associated real type
+      using real_t = block2_gf<Var, typename Target::real_t>;
 
       using g_t           = gf<Var, Target>;
       using data_t        = std::vector<std::vector<g_t>>;
@@ -1490,6 +1502,9 @@ namespace triqs {
       using mutable_view_type = block2_gf_view<Var, Target>;
       using view_type         = block2_gf_view<Var, Target>;
       using const_view_type   = block2_gf_const_view<Var, Target>;
+
+      /// The associated real type
+      using real_t = block2_gf_view<Var, typename Target::real_t>;
 
       using g_t           = gf_view<Var, Target>;
       using data_t        = std::vector<std::vector<g_t>>;
@@ -1842,6 +1857,9 @@ namespace triqs {
       using mutable_view_type = block2_gf_view<Var, Target>;
       using view_type         = block2_gf_const_view<Var, Target>;
       using const_view_type   = block2_gf_const_view<Var, Target>;
+
+      /// The associated real type
+      using real_t = block2_gf_const_view<Var, typename Target::real_t>;
 
       using g_t           = gf_const_view<Var, Target>;
       using data_t        = std::vector<std::vector<g_t>>;

--- a/triqs/gfs/block/block_gf.mako.hpp
+++ b/triqs/gfs/block/block_gf.mako.hpp
@@ -127,6 +127,9 @@ namespace triqs {
    using view_type         = MAKO_GV<Var, Target>;
    using const_view_type   = MAKO_ROOT_const_view<Var, Target>;
 
+   /// The associated real type
+   using real_t = MAKO_GF<Var, typename Target::real_t>;
+
    using g_t = gfMAKO_EXT<Var, Target>;
    // mako %if ARITY == 1 :
    using data_t        = std::vector<g_t>;

--- a/triqs/gfs/functions/functions2.hpp
+++ b/triqs/gfs/functions/functions2.hpp
@@ -112,7 +112,7 @@ namespace gfs {
    @param tolerance tolerance threshold
    @return true iif the function g is real up to tolerance
    */
- template <typename G> bool is_gf_real(G const &g, double tolerance = 1.e-13) {
+ template <typename G> std::enable_if_t<is_gf<G>::value, bool> is_gf_real(G const &g, double tolerance = 1.e-13) {
   return max_element(abs(imag(g.data()))) <= tolerance;
  }
 

--- a/triqs/gfs/gf/gf.hxx
+++ b/triqs/gfs/gf/gf.hxx
@@ -102,6 +102,9 @@ namespace triqs {
       /// The associated regular type (gf<....>)
       using regular_type = gf<Var, Target>;
 
+      /// The associated real type
+      using real_t = gf<Var, typename Target::real_t>;
+
       using variable_t = Var;
       using target_t   = Target;
 
@@ -204,7 +207,8 @@ namespace triqs {
         r()    = 0;
         return r;
       }
-      static zero_t __make_zero(scalar_valued, data_t const &d) { return 0; } // special case
+      static zero_t __make_zero(scalar_valued, data_t const &d) { return 0; }      // special case
+      static zero_t __make_zero(scalar_real_valued, data_t const &d) { return 0; } // special case
       static zero_t _make_zero(data_t const &d) { return __make_zero(Target{}, d); }
       zero_t _remake_zero() { return _zero = _make_zero(_data); } // NOT in constructor...
 
@@ -320,7 +324,7 @@ namespace triqs {
         for (auto const &w : _mesh) (*this)[w] = rhs[w];
         _singularity = rhs.singularity();
         _indices     = rhs.indices();
-        if (_indices.empty()) _indices= indices_t(target_shape());
+        if (_indices.empty()) _indices = indices_t(target_shape());
         //if (not _indices.has_shape(target_shape())) _indices = indices_t(target_shape());
         // to be implemented : there is none in the gf_expr in particular....
         return *this;
@@ -666,7 +670,7 @@ namespace triqs {
       void operator=(mpi_lazy<mpi::tag::scatter, gf_const_view<Var, Target>> l) {
         _mesh = mpi_scatter(l.rhs.mesh(), l.c, l.root);
         _data = mpi_scatter(l.rhs.data(), l.c, l.root, true);
-        if (l.c.rank() == l.root) _singularity= l.rhs.singularity();
+        if (l.c.rank() == l.root) _singularity = l.rhs.singularity();
         mpi_broadcast(_singularity, l.c, l.root);
       }
 
@@ -677,7 +681,7 @@ namespace triqs {
       void operator=(mpi_lazy<mpi::tag::gather, gf_const_view<Var, Target>> l) {
         _mesh = mpi_gather(l.rhs.mesh(), l.c, l.root);
         _data = mpi_gather(l.rhs.data(), l.c, l.root, l.all);
-        if (l.all || (l.c.rank() == l.root)) _singularity= l.rhs.singularity();
+        if (l.all || (l.c.rank() == l.root)) _singularity = l.rhs.singularity();
       }
     };
 
@@ -701,6 +705,9 @@ namespace triqs {
 
       /// The associated regular type (gf<....>)
       using regular_type = gf<Var, Target>;
+
+      /// The associated real type
+      using real_t = gf_view<Var, typename Target::real_t>;
 
       using variable_t = Var;
       using target_t   = Target;
@@ -804,7 +811,8 @@ namespace triqs {
         r()    = 0;
         return r;
       }
-      static zero_t __make_zero(scalar_valued, data_t const &d) { return 0; } // special case
+      static zero_t __make_zero(scalar_valued, data_t const &d) { return 0; }      // special case
+      static zero_t __make_zero(scalar_real_valued, data_t const &d) { return 0; } // special case
       static zero_t _make_zero(data_t const &d) { return __make_zero(Target{}, d); }
       zero_t _remake_zero() { return _zero = _make_zero(_data); } // NOT in constructor...
 
@@ -1238,7 +1246,7 @@ namespace triqs {
       void operator=(mpi_lazy<mpi::tag::scatter, gf_const_view<Var, Target>> l) {
         _mesh = mpi_scatter(l.rhs.mesh(), l.c, l.root);
         _data = mpi_scatter(l.rhs.data(), l.c, l.root, true);
-        if (l.c.rank() == l.root) _singularity= l.rhs.singularity();
+        if (l.c.rank() == l.root) _singularity = l.rhs.singularity();
         mpi_broadcast(_singularity, l.c, l.root);
       }
 
@@ -1249,7 +1257,7 @@ namespace triqs {
       void operator=(mpi_lazy<mpi::tag::gather, gf_const_view<Var, Target>> l) {
         _mesh = mpi_gather(l.rhs.mesh(), l.c, l.root);
         _data = mpi_gather(l.rhs.data(), l.c, l.root, l.all);
-        if (l.all || (l.c.rank() == l.root)) _singularity= l.rhs.singularity();
+        if (l.all || (l.c.rank() == l.root)) _singularity = l.rhs.singularity();
       }
     };
 
@@ -1273,6 +1281,9 @@ namespace triqs {
 
       /// The associated regular type (gf<....>)
       using regular_type = gf<Var, Target>;
+
+      /// The associated real type
+      using real_t = gf_const_view<Var, typename Target::real_t>;
 
       using variable_t = Var;
       using target_t   = Target;
@@ -1376,7 +1387,8 @@ namespace triqs {
         r()    = 0;
         return r;
       }
-      static zero_t __make_zero(scalar_valued, data_t const &d) { return 0; } // special case
+      static zero_t __make_zero(scalar_valued, data_t const &d) { return 0; }      // special case
+      static zero_t __make_zero(scalar_real_valued, data_t const &d) { return 0; } // special case
       static zero_t _make_zero(data_t const &d) { return __make_zero(Target{}, d); }
       zero_t _remake_zero() { return _zero = _make_zero(_data); } // NOT in constructor...
 

--- a/triqs/gfs/gf/gf.mako.hpp
+++ b/triqs/gfs/gf/gf.mako.hpp
@@ -213,6 +213,7 @@ namespace triqs {
     return r;
    }
    static zero_t __make_zero(scalar_valued, data_t const &d) { return 0; } // special case
+   static zero_t __make_zero(scalar_real_valued, data_t const &d) { return 0; } // special case
    static zero_t _make_zero(data_t const &d) { return __make_zero(Target{}, d); }
    zero_t _remake_zero() { return _zero = _make_zero(_data); } // NOT in constructor...
 

--- a/triqs/gfs/gf/gf.mako.hpp
+++ b/triqs/gfs/gf/gf.mako.hpp
@@ -111,6 +111,9 @@ namespace triqs {
    /// The associated regular type (gf<....>)
    using regular_type = gf<Var, Target>;
 
+   /// The associated real type
+   using real_t = MAKO_GF<Var, typename Target::real_t>;
+
    using variable_t = Var;
    using target_t   = Target;
 

--- a/triqs/gfs/gf/targets.hpp
+++ b/triqs/gfs/gf/targets.hpp
@@ -33,6 +33,7 @@ namespace gfs {
   using scalar_t = double;
   using slice_t = arrays::array<scalar_t, rank>;
   // using value_type = std14::conditional_t<(R!=0), arrays::array<dcomplex, R>, double > ;
+  using real_t = tensor_real_valued<R>;
  };
 
  template <int R> struct tensor_valued {
@@ -51,6 +52,7 @@ namespace gfs {
   using scalar_t = double;
   using slice_t = arrays::matrix<scalar_t>;
   // using value_type = arrays::<double>;
+  using real_t = matrix_real_valued;
  };
 
  struct matrix_valued {
@@ -67,6 +69,7 @@ namespace gfs {
   static constexpr bool is_matrix = false;
   using scalar_t = double;
   using slice_t = scalar_t;
+  using real_t = scalar_real_valued;
  };
 
  struct scalar_valued {
@@ -84,6 +87,7 @@ namespace gfs {
   using scalar_t = dcomplex;
   // using slice_t = scalar_t;
   // using value_type = typename T::value_type;
+  using real_t = tail_valued<typename T::real_t>; 
  };
 
  template<typename T> struct is_tail_valued: std::false_type{};

--- a/triqs/operators/many_body_operator.hpp
+++ b/triqs/operators/many_body_operator.hpp
@@ -383,7 +383,7 @@ namespace operators {
  // Assert that two many-body-operators are term-wise close
  template<typename scalar1_t, typename scalar2_t>
  void assert_operators_are_close(many_body_operator_generic<scalar1_t> const &op1, many_body_operator_generic<scalar2_t> const &op2, double precision){ 
-  auto terms_are_equal = [precision]( auto const &t1, auto const &t2 ){ using std::abs; return (t1.monomial == t2.monomial) && abs(t1.coef - t2.coef) < precision; }; 
+  auto terms_are_equal = [precision]( auto const &t1, auto const &t2 ){ return (t1.monomial == t2.monomial) && triqs::utility::is_zero(t1.coef - t2.coef, precision); }; 
   if(op1.get_monomials().size() != op2.get_monomials().size())
     TRIQS_RUNTIME_ERROR << " ASSERTION FAILED: Operators have different number of terms"; 
   if(!std::equal(op1.begin(), op1.end(), op2.begin(), terms_are_equal))

--- a/triqs/operators/many_body_operator.hpp
+++ b/triqs/operators/many_body_operator.hpp
@@ -23,6 +23,7 @@
 
 #include <ostream>
 #include <cmath>
+#include <algorithm>
 #include <boost/operators.hpp>
 #include <triqs/utility/real_or_complex.hpp>
 #include <triqs/utility/numeric_ops.hpp>
@@ -180,11 +181,6 @@ namespace operators {
 
   // Is zero operator ?
   bool is_zero() const { return monomials.empty(); }
-
-  // Check if two many-body-operators are term-wise equal
-  friend bool operator==(many_body_operator_generic const & lhs, many_body_operator_generic const & rhs){ 
-   return lhs.get_monomials() == rhs.get_monomials(); 
-  }
 
   // Algebraic operations involving scalar_t constants
   many_body_operator_generic operator-() const {
@@ -383,6 +379,16 @@ namespace operators {
    return os;
   }
  };
+
+ // Assert that two many-body-operators are term-wise close
+ template<typename scalar1_t, typename scalar2_t>
+ void assert_operators_are_close(many_body_operator_generic<scalar1_t> const &op1, many_body_operator_generic<scalar2_t> const &op2, double precision){ 
+  auto terms_are_equal = [precision]( auto const &t1, auto const &t2 ){ using std::abs; return (t1.monomial == t2.monomial) && abs(t1.coef - t2.coef) < precision; }; 
+  if(op1.get_monomials().size() != op2.get_monomials().size())
+    TRIQS_RUNTIME_ERROR << " ASSERTION FAILED: Operators have different number of terms"; 
+  if(!std::equal(op1.begin(), op1.end(), op2.begin(), terms_are_equal))
+    TRIQS_RUNTIME_ERROR << " ASSERTION FAILED: Operators have different terms"; 
+ }
 
  // ---- factories --------------
 

--- a/triqs/operators/many_body_operator.hpp
+++ b/triqs/operators/many_body_operator.hpp
@@ -181,6 +181,11 @@ namespace operators {
   // Is zero operator ?
   bool is_zero() const { return monomials.empty(); }
 
+  // Check if two many-body-operators are term-wise equal
+  friend bool operator==(many_body_operator_generic const & lhs, many_body_operator_generic const & rhs){ 
+   return lhs.get_monomials() == rhs.get_monomials(); 
+  }
+
   // Algebraic operations involving scalar_t constants
   many_body_operator_generic operator-() const {
    auto res = *this;
@@ -315,7 +320,7 @@ namespace operators {
 
   private:
   // Normalize a monomial and insert into a map
-  static void normalize_and_insert(monomial_t& m, scalar_t coeff, monomials_map_t& target) {
+  static void normalize_and_insert(monomial_t m, scalar_t coeff, monomials_map_t& target) {
    // The normalization is done by employing a simple bubble sort algorithms.
    // Apart from sorting elements this function keeps track of the sign and
    // recursively calls itself if a permutation of two operators produces a new
@@ -351,7 +356,7 @@ namespace operators {
    // Insert the result
    bool is_new_monomial;
    typename monomials_map_t::iterator it;
-   std::tie(it, is_new_monomial) = target.insert(std::make_pair(m, coeff));
+   std::tie(it, is_new_monomial) = target.insert(std::make_pair(std::move(m), coeff));
    if (!is_new_monomial) {
     it->second += coeff;
     erase_zero_monomial(target, it);

--- a/triqs/operators/many_body_operator.hpp
+++ b/triqs/operators/many_body_operator.hpp
@@ -383,7 +383,7 @@ namespace operators {
  // Assert that two many-body-operators are term-wise close
  template<typename scalar1_t, typename scalar2_t>
  void assert_operators_are_close(many_body_operator_generic<scalar1_t> const &op1, many_body_operator_generic<scalar2_t> const &op2, double precision){ 
-  auto terms_are_equal = [precision]( auto const &t1, auto const &t2 ){ return (t1.monomial == t2.monomial) && triqs::utility::is_zero(t1.coef - t2.coef, precision); }; 
+  auto terms_are_equal = [precision]( auto const &t1, auto const &t2 ){ using triqs::utility::is_zero; return (t1.monomial == t2.monomial) && is_zero(t1.coef - t2.coef, precision); }; 
   if(op1.get_monomials().size() != op2.get_monomials().size())
     TRIQS_RUNTIME_ERROR << " ASSERTION FAILED: Operators have different number of terms"; 
   if(!std::equal(op1.begin(), op1.end(), op2.begin(), terms_are_equal))

--- a/triqs/test_tools/many_body_operator.hpp
+++ b/triqs/test_tools/many_body_operator.hpp
@@ -1,0 +1,15 @@
+#pragma once
+#include <triqs/operators/many_body_operator.hpp>
+
+// Test that two operators are term-wise equal up to a precision
+template<typename X, typename Y>
+::testing::AssertionResult test_operators_are_close(X const &x, Y const &y, double precision = 1e-6) {
+ try {
+  assert_operators_are_close(x,y, precision);
+  return ::testing::AssertionSuccess();
+ } catch (triqs::exception const & msg) {
+  return ::testing::AssertionFailure() << msg.what();
+ }
+}
+
+#define EXPECT_OPERATOR_NEAR(X, ...) EXPECT_TRUE(test_operators_are_close(X,__VA_ARGS__))

--- a/triqs/test_tools/many_body_operator.hpp
+++ b/triqs/test_tools/many_body_operator.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "./arrays.hpp"
 #include <triqs/operators/many_body_operator.hpp>
 
 // Test that two operators are term-wise equal up to a precision

--- a/triqs/utility/numeric_ops.hpp
+++ b/triqs/utility/numeric_ops.hpp
@@ -35,7 +35,7 @@ namespace utility {
 // Zero value tests
 //
 template<typename T> // Integral types
-std14::enable_if_t<std::is_integral<T>::value,bool> is_zero(T const& x) {
+std14::enable_if_t<std::is_integral<T>::value,bool> is_zero(T const& x, T = 0) {
  return x==0;
 }
 
@@ -44,9 +44,9 @@ std14::enable_if_t<std::is_floating_point<T>::value,bool> is_zero(T const& x, T 
  return std::abs(x) < tolerance;
 }
 
-template<typename T> // std::complex
-std14::enable_if_t<triqs::is_complex<T>::value,bool> is_zero(T const& x) {
- return is_zero(std::real(x)) && is_zero(std::imag(x));
+template<typename value_t> // std::complex
+bool is_zero(std::complex<value_t> const& x, value_t tolerance = 100*std::numeric_limits<value_t>::epsilon()) {
+ return is_zero(std::real(x), tolerance) && is_zero(std::imag(x), tolerance);
 }
 
 //

--- a/triqs/utility/numeric_ops.hpp
+++ b/triqs/utility/numeric_ops.hpp
@@ -35,7 +35,7 @@ namespace utility {
 // Zero value tests
 //
 template<typename T> // Integral types
-std14::enable_if_t<std::is_integral<T>::value,bool> is_zero(T const& x, T = 0) {
+std14::enable_if_t<std::is_integral<T>::value,bool> is_zero(T const& x) {
  return x==0;
 }
 

--- a/triqs/utility/real_or_complex.hpp
+++ b/triqs/utility/real_or_complex.hpp
@@ -57,10 +57,10 @@ namespace utility {
   friend double abs(real_or_complex const& x) { return std::abs(x._x); }
   friend real_or_complex conj(real_or_complex x) { x._x = std::conj(x._x); return x; }
 
-  friend bool is_zero(real_or_complex const& x) {
-   using utility::is_zero;
-   if (x.is_real()) return is_zero(double(x));
-   return is_zero(x._x);
+  friend bool is_zero(real_or_complex const& x, double tolerance = 100*std::numeric_limits<double>::epsilon()) {
+   using triqs::utility::is_zero;
+   if (x.is_real()) return is_zero(double(x), tolerance);
+   return is_zero(x._x, tolerance);
   }
 
   friend std::ostream& operator<<(std::ostream& out, real_or_complex const& x) {


### PR DESCRIPTION
**[gf,block_gf]** Added type real_t to gfs and all target types
    -gf, block_gf, block2_gf now have an interal real_t that corresponds to
    the real version of the Green function type    
    -made the is_gf_real function slightly more restrictive
    -The different target types that can be used for a gf now all have an
    internal real type
    -**BugFix**: __make_zero( .. ) in gf needs special behaviour also for scalar_real_valued

**[many_body_operator]** Small fix and operator==
    -added == operator for many_body_operator_generic
    -normalize_and_insert should take monomial by copy
