### PR TITLE
[gf] fix pytriqs g.N1, g.N2 usage

### DIFF
--- a/pytriqs/gf/block_gf.py
+++ b/pytriqs/gf/block_gf.py
@@ -110,7 +110,7 @@ class BlockGf(object):
         """Copy the Green's function from G2: G2 MUST have the same structure!"""
         assert isinstance(G2, BlockGf)
         for (i,g),(i2,g2) in itertools.izip(self,G2): 
-           if  (g.N1,g.N2) != (g2.N1,g2.N2): 
+           if  (g.target_shape[0],g.target_shape[1]) != (g2.target_shape[0],g2.target_shape[1]): 
                raise RuntimeError, "Blocks %s and %s of the Green Function do have the same dimension"%(i1,i2) 
         for (i,g),(i2,g2) in itertools.izip(self,G2): g.copy_from(g2)
 

--- a/pytriqs/gf/tools.py
+++ b/pytriqs/gf/tools.py
@@ -144,7 +144,7 @@ def tail_fit(Sigma_iw,G0_iw=None,G_iw=None,fit_min_n=None,fit_max_n=None,fit_min
 
     # Define default tail quantities
     if fit_known_moments is None:
-        fit_known_moments = {name:TailGf(sig.N1,sig.N2,0,0) for name, sig in Sigma_iw}
+        fit_known_moments = {name:TailGf(sig.target_shape[0],sig.target_shape[1],0,0) for name, sig in Sigma_iw}
     if fit_min_w is not None: fit_min_n = int(0.5*(fit_min_w*Sigma_iw.mesh.beta/np.pi - 1.0))
     if fit_max_w is not None: fit_max_n = int(0.5*(fit_max_w*Sigma_iw.mesh.beta/np.pi - 1.0))
     if fit_min_n is None: fit_min_n = int(0.8*len(Sigma_iw.mesh)/2)
@@ -209,7 +209,7 @@ def write_gf_to_txt(g):
         mesh = np.array(list(g.mesh)).imag.reshape(-1,1)
     else:
         raise ValueError, 'write_gf_to_txt: Only GfReFreq and GfImFreq quantities are supported.'
-    for i,j in product(range(g.N1),range(g.N2)):
+    for i,j in product(range(g.target_shape[0]),range(g.target_shape[1])):
         txtfile = '%s_%s_%s.dat'%(g.name,i,j)
         redata = g.data[:,i,j].real.reshape((g.data.shape[0],-1))
         imdata = g.data[:,i,j].imag.reshape((g.data.shape[0],-1))

--- a/pytriqs/sumk/sumk_discrete.py
+++ b/pytriqs/sumk/sumk_discrete.py
@@ -127,9 +127,9 @@ class SumkDiscrete:
 
         # check input
         assert self.orthogonal_basis, "Local_G: must be orthogonal. non ortho cases not checked."
-        assert len(list(set([g.N1 for i,g in G]))) == 1
+        assert len(list(set([g.target_shape[0] for i,g in G]))) == 1
         assert self.bz_weights.shape[0] == self.n_kpts(), "Internal Error"
-        no = list(set([g.N1 for i,g in G]))[0]
+        no = list(set([g.target_shape[0] for i,g in G]))[0]
 
         # Initialize
         G.zero()


### PR DESCRIPTION
Some cleaning of the `sumk` and `tail_fit` from `g.N1` and `g.N2` usage, now replaced with `g.target_shape[]`.

Please merge.