### PR TITLE
[gf/tail] Bugfix: NAN propagation in tail

### DIFF
--- a/triqs/gfs/singularity/tail.hxx
+++ b/triqs/gfs/singularity/tail.hxx
@@ -1170,7 +1170,11 @@ namespace triqs {
         // hence p <= min ( a.n_max, n-b.n_min ) and p >= max ( a.n_min, n- b.n_max)
         const int pmin = std::max(l.order_min(), n - r.order_max());
         const int pmax = std::min(l.order_max(), n - r.order_min());
-        for (int p = pmin; p <= pmax; ++p) { res(n) += l(p) * r(n - p); }
+        for (int p = pmin; p <= pmax; ++p) {
+          // Propagate NAN only if other component is non-zero
+          if (max_element(abs(l(p))) < 1e-15 || max_element(abs(r(n - p))) < 1e-15) continue;
+          res(n) += l(p) * r(n - p);
+        }
       }
       return res;
     }

--- a/triqs/gfs/singularity/tail.mako.hpp
+++ b/triqs/gfs/singularity/tail.mako.hpp
@@ -724,7 +724,11 @@ namespace gfs {
    // hence p <= min ( a.n_max, n-b.n_min ) and p >= max ( a.n_min, n- b.n_max)
    const int pmin = std::max(l.order_min(), n - r.order_max());
    const int pmax = std::min(l.order_max(), n - r.order_min());
-   for (int p = pmin; p <= pmax; ++p) { res(n) += l(p) * r(n - p); }
+   for (int p = pmin; p <= pmax; ++p) { 
+     // Propagate NAN only if other component is non-zero
+     if( max_element(abs(l(p))) < 1e-15 || max_element(abs(r(n-p))) < 1e-15 ) continue; 
+     res(n) += l(p) * r(n - p); 
+   }
   }
   return res;
  }


### PR DESCRIPTION
To get proper results from tail (and GF) multiplication, NAN from the first
operand should not propagate if the component of second operand vanishes!

@parcollet Please review and merge!
