### PR TITLE
[pade] Fix a problem that arises for large n_points

### DIFF
--- a/triqs/utility/pade_approximants.hpp
+++ b/triqs/utility/pade_approximants.hpp
@@ -108,8 +108,8 @@ class pade_approximant {
    for(int i=0; i<=N-2; ++i){
      dcomplex Anew = A2 + (e - z_in(i))*a(i+1)*A1;
      dcomplex Bnew = B2 + (e - z_in(i))*a(i+1)*B1;
-     A1 = A2; A2 = Anew;
-     B1 = B2; B2 = Bnew;
+     A1 = A2/Bnew; A2 = Anew/Bnew;
+     B1 = B2/Bnew; B2 = 1.0;
    }
 
    return A2/B2;


### PR DESCRIPTION
The present Pade code returns NaN when number of Matsubara is large. This pull request fixes this problem. What is changed is that variables A1, A2, B1, B2 are normalized in every step of the iteration so that those do not overflow. It avoids NaN and keeps the ratio A2/B2 (final result).

You can reproduce the above problem using the sample code in
https://triqs.ipht.cnrs.fr/1.x/reference/gfs/py/block/GfReFreq.html
Increase L from 101 to, e.g. 1001, and you will obtain NaN if you print g_pade.data.
In the fixed version, you can obtain correct results for arbitrary number of L.

Best,
Junya Otsuki