### PR TITLE
[tail] Fixing __tail.reset, Complex Fitting in one go

### DIFF
--- a/pytriqs/gf/backwd_compat/gf_imfreq.py
+++ b/pytriqs/gf/backwd_compat/gf_imfreq.py
@@ -74,7 +74,7 @@ class GfImFreq(Gf) :
                       data = data, 
                       target_shape = target_shape,
                       singularity = tail or singularity,
-                      _singularity_maker = make_singularity_maker(8,tail, singularity),
+                      _singularity_maker = make_singularity_maker(tail, singularity),
                       indices = indices, 
                       name = name) 
 

--- a/pytriqs/gf/backwd_compat/gf_imtime.py
+++ b/pytriqs/gf/backwd_compat/gf_imtime.py
@@ -74,7 +74,7 @@ class GfImTime(Gf) :
                       data = data, 
                       target_shape = target_shape,
                       singularity = tail or singularity,
-                      _singularity_maker = make_singularity_maker(8, tail, singularity),
+                      _singularity_maker = make_singularity_maker(tail, singularity),
                       indices = indices, 
                       name = name) 
         delegate(self, **kw)

--- a/pytriqs/gf/backwd_compat/gf_refreq.py
+++ b/pytriqs/gf/backwd_compat/gf_refreq.py
@@ -73,7 +73,7 @@ class GfReFreq(Gf) :
                       data = data, 
                       target_shape = target_shape,
                       singularity = tail or singularity,
-                      _singularity_maker =make_singularity_maker(10, tail, singularity), 
+                      _singularity_maker =make_singularity_maker(tail, singularity), 
                       indices = indices, 
                       name = name) 
         delegate(self, **kw)

--- a/pytriqs/gf/backwd_compat/gf_retime.py
+++ b/pytriqs/gf/backwd_compat/gf_retime.py
@@ -74,7 +74,7 @@ class GfReTime(Gf) :
                       data = data, 
                       target_shape = target_shape,
                       singularity = tail or singularity,
-                      _singularity_maker = make_singularity_maker(10, tail, singularity),
+                      _singularity_maker = make_singularity_maker(tail, singularity),
                       indices = indices, 
                       name = name) 
         delegate(self, **kw)

--- a/pytriqs/gf/backwd_compat/tool_gfloc.py
+++ b/pytriqs/gf/backwd_compat/tool_gfloc.py
@@ -1,7 +1,12 @@
 from pytriqs.gf.singularities import TailGf_s, TailGf, TailGfTv3, TailGfTv4
 
-def make_singularity_maker(n_order, tail, singularity):
+def make_singularity_maker(tail, singularity):
     tail_type= [TailGf_s, None, TailGf, TailGfTv3, TailGfTv4] # None -> replace with vector valued ?
-    return (lambda se : tail_type[len(se.target_shape)](target_shape = se.target_shape, n_order=n_order, order_min = -2)) if not (tail or singularity) else None
-
+    def f(se):
+      if not (tail or singularity):
+        t = tail_type[len(se.target_shape)](target_shape = se.target_shape)
+      else:
+        t = None
+      return t
+    return f
 

--- a/pytriqs/gf/descriptor_base.py
+++ b/pytriqs/gf/descriptor_base.py
@@ -108,7 +108,7 @@ class Const(Base):
             C = C*numpy.identity(G.target_shape[0]) 
         if C.shape != (G.target_shape[0],G.target_shape[1]): raise RuntimeError, "Size of constant incorrect"
 
-        G.tail.reset(12)
+        G.tail.zero()
         G.tail[0][:,:] = C
         
         Function(lambda om: C, None)(G)
@@ -124,7 +124,7 @@ class Omega_(Base):
             raise TypeError, "This initializer is only correct in frequency"
 
         Id = numpy.identity(G.target_shape[0])
-        G.tail.reset(10)
+        G.tail.zero()
         G.tail[-1][:,:] = Id
         
         for n,om in enumerate(G.mesh): G.data[n,:,:] = om*Id

--- a/pytriqs/gf/singularities_desc.py
+++ b/pytriqs/gf/singularities_desc.py
@@ -64,7 +64,7 @@ for Target, Rvt, Rt, ext, n in zip(['scalar_valued', 'matrix_valued', 'tensor_va
            )
 
     t.add_regular_type_converter()
-    t.add_constructor(signature = "(triqs::utility::mini_vector<int,%s> target_shape, int n_order=10, int order_min=-1)"%n,
+    t.add_constructor(signature = "(triqs::utility::mini_vector<int,%s> target_shape)"%n,
                       intermediate_type = c_type_reg,   doc = "Constructs a new tail, of matrix size N1xN2")
  
     module.add_function("%s _make_tail_view_from_data(triqs::arrays::array_view<dcomplex, %s + 1> data)"%(c_type,n), 
@@ -73,7 +73,8 @@ for Target, Rvt, Rt, ext, n in zip(['scalar_valued', 'matrix_valued', 'tensor_va
     # backward compat
     if Target == "matrix_valued":
         t.add_constructor(signature = "(int N1, int N2, int n_order=10, int order_min=-1)",
-                          intermediate_type = c_type_reg, doc = "Constructs a new tail, of matrix size N1xN2")
+                          calling_pattern = "auto result = __tail<matrix_valued>(make_shape(N1,N2)); result.reset(order_min+n_order)",
+                          doc = "Constructs a new tail, of matrix size N1xN2")
 
     t.add_property(name = "data",
                    getter = cfunction("array_view<dcomplex,%s+1> data()"%n),
@@ -114,7 +115,7 @@ for Target, Rvt, Rt, ext, n in zip(['scalar_valued', 'matrix_valued', 'tensor_va
                            signature = "void (matrix<dcomplex> l, %s t, matrix<dcomplex> r)"%c_type)
 
     t.add_method("void zero()", doc = "Sets the expansion to 0")
-    t.add_method("void reset(int n)", doc = "Sets the expansion to 0 until order n, to NaN afterwards.")
+    t.add_method("void reset(int n)", doc = "Sets the expansion to 0 until order n-1, to NaN afterwards.")
 
     t.add_method_copy()
     t.add_method_copy_from()

--- a/pytriqs/gf/tools.py
+++ b/pytriqs/gf/tools.py
@@ -152,7 +152,10 @@ def tail_fit(Sigma_iw,G0_iw=None,G_iw=None,fit_min_n=None,fit_max_n=None,fit_min
     if fit_max_moment is None: fit_max_moment = 3
 
     # Now fit the tails of Sigma_iw and G_iw
-    for name, sig in Sigma_iw: sig.fit_tail(fit_known_moments[name], fit_max_moment, fit_min_n, fit_max_n)
+    try:
+        for name, sig in Sigma_iw: sig.fit_tail(fit_known_moments[name], fit_max_moment, fit_min_n, fit_max_n)
+    except RuntimeError:
+        for name, sig in Sigma_iw: sig.fit_tail(fit_known_moments[name], fit_max_moment, -fit_max_n-1, -fit_min_n-1, fit_min_n, fit_max_n)
     if (G_iw is not None) and (G0_iw is not None):
         for name, g in G_iw: g.tail = inverse( inverse(G0_iw[name].tail) - Sigma_iw[name].tail )
 

--- a/test/triqs/gfs/fit_tail.cpp
+++ b/test/triqs/gfs/fit_tail.cpp
@@ -13,10 +13,10 @@ TEST(Gf, FitTailBasic) {
 
  triqs::arrays::array<dcomplex, 1> c{1, 3, 5, 7, 9};
 
- int size = 0; // means we don't know any moments
- int order_min = 1; // means that the first moment in the final tail will be the first moment
- auto known_moments = __tail<matrix_valued>(1,1, size, order_min); // length is 0, first moment to fit is order_min
- auto known_moments_s = __tail<scalar_valued>(size, order_min); // length is 0, first moment to fit is order_min
+ auto known_moments = __tail<matrix_valued>(make_shape(1,1)); // all moments are set to zero
+ known_moments.reset(1); // first unkown moment is 1 (set moments >= 1 to NaN)
+ auto known_moments_s = __tail<scalar_valued>(make_shape()); // all moments are set to zero
+ known_moments_s.reset(1); // first unkown moment is 1 (set moments >= 1 to NaN)
 
  gw(iom_) << c(0) / iom_ + c(1) / iom_ / iom_ + c(2) / iom_ / iom_ / iom_;
  gw_s(iom_) << c(0) / iom_ + c(1) / iom_ / iom_ + c(2) / iom_ / iom_ / iom_;
@@ -26,11 +26,11 @@ TEST(Gf, FitTailBasic) {
 
  int wn_min = 50; // frequency to start the fit
  int wn_max = 90; // final fitting frequency (included)
- int n_moments = 3; // number of moments in the final tail (including known ones)
+ int max_moment = 3; // number of moments in the final tail (including known ones)
 
  // restore tail
- fit_tail(gw, known_moments, n_moments, wn_min, wn_max);
- fit_tail(gw_s, known_moments_s, n_moments, wn_min, wn_max);
+ fit_tail(gw, known_moments, max_moment, wn_min, wn_max);
+ fit_tail(gw_s, known_moments_s, max_moment, wn_min, wn_max);
 
  triqs::arrays::array<dcomplex, 1> res{0, 0, 1, 3, 5};
  EXPECT_ARRAY_NEAR(res, gw.singularity().data()(range(1, 6), 0, 0));
@@ -39,11 +39,9 @@ TEST(Gf, FitTailBasic) {
  gw.singularity().data()() = 0.0;
 
  // now with a known moment
- size = 1; // means that we know one moment
- order_min = 1; // means that the first moment in the final tail will be the first moment
- known_moments = __tail<matrix_valued>(1, 1, size, order_min); // length is 0, first moment to fit is order_min
+ known_moments.reset(2); // first unknow moment is 2
  known_moments(1) = 1.; // set the first moment
- fit_tail(gw, known_moments, n_moments, wn_min, wn_max, true); // true replace the gf data in the fitting range by the tail values
+ fit_tail(gw, known_moments, max_moment, wn_min, wn_max, true); // true replace the gf data in the fitting range by the tail values
 
  EXPECT_ARRAY_NEAR(res, gw.singularity().data()(range(1, 6), 0, 0));
 }
@@ -64,20 +62,19 @@ TEST(Gf, FitTailReal_F_and_B) {
 
  int wn_min = 50; 
  int wn_max = 90; 
- int n_moments = 4; 
- int size = 1; 
- int order_min = 1;
- auto known_moments = __tail<matrix_valued>(1, 1, size, order_min);
- known_moments(1) = 1.; 
- fit_tail(gw, known_moments, n_moments, wn_min, wn_max, true); 
- fit_tail(gw_b, known_moments, n_moments, wn_min, wn_max, true); 
+ int max_moment = 4; 
+ auto known_moments = __tail<matrix_valued>(make_shape(1, 1)); // all moments are set to zero
+ known_moments.reset(2); // put NaN for moments >= 2
+ known_moments(1) = 1.; // this one we know
+ fit_tail(gw, known_moments, max_moment, wn_min, wn_max, true); 
+ fit_tail(gw_b, known_moments, max_moment, wn_min, wn_max, true); 
 
- tail t(make_shape(1,1),4,-1);
- t.data()(range(1,7),0,0) =triqs::arrays::array<dcomplex, 1> {0.0, 0.0, 1.0, 1.0, 0.999251, 0.998655};
+ auto t_exact = __tail<matrix_valued>(make_shape(1, 1)); // all moments are set to zero
+ t_exact.reset(5);
+ t_exact.data()(range(3,7),0,0) = triqs::arrays::array<dcomplex, 1> {1.0, 1.0, 1.0, 1.0};
 
- EXPECT_TAIL_NEAR(t, gw.singularity());
- t.data()(range(1,7),0,0) =triqs::arrays::array<dcomplex, 1> {0.0, 0.0, 1.0, 1.0, 0.999236, 0.998631};
- EXPECT_TAIL_NEAR(t, gw_b.singularity());
+ EXPECT_TAIL_NEAR(t_exact, gw.singularity(), 2e-3);
+ EXPECT_TAIL_NEAR(t_exact, gw_b.singularity(), 2e-3);
 }
 
 
@@ -94,15 +91,17 @@ TEST(Gf, FitTailComplex) {
 
  int wn_min = 50; 
  int wn_max = 90;
- int n_moments = 4; 
- auto known_moments = __tail<matrix_valued>(1, 1, 1, 1);
- known_moments(1) = 1.; 
- fit_tail(gw, known_moments, n_moments, -wn_max, -wn_min, wn_min, wn_max,  true); 
+ int max_moment = 4;
+ auto known_moments = __tail<matrix_valued>(make_shape(1, 1));
+ known_moments.reset(2);
+ known_moments(1) = 1.;
+ fit_tail(gw, known_moments, max_moment, -wn_max-1, -wn_min-1, wn_min, wn_max,  true); 
 
- tail t(make_shape(1,1),-2,4);
- t.data()(range(0,7),0,0) = triqs::arrays::array<dcomplex, 1> {dcomplex(0.0,0.0),dcomplex(0.0,0.0), dcomplex(0.0,0.0), dcomplex(1.0,0.0), a, std::pow(a,2), std::pow(a,3)};
+ auto t_exact = __tail<matrix_valued>(make_shape(1, 1));
+ t_exact.reset(5);
+ t_exact.data()(range(3,7),0,0) = triqs::arrays::array<dcomplex, 1> {dcomplex(1.0,0.0), a, std::pow(a,2), std::pow(a,3)};
 
- EXPECT_TAIL_NEAR(t, gw.singularity(), 8e-3); 
+ EXPECT_TAIL_NEAR(t_exact, gw.singularity(), 9e-3); 
 }
 MAKE_MAIN;
 

--- a/test/triqs/gfs/multivar/g_k_tail.cpp
+++ b/test/triqs/gfs/multivar/g_k_tail.cpp
@@ -4,7 +4,7 @@ using namespace triqs::clef;
 
 TEST(Gf, k) {
  auto bz = brillouin_zone{bravais_lattice{make_unit_matrix<double>(2)}};
- auto t = __tail<matrix_valued>{1, 1};
+ auto t = __tail<matrix_valued>(make_shape(1,1));
  auto G = m_tail<brillouin_zone, matrix_valued>{{bz, 100}, {1, 1}};
 
  placeholder<0> k_;

--- a/triqs/arrays/indexmaps/common.hpp
+++ b/triqs/arrays/indexmaps/common.hpp
@@ -36,7 +36,7 @@ namespace triqs { namespace arrays {
 
  // make_shape
  template<typename... T> 
-  mini_vector<size_t, sizeof...(T)+1> make_shape(size_t x0, T... args) { return  mini_vector<size_t, sizeof...(T)+1> (x0,args...);}
+  mini_vector<size_t, sizeof...(T)> make_shape(T... args) { return  mini_vector<size_t, sizeof...(T)> (args...);}
 
  namespace indexmaps { 
 

--- a/triqs/gfs/functions/legendre.cpp
+++ b/triqs/gfs/functions/legendre.cpp
@@ -31,10 +31,10 @@ namespace triqs { namespace gfs {
 
  // compute a tail from the Legendre GF
  // this is Eq. 8 of our paper
- __tail_view<matrix_valued> get_tail(gf_const_view<legendre> gl, int size = 10, int omin = -1) {
+ __tail_view<matrix_valued> get_tail(gf_const_view<legendre> gl) {
 
    auto sh = gl.data().shape().front_pop();
-   __tail<matrix_valued> t(sh, size, omin);
+   __tail<matrix_valued> t(sh);
    t.data()() = 0.0;
 
    for (int p=1; p<=t.order_max(); p++)

--- a/triqs/gfs/functions/legendre.hpp
+++ b/triqs/gfs/functions/legendre.hpp
@@ -27,7 +27,7 @@ namespace gfs {
  // For Legendre functions
  // ------------------------------------------------------
 
- __tail_view<matrix_valued> get_tail(gf_const_view<legendre> gl, int size, int omin);
+ __tail_view<matrix_valued> get_tail(gf_const_view<legendre> gl);
 
  void enforce_discontinuity(gf_view<legendre>& gl, triqs::arrays::array_view<double, 2> disc);
 }

--- a/triqs/gfs/singularity/fit_tail.cpp
+++ b/triqs/gfs/singularity/fit_tail.cpp
@@ -8,15 +8,15 @@ namespace triqs { namespace gfs {
   n_min = std::max(n_min, int(gf.mesh().first_index()));
 
   const int known_moments_omin = known_moments.backwd_omin();
-  const int known_moments_omax = known_moments.largest_non_nan() - 0;
-  const int known_moments_size = known_moments_omax - known_moments_omin + 0;
+  const int known_moments_omax = known_moments.largest_non_nan();
+  const int known_moments_size = known_moments_omax - known_moments_omin + 1;
 
   __tail<matrix_valued> res = known_moments;
 
   // if known_moments_size==0, the lowest order to be obtained from the fit is determined by order_min in known_moments
   // if known_moments_size==0, the lowest order is the one following order_max() in known_moments
 
-  int n_unknown_moments = (max_moment-known_moments_omin+1) - known_moments_size;
+  int n_unknown_moments = max_moment - known_moments_omax;
 
   //std::cout  << known_moments_omax << " "<< known_moments_omin <<" "<< known_moments_size << std::endl;
   //std::cout << " n_unknown_moments " << n_unknown_moments << std::endl;
@@ -25,7 +25,7 @@ namespace triqs { namespace gfs {
 
   // get the number of even unknown moments: it is n_unknown_moments/2+1 if the first
   // moment is even and max_moment is odd; n_unknown_moments/2 otherwise
-  int omin = known_moments_size == 0 ? known_moments_omin : known_moments_omax + 0; // smallest unknown moment
+  int omin = known_moments_omax + 1; // smallest unknown moment
   int omin_even = omin % 2 == 0 ? omin : omin + 1;
   int omin_odd = omin % 2 != 0 ? omin : omin + 1;
   int size_even = n_unknown_moments / 2;
@@ -103,17 +103,17 @@ namespace triqs { namespace gfs {
   n_min = std::max(n_min, int(gf.mesh().first_index()));
 
   const int known_moments_omin = known_moments.backwd_omin();
-  const int known_moments_omax = known_moments.largest_non_nan() -0;
-  const int known_moments_size = known_moments_omax - known_moments_omin + 0;
+  const int known_moments_omax = known_moments.largest_non_nan();
+  const int known_moments_size = known_moments_omax - known_moments_omin + 1;
 
   __tail<matrix_valued> res = known_moments;
 
-  int n_unknown_moments = (max_moment-known_moments_omin+1) - known_moments_size;
+  int n_unknown_moments = max_moment - known_moments_omax;
   if (n_unknown_moments < 1) return known_moments;
 
   // if known_moments_size==0, the lowest order to be obtained from the fit is determined by order_min() in known_moments
   // if known_moments_size!=0, the lowest order is the one following order_max() in known_moments
-  int omin = known_moments_size == 0 ? known_moments_omin : known_moments_omax + 0;
+  int omin = known_moments_omax + 1; // smallest unknown moment
   int n_freq = n_max - n_min + 1;
   if (n_freq < 0) TRIQS_RUNTIME_ERROR << "n_max - n_min + 1 <0";
 

--- a/triqs/gfs/singularity/fit_tail.cpp
+++ b/triqs/gfs/singularity/fit_tail.cpp
@@ -1,4 +1,6 @@
 #include "./fit_tail.hpp"
+#include "../../utility/itertools.hpp"
+
 namespace triqs { namespace gfs {  
 
  __tail<matrix_valued> fit_real_tail_impl(gf_view<imfreq> gf, __tail_const_view<matrix_valued> known_moments, int max_moment, int n_min, int n_max) {
@@ -96,11 +98,13 @@ namespace triqs { namespace gfs {
   return res; // return tail
  }
 
- __tail<matrix_valued> fit_complex_tail_impl(gf_view<imfreq> gf, __tail_const_view<matrix_valued> known_moments, int max_moment, int n_min, int n_max) {
+ __tail<matrix_valued> fit_complex_tail_impl(gf_view<imfreq> gf, __tail_const_view<matrix_valued> known_moments, int max_moment, int n_min1, int n_max1,int n_min2, int n_max2) {
 
   // precondition : check that n_max is not too large
-  n_max = std::min(n_max, int(gf.mesh().last_index()));
-  n_min = std::max(n_min, int(gf.mesh().first_index()));
+  n_max1 = std::min(n_max1, int(gf.mesh().last_index()));
+  n_max2 = std::min(n_max2, int(gf.mesh().last_index()));
+  n_min1 = std::max(n_min1, int(gf.mesh().first_index()));
+  n_min2 = std::max(n_min2, int(gf.mesh().first_index()));
 
   const int known_moments_omin = known_moments.backwd_omin();
   const int known_moments_omax = known_moments.largest_non_nan();
@@ -114,11 +118,13 @@ namespace triqs { namespace gfs {
   // if known_moments_size==0, the lowest order to be obtained from the fit is determined by order_min() in known_moments
   // if known_moments_size!=0, the lowest order is the one following order_max() in known_moments
   int omin = known_moments_omax + 1; // smallest unknown moment
-  int n_freq = n_max - n_min + 1;
-  if (n_freq < 0) TRIQS_RUNTIME_ERROR << "n_max - n_min + 1 <0";
+  int n_freq1 = n_max1 - n_min1 + 1;
+  int n_freq2 = n_max2 - n_min2 + 1;
+  if (n_freq1 < 0) TRIQS_RUNTIME_ERROR << "n_max1 - n_min1 + 1 <0";
+  if (n_freq2 < 0) TRIQS_RUNTIME_ERROR << "n_max2 - n_min2 + 1 <0";
 
-  arrays::matrix<double> A(n_freq, n_unknown_moments, FORTRAN_LAYOUT);
-  arrays::matrix<double> B(n_freq, 1, FORTRAN_LAYOUT);
+  arrays::matrix<double> A(n_freq1+n_freq2, n_unknown_moments, FORTRAN_LAYOUT);
+  arrays::matrix<double> B(n_freq1+n_freq2, 1, FORTRAN_LAYOUT);
   arrays::vector<double> S(n_unknown_moments);
   const double rcond = 0.0;
   int rank;
@@ -129,8 +135,25 @@ namespace triqs { namespace gfs {
 
     // IMAGINARY PART
     // k is a label for the matsubara frequency
-    for (int k = 0; k < n_freq; k++) {
-     auto n = n_min + k;
+    for (int k = 0; k < n_freq1; k++) {
+     auto n = n_min1 + k;
+     auto iw = std::complex<double>(gf.mesh().index_to_point(n));
+
+     // construct data to be fitted - subtract known tail if present
+     B(k, 0) = imag(gf.data()(gf.mesh().index_to_linear(n), i, j));
+     if (known_moments_size > 0)
+      B(k, 0) -= imag(evaluate(slice_target_sing(known_moments, arrays::range(i, i + 1), arrays::range(j, j + 1)), iw)(0, 0));
+
+     // set design matrix
+     // if the order is odd the fit yields the real coefficient of the moment
+     // if the order is even the fit yields the imaginary coefficient of the moment
+     for (int l = 0; l < n_unknown_moments; l++) {
+      int order = omin + l;
+      A(k, l) = imag( (order%2==1 ? 1.0 : dcomplex{0,1})*std::pow(iw, -1.0 * order) );
+     }
+    }
+    for (int k = n_freq1; k < n_freq1+n_freq2; k++) {
+     auto n = n_min2 + k - n_freq1;
      auto iw = std::complex<double>(gf.mesh().index_to_point(n));
 
      // construct data to be fitted - subtract known tail if present
@@ -154,8 +177,26 @@ namespace triqs { namespace gfs {
 
     // REAL PART
     // k is a label for the matsubara frequency
-    for (int k = 0; k < n_freq; k++) {
-     auto n = n_min + k;
+    for (int k = 0; k < n_freq1; k++) {
+     auto n = n_min1 + k;
+     auto iw = std::complex<double>(gf.mesh().index_to_point(n));
+
+     // construct data to be fitted - subtract known tail if present
+     B(k, 0) = real(gf.data()(gf.mesh().index_to_linear(n), i, j));
+     if (known_moments_size > 0)
+      B(k, 0) -= real(evaluate(slice_target_sing(known_moments, arrays::range(i, i + 1), arrays::range(j, j + 1)), iw)(0, 0));
+
+     // set design matrix
+     // if the order is even the fit yields the real coefficient of the moment
+     // if the order is odd the fit yields the imaginary coefficient of the moment
+     for (int l = 0; l < n_unknown_moments; l++) {
+      int order = omin + l;
+      A(k, l) = real( (order%2==0 ? 1.0 : dcomplex{0,1})*std::pow(iw, -1.0 * order) );
+     }
+    }
+
+    for (int k = n_freq1; k < n_freq1+n_freq2; k++) {
+     auto n = n_min2 + k - n_freq1;
      auto iw = std::complex<double>(gf.mesh().index_to_point(n));
 
      // construct data to be fitted - subtract known tail if present
@@ -210,12 +251,11 @@ namespace triqs { namespace gfs {
   if (neg_n_max >= 0) TRIQS_RUNTIME_ERROR << "neg_n_max ("<< neg_n_max <<") must be smaller than 0";
   if (neg_n_min >= neg_n_max) TRIQS_RUNTIME_ERROR << "neg_n_min ("<<neg_n_min <<") must be smaller than neg_n_max ("<<neg_n_max<<")";
 
-  gf.singularity()  = fit_complex_tail_impl(gf, known_moments, max_moment, neg_n_min, neg_n_max);
-  gf.singularity() += fit_complex_tail_impl(gf, known_moments, max_moment, pos_n_min, pos_n_max);
-  gf.singularity() *= 0.5;
+  gf.singularity()  = fit_complex_tail_impl(gf, known_moments, max_moment, neg_n_min, neg_n_max, pos_n_min, pos_n_max);
+
   if (replace_by_fit) { // replace data in the fitting range by the values from the fitted tail
    for (auto iw : gf.mesh()) {
-    if ((iw.n >= neg_n_min and iw.n <= neg_n_max) or (iw.n >= pos_n_min and iw.n <= pos_n_max)) gf[iw] = evaluate(gf.singularity(), iw);
+    if (iw.n <= neg_n_max or iw.n >= pos_n_min) gf[iw] = evaluate(gf.singularity(), iw);
    }
   }
  }
@@ -225,6 +265,13 @@ namespace triqs { namespace gfs {
    // for(auto &gf : block_gf) fit_tail(gf, known_moments, max_moment, n_min, n_max, replace_by_fit);
    for (int i = 0; i < block_gf.size(); i++)
     fit_tail(block_gf[i], known_moments, max_moment, n_min, n_max, replace_by_fit);
+  }
+
+ void fit_tail(block_gf_view<imfreq> block_gf, __tail_view<matrix_valued> known_moments, int max_moment, int neg_n_min,
+               int neg_n_max, int pos_n_min, int pos_n_max, bool replace_by_fit) {
+   // for(auto &gf : block_gf) fit_tail(gf, known_moments, max_moment, n_min, n_max, replace_by_fit);
+   for (int i = 0; i < block_gf.size(); i++)
+    fit_tail(block_gf[i], known_moments, max_moment, neg_n_min, neg_n_max, pos_n_min, pos_n_max, replace_by_fit);
   }
 
   void fit_tail(gf_view<imfreq, scalar_valued> gf, __tail_const_view<scalar_valued> known_moments, int max_moment, int n_min,

--- a/triqs/gfs/singularity/fit_tail.hpp
+++ b/triqs/gfs/singularity/fit_tail.hpp
@@ -39,7 +39,7 @@ namespace triqs { namespace gfs {
 
   @return the tail obtained by fitting
  */
- __tail<matrix_valued> fit_real_tail_impl(gf_view<imfreq> gf, __tail_const_view<matrix_valued> known_moments, int max_moment, int n_min, int n_max) ;
+ __tail<matrix_valued> fit_real_tail_impl(gf_view<imfreq> gf, __tail_const_view<matrix_valued> known_moments, int max_moment, int n_min, int n_max);
 
  /// routine for fitting the tail (singularity) of a complex Matsubara Green's function
  /**
@@ -55,7 +55,8 @@ namespace triqs { namespace gfs {
 
   @return the tail obtained by fitting
  */
- __tail<matrix_valued> fit_complex_tail_impl(gf_view<imfreq> gf, __tail_const_view<matrix_valued> known_moments, int max_moment, int n_min, int n_max) ;
+ __tail<matrix_valued> fit_complex_tail_impl(gf_view<imfreq> gf, __tail_const_view<matrix_valued> known_moments, int max_moment, 
+   int n_min1, int n_max1, int n_min2, int n_max2);
 
  ///Fit the tail of a real (in tau) gf
  /**
@@ -67,8 +68,7 @@ namespace triqs { namespace gfs {
   @param replace_by_fit if true, replace the gf data with the asymptotic behavior obtained by fitting the tails.
   @note Based on [[fit_tail_impl]]. Works for functions with positive only or all Matsubara frequencies.
  */
- void fit_tail(gf_view<imfreq> gf, __tail_const_view<matrix_valued> known_moments, int max_moment, int n_min, int n_max,
-   bool replace_by_fit = false) ;
+ void fit_tail(gf_view<imfreq> gf, __tail_const_view<matrix_valued> known_moments, int max_moment, int n_min, int n_max, bool replace_by_fit = false);
 
  ///Fit the tail of a complex (in tau) gf
  /**
@@ -105,7 +105,7 @@ namespace triqs { namespace gfs {
   @note Based on [[fit_tail_impl]]
  */
  void fit_tail(block_gf_view<imfreq> block_gf, __tail_const_view<matrix_valued> known_moments, int max_moment, int n_min,
-   int n_max, bool replace_by_fit = false) ;
+   int n_max, bool replace_by_fit = false);
 
  ///Fit the tail of a gf (scalar-valued)
  /**
@@ -126,8 +126,8 @@ namespace triqs { namespace gfs {
         -if n_min<0 (and n_max<0), replace all frequencies w_n <= w_n{n_max}
   @note Based on [[fit_tail_impl]]
  */
- void fit_tail(gf_view<imfreq, scalar_valued> gf, __tail_const_view<scalar_valued> known_moments, int max_moment, int n_min, int n_max, bool replace_by_fit = false) ;
- void fit_tail(gf_view<imfreq, scalar_valued> gf, __tail_const_view<scalar_valued> known_moments, int max_moment, int neg_n_min, int neg_n_max,int pos_n_min, int pos_n_max, bool replace_by_fit = false) ;
+ void fit_tail(gf_view<imfreq, scalar_valued> gf, __tail_const_view<scalar_valued> known_moments, int max_moment, int n_min, int n_max, bool replace_by_fit = false);
+ void fit_tail(gf_view<imfreq, scalar_valued> gf, __tail_const_view<scalar_valued> known_moments, int max_moment, int neg_n_min, int neg_n_max,int pos_n_min, int pos_n_max, bool replace_by_fit = false);
 
  ///fit tail of tensor_valued Gf, rank 3
  array<__tail<scalar_valued>, 3> fit_tail(gf_const_view<imfreq, tensor_valued<3>> g, array_const_view<__tail<scalar_valued>,3> known_moments, int max_moment, int n_min, int n_max);

--- a/triqs/gfs/singularity/tail.hxx
+++ b/triqs/gfs/singularity/tail.hxx
@@ -135,41 +135,39 @@ namespace triqs {
       template <typename Int> explicit __tail(mini_vector<Int, T::rank> sh) : _data(sh.front_append(_size())) { zero(); }
 
       /**
+    * DEPRECATED Constructor
+    *
     * @param sh target shape.
-    * @param n_orders number of moments in the tail ...
+    * @param n_moments number of moments greater than o_min
     * @param o_min ... starting at o_min.
     *
-    * Only n_orders + o_min matters. Kept this way for backward compatibility.
+    * Only n_moments + o_min matters. Kept this way for backward compatibility.
     * Precondition : o_min >= order_min()
     *
-    * Tail is initialized to 0 for n <= o_min + n_orders and NaN afterwards.
+    * Tail is initialized to 0 for n <= o_min + n_moments and NaN afterwards.
     */
-      template <typename Int> explicit __tail(mini_vector<Int, T::rank> sh, int n_orders, int o_min) : __tail{sh} {
-        if (o_min < order_min()) TRIQS_RUNTIME_ERROR << "Tail construction : o_min is < " << order_min();
-        reset(o_min + n_orders + 1);
+      template <typename Int>
+      TRIQS_DEPRECATED("__tail{shape, n_moments, omin} deprecated. Please use __tail{shape} instead followed by a reset")
+      explicit __tail(mini_vector<Int, T::rank> sh, int n_moments, int o_min) : __tail{sh} {
+        if (n_moments > _size()) TRIQS_RUNTIME_ERROR << " Tail construction is limited to a total number of " << _size() << " moments";
+        reset(o_min + n_moments);
       }
 
       /**
+    * DEPRECATED Constructor
     * Parameters are (for rank R)
     *
-    * (n0, ... n_{R-1}) : dimensions of the target shape
+    * (n0, ... n_{R-1}) : Invoke __tail{ make_make(n0, ... n_{R-1}) }
     * or
-    * (n0, ... n_{R-1}, n_orders, o_min)
-    *
-    * @param n_orders number of moments in the tail ...
-    * @param o_min ... starting at o_min.
-    *
-    * Only n_orders + o_min matters. Kept this way for backward compatibility.
-    * Precondition : o_min >= order_min()
-    *
-    * Tail is initialized to 0 for n <= o_min + n_orders and NaN afterwards.
+    * (n0, ... n_{R-1}, n_moments, o_min) : Invoke __tail{ make_shape(n0, ... n_{R-1}), n_moments, o_min }
     */
-      template <typename... Args> //TRIQS_DEPRECATED("Deprecated constructor")
-      explicit __tail(int n0, Args const &... args) {
-        constexpr int n_args = sizeof...(Args) + 1;
-        static_assert((n_args - T::rank == 2) or ((n_args - T::rank == 0)), "Too many arguments in tail construction");
+      template <typename... Args>
+      TRIQS_DEPRECATED("__tail{n0, n1, ... } deprecated. Please use __tail{shape, n_moments} instead")
+      explicit __tail(Args... ns) {
+        constexpr int n_args = sizeof...(Args);
+        static_assert((n_args == T::rank) or (n_args == 2 + T::rank), "Wrong number of arguments in tail construction");
         mini_vector<int, T::rank> shape;
-        mini_vector<int, n_args> _args{n0, int(args)...};
+        mini_vector<int, n_args> _args{int(ns)...};
         for (int i = 0; i < T::rank; ++i) shape[i] = _args[i];
         *this = (n_args == T::rank ? __tail{shape} : __tail{shape, _args[n_args - 2], _args[n_args - 1]});
       }
@@ -213,7 +211,7 @@ namespace triqs {
 
       /// Sets order < n to 0 and Nan from n to order_max
       void reset(int n = order_min()) {
-        n                                    = std::min(n, order_max() + 1) - order_min();
+        n                                    = std::min(n, order_max()) - order_min();
         _data(range(0, n), ellipsis())       = 0;
         _data(range(n, _size()), ellipsis()) = std::numeric_limits<double>::quiet_NaN();
       }
@@ -493,7 +491,7 @@ namespace triqs {
 
       /// Sets order < n to 0 and Nan from n to order_max
       void reset(int n = order_min()) {
-        n                                    = std::min(n, order_max() + 1) - order_min();
+        n                                    = std::min(n, order_max()) - order_min();
         _data(range(0, n), ellipsis())       = 0;
         _data(range(n, _size()), ellipsis()) = std::numeric_limits<double>::quiet_NaN();
       }

--- a/triqs/gfs/singularity/tail.mako.hpp
+++ b/triqs/gfs/singularity/tail.mako.hpp
@@ -158,41 +158,37 @@ namespace gfs {
   template <typename Int> explicit __tail(mini_vector<Int, T::rank> sh) : _data(sh.front_append(_size())) { zero(); }
 
   /**
+    * DEPRECATED Constructor
+    *
     * @param sh target shape.
-    * @param n_orders number of moments in the tail ...
+    * @param n_moments number of moments greater than o_min
     * @param o_min ... starting at o_min.
     *
-    * Only n_orders + o_min matters. Kept this way for backward compatibility.
+    * Only n_moments + o_min matters. Kept this way for backward compatibility.
     * Precondition : o_min >= order_min()
     *
-    * Tail is initialized to 0 for n <= o_min + n_orders and NaN afterwards.
+    * Tail is initialized to 0 for n <= o_min + n_moments and NaN afterwards.
     */
-  template <typename Int> explicit __tail(mini_vector<Int, T::rank> sh, int n_orders, int o_min) : __tail{sh} {
-   if (o_min < order_min()) TRIQS_RUNTIME_ERROR << "Tail construction : o_min is < " << order_min();
-   reset(o_min + n_orders + 1);
+  template <typename Int> TRIQS_DEPRECATED("__tail{shape, n_moments, omin} deprecated. Please use __tail{shape} instead followed by a reset") 
+  explicit __tail(mini_vector<Int, T::rank> sh, int n_moments, int o_min) : __tail{sh} {
+   if( n_moments > _size() ) TRIQS_RUNTIME_ERROR << " Tail construction is limited to a total number of " << _size() << " moments"; 
+   reset(o_min + n_moments);
   }
 
   /**
+    * DEPRECATED Constructor
     * Parameters are (for rank R)
     *
-    * (n0, ... n_{R-1}) : dimensions of the target shape
+    * (n0, ... n_{R-1}) : Invoke __tail{ make_make(n0, ... n_{R-1}) }
     * or
-    * (n0, ... n_{R-1}, n_orders, o_min)
-    *
-    * @param n_orders number of moments in the tail ...
-    * @param o_min ... starting at o_min.
-    *
-    * Only n_orders + o_min matters. Kept this way for backward compatibility.
-    * Precondition : o_min >= order_min()
-    *
-    * Tail is initialized to 0 for n <= o_min + n_orders and NaN afterwards.
+    * (n0, ... n_{R-1}, n_moments, o_min) : Invoke __tail{ make_shape(n0, ... n_{R-1}), n_moments, o_min }
     */
-  template <typename... Args>  //TRIQS_DEPRECATED("Deprecated constructor") 
-  explicit __tail(int n0, Args const &... args) {
-   constexpr int n_args = sizeof...(Args) + 1;
-   static_assert((n_args - T::rank == 2) or ((n_args - T::rank == 0)), "Too many arguments in tail construction");
+  template <typename... Args> TRIQS_DEPRECATED("__tail{n0, n1, ... } deprecated. Please use __tail{shape, n_moments} instead") 
+  explicit __tail(Args... ns) {
+   constexpr int n_args = sizeof...(Args); 
+   static_assert((n_args == T::rank) or (n_args == 2 + T::rank), "Wrong number of arguments in tail construction");
    mini_vector<int, T::rank> shape;
-   mini_vector<int, n_args> _args{n0, int(args)...};
+   mini_vector<int, n_args> _args{int(ns)...};
    for (int i = 0; i < T::rank; ++i) shape[i] = _args[i];
    *this = (n_args == T::rank ? __tail{shape} : __tail{shape, _args[n_args - 2], _args[n_args - 1]});
   }
@@ -275,7 +271,7 @@ namespace gfs {
 
   /// Sets order < n to 0 and Nan from n to order_max
   void reset(int n = order_min()) {
-   n = std::min(n, order_max() + 1) - order_min();
+   n = std::min(n, order_max()) - order_min();
    _data(range(0, n), ellipsis()) = 0;
    _data(range(n, _size()), ellipsis()) = std::numeric_limits<double>::quiet_NaN();
   }

--- a/triqs/gfs/transform/fourier_two_variables.cpp
+++ b/triqs/gfs/transform/fourier_two_variables.cpp
@@ -19,8 +19,7 @@ namespace triqs {
    gf<cartesian_product<imfreq, imtime>, tensor_valued<3>> gwt({imfreq_mesh_1, std::get<1>(g2t.mesh())}, g2t.target_shape());
 
    array<__tail<scalar_valued>, 3> tail_3(g2t.target_shape());
-   __tail<scalar_valued> t(1, 1);
-   t.data()() = 0;
+   __tail<scalar_valued> t(make_shape()); // moments are set to zero
    tail_3()   = t;
 
    auto _ = var_t{};
@@ -57,14 +56,12 @@ namespace triqs {
    gf<cartesian_product<imtime, imfreq>, tensor_valued<3>> gtw({imtime_mesh_1, std::get<1>(g2w.mesh())}, g2w.target_shape());
 
    array<__tail<scalar_valued>, 3> known_moments(g2w.target_shape());
-   __tail<scalar_valued> t(2, -1);
-   t(-1)           = 0.;
-   t(0)            = 0.;
+   __tail<scalar_valued> t(make_shape()); // moments are set to zero
+   t.reset(1);
    known_moments() = t;
 
    array<__tail<scalar_valued>, 3> tail_zero(g2w.target_shape());
-   __tail<scalar_valued> t0;
-   t0.data()() = 0;
+   __tail<scalar_valued> t0(make_shape()); // moments are set to zero
    tail_zero() = t0;
 
    auto _ = var_t{};

--- a/triqs/gfs/transform/legendre_matsubara.cpp
+++ b/triqs/gfs/transform/legendre_matsubara.cpp
@@ -43,7 +43,7 @@ namespace gfs {
    }
   }
 
-  gw.singularity() = get_tail(gl, gw.singularity().n_valid_orders(), gw.singularity().order_min());
+  gw.singularity() = get_tail(gl);
  }
 
  // ----------------------------
@@ -60,7 +60,7 @@ namespace gfs {
    }
   }
 
-  gt.singularity() = get_tail(gl, gt.singularity().n_valid_orders(), gt.singularity().order_min());
+  gt.singularity() = get_tail(gl);
  }
 
  // ----------------------------


### PR DESCRIPTION
-**Bugfix**: tail.reset(n) now properly resets all moments starting from n to NaN (unknown) 
-adjusting fit_tail and constructors accordingly
-Cleaning of fit_tail.cpp
-Removing all usage of constructor __tail(n1, .. )
-Removing all usage __tail(shape, n_orders, omin)
-Adjusted python tail constructors for backward compatibility
-Added deprecation warnings for improper constructors

-**FIX** by Gernot for complex fitting in one go

 -Some cleaning in fit_tail.cpp