### PR TITLE
[brillouin_zone, gf_mesh] Changes relevant for a generic fourier impl

### DIFF
--- a/triqs/lattice/brillouin_zone.hpp
+++ b/triqs/lattice/brillouin_zone.hpp
@@ -39,6 +39,9 @@ namespace lattice {
 
   /// Access to the underlying bravais lattice
   bravais_lattice lattice() const { return lattice_; }
+
+  /// Allow cast to bravais lattice
+  operator bravais_lattice() const { return lattice_; }
   
   ///return reciprocal matrix: lines are cartesian coordinates of each reciprocal unit vectors
   arrays::matrix_view<double> units() const { return K_reciprocal; }

--- a/triqs/lattice/gf_mesh_cyclic_lattice.hpp
+++ b/triqs/lattice/gf_mesh_cyclic_lattice.hpp
@@ -44,8 +44,10 @@ namespace gfs {
      : bl(bl_), cluster_mesh{bl_.units(), periodization_matrix_ } {}
 
   ///backward compatibility (also serves as default const.)
-  gf_mesh(int L1=1, int L2=1, int L3=1): bl(make_unit_matrix<double>(3)), cluster_mesh(make_unit_matrix<double>(3), matrix<int>({{L1, 0, 0},{0, L2, 0},{0, 0, L3}})){
-  }
+  gf_mesh(int L1=1, int L2=1, int L3=1): bl{make_unit_matrix<double>(3)}, cluster_mesh{make_unit_matrix<double>(3), matrix<int>({{L1, 0, 0},{0, L2, 0},{0, 0, L3}})}{}
+
+  ///Construct gf_mesh<cyclic_lattice> from domain (bravais_lattice) and int L (linear size of Cluster mesh)
+  gf_mesh(bravais_lattice const& bl_, int L): bl(bl_), cluster_mesh{make_unit_matrix<double>(3), L * make_unit_matrix<int>(3)} {}
 
   using domain_t = bravais_lattice;
   domain_t const& domain() const { return bl; }


### PR DESCRIPTION
-Construct gf_mesh<cyclic_lattice> from domain and linear cluster mesh size
-Allow cast of brillouin_zone to bravais_lattice

These changes unify the interface of the gf_mesh and allow for a generic
fourier implementation that works for imfreq, imtime, cyclic_lattice,
brillouin_zone