### PR TITLE
Install modulefile for the module command

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -279,3 +279,9 @@ MESSAGE(STATUS "*   source ${CMAKE_INSTALL_PREFIX}/share/triqsvars.sh          "
 MESSAGE(STATUS "*                                                              ") 
 MESSAGE(STATUS "*   to set up the environment variables                        ") 
 MESSAGE(STATUS "***************************************************************")
+
+#--------------------------------------------------------
+# Process and install modulefile
+#--------------------------------------------------------
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/triqs.modulefile.in ${CMAKE_CURRENT_BINARY_DIR}/triqs.modulefile @ONLY)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/triqs.modulefile DESTINATION ${CMAKE_INSTALL_PREFIX}/share)

--- a/triqs.modulefile.in
+++ b/triqs.modulefile.in
@@ -1,4 +1,6 @@
 #%Module1.0
+#
+# To be installed as ${MODULEPATH}/triqs/@TRIQS_VERSION@
 
 set     name        triqs
 set     version     @TRIQS_VERSION@
@@ -17,6 +19,10 @@ proc ModulesHelp { } {
     puts stderr "Version:     $version"
     puts stderr "Git hash:    $git_hash"
 }
+
+# You may need to edit the next line if cpp2py module is installed
+# under a different name in your setup.
+prereq cpp2py/@CPP2PY_VERSION@
 
 # Only one version of triqs can be loaded at a time
 conflict $name

--- a/triqs.modulefile.in
+++ b/triqs.modulefile.in
@@ -1,0 +1,33 @@
+#%Module1.0
+
+set     name        triqs
+set     version     @TRIQS_VERSION@
+set     root        @CMAKE_INSTALL_PREFIX@
+set     git_hash    @TRIQS_GIT_HASH@
+
+set     url         "https://triqs.ipht.cnrs.fr/$version/index.html"
+set     description "Toolbox for Research on Interacting Quantum Systems"
+
+module-whatis   "$description"
+
+proc ModulesHelp { } {
+    global description url version git_hash
+    puts stderr "Description: $description"
+    puts stderr "URL:         $url"
+    puts stderr "Version:     $version"
+    puts stderr "Git hash:    $git_hash"
+}
+
+# Only one version of triqs can be loaded at a time
+conflict $name
+
+setenv          TRIQS_ROOT          $root
+setenv          TRIQS_VERSION       $version
+setenv          TRIQS_GIT_HASH      $git_hash
+
+prepend-path    PATH                $root/bin
+prepend-path    CPATH               $root/include
+prepend-path    LIBRARY_PATH        $root/lib
+prepend-path    LD_LIBRARY_PATH     $root/lib
+prepend-path    PYTHONPATH          $root/@CPP2PY_PYTHON_LIB_DEST_ROOT@
+prepend-path    CMAKE_PREFIX_PATH   $root/share/cmake


### PR DESCRIPTION
Install a TCL modulefile similar to `triqsvars.sh`. It can be used for easy integration with the module systems on HPC machines.

*N.B.* Now that applications are allowed to be installed under different prefixes, they could provide their own modulefiles.