### PR TITLE
[gf] Extending block/block2 gf functionality: real, map, ..

### DIFF
--- a/test/triqs/gfs/functions/real.cpp
+++ b/test/triqs/gfs/functions/real.cpp
@@ -1,0 +1,55 @@
+#include <triqs/gfs.hpp>
+#include <triqs/test_tools/gfs.hpp>
+using namespace triqs::gfs;
+using namespace std::complex_literals;
+
+TEST(Functions, RealGf) {
+
+  double beta  = 1;
+  int n_iw     = 100;
+  auto iw_mesh = gf_mesh<imfreq>{beta, Fermion, n_iw};
+  auto shape   = make_shape(1, 1, 1);
+
+  // -- Build Green functions
+
+  auto g_iw    = gf<imfreq, tensor_valued<3>>{iw_mesh, shape};
+  auto giw_vec = std::vector{g_iw, g_iw};
+
+  placeholder<0> iw_;
+  giw_vec[0](iw_) << 1.0 / (iw_ + 1.0 + 1i);
+  giw_vec[1](iw_) << 2.0 / (iw_ - 1.0 + 1i);
+
+  auto block_giw = make_block_gf({"one", "two"}, giw_vec);
+
+  auto giw_vecvec = std::vector{giw_vec, giw_vec};
+  auto block2_giw = make_block2_gf({"one", "two"}, {"one", "two"}, giw_vecvec);
+
+  // -- Build the real Block Green function
+
+  std::vector<gf<imfreq, tensor_real_valued<3>>> giw_real_vec;
+  for (auto const &bl : block_giw) giw_real_vec.emplace_back(real(bl));
+
+  auto block_giw_real = make_block_gf({"one", "two"}, giw_real_vec);
+
+  // -- Build the real Block2 Green function
+
+  auto giw_real_vecvec = std::vector{giw_real_vec, giw_real_vec};
+  auto block2_giw_real = make_block2_gf({"one", "two"}, {"one", "two"}, giw_real_vecvec);
+
+  // -- Asserts
+
+  EXPECT_BLOCK_GF_NEAR(block_giw_real, real(block_giw));
+  EXPECT_BLOCK2_GF_NEAR(block2_giw_real, real(block2_giw));
+
+  EXPECT_TRUE(!is_gf_real_in_tau(block_giw[0]));
+  EXPECT_TRUE(!is_gf_real_in_tau(block_giw[1]));
+  EXPECT_TRUE(!is_gf_real_in_tau(block_giw));
+  EXPECT_TRUE(!is_gf_real_in_tau(block2_giw));
+
+  EXPECT_TRUE(is_gf_real_in_tau(make_real_in_tau(block_giw[0])));
+  EXPECT_TRUE(is_gf_real_in_tau(make_real_in_tau(block_giw[1])));
+  EXPECT_TRUE(is_gf_real_in_tau(make_real_in_tau(block_giw)));
+  EXPECT_TRUE(is_gf_real_in_tau(make_real_in_tau(block2_giw)));
+}
+
+MAKE_MAIN;

--- a/triqs/gfs/block/block_gf.hxx
+++ b/triqs/gfs/block/block_gf.hxx
@@ -2227,6 +2227,13 @@ namespace triqs {
     make_block2_gf_view(std::vector<std::string> block_names1, std::vector<std::string> block_names2, std::vector<std::vector<GF>> v) {
       return {{std::move(block_names1), std::move(block_names2)}, std::move(v)};
     }
+
+    // from block_names and data vector
+    template <typename GF>
+    block2_gf_const_view<typename GF::variable_t, typename GF::target_t>
+    make_block2_gf_const_view(std::vector<std::string> block_names1, std::vector<std::string> block_names2, std::vector<std::vector<GF>> v) {
+      return {{std::move(block_names1), std::move(block_names2)}, std::move(v)};
+    }
   } // namespace gfs
 } // namespace triqs
 

--- a/triqs/gfs/block/block_gf.mako.hpp
+++ b/triqs/gfs/block/block_gf.mako.hpp
@@ -727,6 +727,14 @@ namespace triqs {
                                                                                      std::vector<std::vector<GF>> v) {
    return {{std::move(block_names1), std::move(block_names2)}, std::move(v)};
   }
+
+  // from block_names and data vector
+  template <typename GF>
+  block2_gf_const_view<typename GF::variable_t, typename GF::target_t> make_block2_gf_const_view(std::vector<std::string> block_names1,
+                                                                                     		 std::vector<std::string> block_names2,
+                                                                                     		 std::vector<std::vector<GF>> v) {
+   return {{std::move(block_names1), std::move(block_names2)}, std::move(v)};
+  }
  }
 }
 

--- a/triqs/gfs/block/map.hpp
+++ b/triqs/gfs/block/map.hpp
@@ -74,18 +74,30 @@ namespace gfs {
 
   // now , when R is a gf, gf_view, a gf_const_view
   template <typename F, typename G, typename... T> struct map<F, G, gf<T...>> {
-   static auto invoke(F &&f, G &&g)
-       {return make_block_gf(g.block_names(), _map(std::forward<F>(f), std::forward<G>(g).data()));}
+   static auto invoke(F &&f, G &&g){
+    if constexpr (std::remove_reference_t<G>::arity == 1)
+     return make_block_gf(g.block_names(), _map(std::forward<F>(f), std::forward<G>(g).data()));
+    else
+     return make_block2_gf(g.block_names()[0], g.block_names()[1], _map(std::forward<F>(f), std::forward<G>(g).data()));
+   }
   };
 
   template <typename F, typename G, typename... T> struct map<F, G, gf_view<T...>> {
-   static auto invoke(F &&f, G &&g)
-       {return make_block_gf_view(g.block_names(), _map(std::forward<F>(f), std::forward<G>(g).data()));}
+   static auto invoke(F &&f, G &&g){
+    if constexpr (std::remove_reference_t<G>::arity == 1)
+     return make_block_gf_view(g.block_names(), _map(std::forward<F>(f), std::forward<G>(g).data()));
+    else
+     return make_block2_gf_view(g.block_names()[0], g.block_names()[1], _map(std::forward<F>(f), std::forward<G>(g).data()));
+   }
   };
 
   template <typename F, typename G, typename... T> struct map<F, G, gf_const_view<T...>> {
-   static auto invoke(F &&f, G &&g)
-       {return make_block_gf_const_view(g.block_names(), _map(std::forward<F>(f), std::forward<G>(g).data()));}
+   static auto invoke(F &&f, G &&g){ 
+    if constexpr (std::remove_reference_t<G>::arity == 1)
+     return make_block_gf_const_view(g.block_names(), _map(std::forward<F>(f), std::forward<G>(g).data()));
+    else
+     return make_block2_gf_const_view(g.block_names()[0], g.block_names()[1], _map(std::forward<F>(f), std::forward<G>(g).data()));
+   }
   };
  }
 


### PR DESCRIPTION
-Enabling map_block_gf for block2_gf
-FIX real(Gf) now unsets the tail and keeps indices
-Adding real(block_gf), real(block2_gf) + test
-Add is_gf_real(block_gf), is_gf_real(block2_gf) + test
-Add is_gf_real_in_tau(block_gf), is_gf_real_in_tau(block2_gf) + test
-Add make_gf_real_in_tau(block_gf), make_gf_real_in_tau(block2_gf) + test

@parcollet Please review and merge. In particular check the adjustments in real(Gf) regarding
tail and indices!