### PR TITLE
Add basic jenkins support with ubuntu build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,6 +11,7 @@ pipeline {
           agent {
             dockerfile {
               dir "packaging/ubuntu"
+              args '-v /etc/passwd:/etc/passwd -v /etc/group:/etc/group'
             }
           }
           steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,30 @@
+pipeline {
+  agent none
+  options {
+    disableConcurrentBuilds()
+    timeout(time: 1, unit: 'HOURS')
+  }
+  stages {
+    stage('build') {
+      parallel {
+        stage('ubuntu') {
+          agent {
+            dockerfile {
+              dir "packaging/ubuntu"
+            }
+          }
+          steps {
+            sh '''#!/bin/bash -ex
+              source $INSTALL/share/cpp2pyvars.sh
+              mkdir -p build
+              cd build
+              cmake .. -DCMAKE_INSTALL_PREFIX=$INSTALL
+              make
+              make test
+            '''
+          }
+        }
+      }
+    }
+  }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,6 +25,24 @@ pipeline {
             '''
           }
         }
+        stage('centos') {
+          agent {
+            dockerfile {
+              dir "packaging/centos"
+              args '-v /etc/passwd:/etc/passwd -v /etc/group:/etc/group'
+            }
+          }
+          steps {
+            sh '''#!/bin/bash -ex
+              source $INSTALL/share/cpp2pyvars.sh
+              mkdir -p build
+              cd build
+              cmake .. -DCMAKE_INSTALL_PREFIX=$INSTALL
+              make
+              make test
+            '''
+          }
+        }
       }
     }
   }

--- a/packaging/centos/Dockerfile
+++ b/packaging/centos/Dockerfile
@@ -1,0 +1,38 @@
+FROM centos:7
+
+RUN yum -y install centos-release-scl epel-release && yum -y update
+RUN yum -y install \
+      blas-devel \
+      boost-devel \
+      cmake \
+      devtoolset-7-gcc-c++ \
+      fftw-devel \
+      gcc-c++ \
+      gcc-gfortran \
+      git \
+      gmp-devel \
+      h5py \
+      hdf5-devel \
+      lapack-devel \
+      lapack-devel \
+      make \
+      mpi4py-openmpi \
+      numpy \
+      openmpi-devel \
+      python-devel \
+      python-jinja2 \
+      python-mako \
+      python-matplotlib \
+      python-tornado \
+      python-virtualenv \
+      python-zmq \
+      scipy
+
+ENV PATH=/opt/rh/devtoolset-7/root/usr/bin:${PATH}:/usr/lib64/openmpi/bin
+
+ENV SRC=/work/src BUILD=/work/build INSTALL=/work/install
+
+# cpp2py
+RUN git clone https://github.com/TRIQS/cpp2py ${SRC}/cpp2py
+WORKDIR ${BUILD}/cpp2py
+RUN cmake ${SRC}/cpp2py -DCMAKE_INSTALL_PREFIX=${INSTALL} && make && make install

--- a/packaging/centos/Dockerfile
+++ b/packaging/centos/Dockerfile
@@ -28,7 +28,7 @@ RUN yum -y install \
       python-zmq \
       scipy
 
-ENV PATH=/opt/rh/devtoolset-7/root/usr/bin:${PATH}:/usr/lib64/openmpi/bin
+ENV PATH=/opt/rh/devtoolset-7/root/usr/bin:${PATH}:/usr/lib64/openmpi/bin PYTHONPATH=/usr/lib64/python2.7/site-packages/openmpi
 
 ENV SRC=/work/src BUILD=/work/build INSTALL=/work/install
 

--- a/packaging/ubuntu/Dockerfile
+++ b/packaging/ubuntu/Dockerfile
@@ -1,0 +1,54 @@
+FROM ubuntu:xenial
+# TODO: move RELEASE ARG above FROM -- requires newer docker
+ARG RELEASE=xenial
+
+RUN apt-get update && apt-get install -y \
+      cmake \
+      g++ \
+      gfortran \
+      git \
+      hdf5-tools \
+      libblas-dev \
+      libboost-all-dev \
+      libfftw3-dev \
+      libgfortran3 \
+      libgmp-dev \
+      libhdf5-serial-dev \
+      liblapack-dev \
+      libopenmpi-dev \
+      openmpi-bin \
+      openmpi-common \
+      openmpi-doc \
+      python-dev \
+      python-h5py \
+      python-jinja2 \
+      python-mako \
+      python-matplotlib \
+      python-mpi4py \
+      python-numpy \
+      python-scipy \
+      python-tornado \
+      python-virtualenv \
+      python-zmq \
+      software-properties-common
+
+RUN add-apt-repository ppa:ubuntu-toolchain-r/test
+RUN apt-get update && apt-get install -y \
+  g++-7
+ENV CC=gcc-7 CXX=g++-7
+
+ARG CLANG=5.0
+RUN add-apt-repository "deb http://apt.llvm.org/${RELEASE}/ llvm-toolchain-${RELEASE}-${CLANG} main" -y
+RUN apt-key adv --fetch-keys http://apt.llvm.org/llvm-snapshot.gpg.key
+RUN apt-get update && apt-get install -y \
+      clang-${CLANG} \
+      libclang-${CLANG}-dev \
+      python-clang-${CLANG}
+ENV CC=clang-${CLANG} CXX=clang++-${CLANG}
+
+ENV SRC=/work/src BUILD=/work/build INSTALL=/work/install
+
+# cpp2py
+RUN git clone https://github.com/TRIQS/cpp2py ${SRC}/cpp2py
+WORKDIR ${BUILD}/cpp2py
+RUN cmake ${SRC}/cpp2py -DCMAKE_INSTALL_PREFIX=${INSTALL} && make && make install


### PR DESCRIPTION
This is just a simple jenkins build of triqs on ubuntu xenial to start with.

Currently the build is successful, but there are a few failing tests -- not sure if these are expected (perhaps because not running under mpi):
```
[ubuntu] 95% tests passed, 11 tests failed out of 210
[ubuntu] 
[ubuntu] Total Test time (real) =  40.26 sec
[ubuntu] 
[ubuntu] The following tests FAILED:
[ubuntu] 	 25 - ising2d (Failed)
[ubuntu] 	 29 - mpi_vector_np2 (Failed)
[ubuntu] 	 30 - mpi_vector_np3 (Failed)
[ubuntu] 	 31 - mpi_vector_np4 (Failed)
[ubuntu] 	 33 - mpi_gf_np2 (Failed)
[ubuntu] 	 34 - mpi_gf_np3 (Failed)
[ubuntu] 	 35 - mpi_gf_np4 (Failed)
[ubuntu] 	 37 - mpi_array_np2 (Failed)
[ubuntu] 	 38 - mpi_array_np3 (Failed)
[ubuntu] 	 39 - mpi_array_np4 (Failed)
[ubuntu] 	 40 - comm_split_np4 (Failed)
```

From [flatiron internal jenkins](https://jenkins.flatironinstitute.org/job/TRIQS/job/triqs/job/jenkins/).