### PR TITLE
[gf] Fix #541 Fix two bugs in block2_gf copy assignment, some cleaning

### DIFF
--- a/cmake/FindSphinx.cmake
+++ b/cmake/FindSphinx.cmake
@@ -6,35 +6,35 @@
 # This module looks for sphinx documentation tool 
 # and define a function that prepares the Makefile for sphinx-build
 
-FIND_PROGRAM(SPHINXBUILD_EXECUTABLE
+find_program(SPHINXBUILD_EXECUTABLE
  NAMES sphinx-build 
  PATHS /usr/bin /opt/local/bin /usr/local/bin #opt/sphinx-doc/bin
  PATH_SUFFIXES  bin
  )
 
 if (NOT SPHINXBUILD_EXECUTABLE)
- MESSAGE(FATAL_ERROR "I cannot find sphinx to build the triqs documentation")
+ message(FATAL_ERROR "I cannot find sphinx to build the triqs documentation")
 endif()
 
-execute_process (
-      COMMAND "${SPHINXBUILD_EXECUTABLE}" -h
+execute_process(
+      COMMAND "${SPHINXBUILD_EXECUTABLE}" --version
       OUTPUT_VARIABLE SPHINXBUILD_VERSION
       ERROR_VARIABLE  SPHINXBUILD_VERSION
     )
-if (SPHINXBUILD_VERSION MATCHES "Sphinx v([0-9]+\\.[0-9]+(\\.|b)[0-9]+)")
+if (SPHINXBUILD_VERSION MATCHES "[Ss]phinx.* ([0-9]+\\.[0-9]+(\\.|b)[0-9]+)")
   set (SPHINXBUILD_VERSION "${CMAKE_MATCH_1}")
 endif()
 
 if (SPHINXBUILD_VERSION VERSION_EQUAL 1.6.3)
- MESSAGE(FATAL_ERROR "sphinx-build found at ${SPHINXBUILD_EXECUTABLE} but version 1.6.3 has a bug. Upgrade sphinx.")
+ message(FATAL_ERROR "sphinx-build found at ${SPHINXBUILD_EXECUTABLE} but version 1.6.3 has a bug. Upgrade sphinx.")
 else()
- MESSAGE(STATUS "sphinx-build program found at ${SPHINXBUILD_EXECUTABLE} with version ${SPHINXBUILD_VERSION}")
+ message(STATUS "sphinx-build program found at ${SPHINXBUILD_EXECUTABLE} with version ${SPHINXBUILD_VERSION}")
 endif ()
 
-INCLUDE(FindPackageHandleStandardArgs)
+include(FindPackageHandleStandardArgs)
 FIND_PACKAGE_HANDLE_STANDARD_ARGS(SPHINX DEFAULT_MSG SPHINXBUILD_EXECUTABLE)
 
-MARK_AS_ADVANCED( SPHINXBUILD_EXECUTABLE )
+mark_as_advanced( SPHINXBUILD_EXECUTABLE )
 
 # Imported target
 add_executable(sphinx IMPORTED)

--- a/doc/sphinxext/autorun/autorun.py
+++ b/doc/sphinxext/autorun/autorun.py
@@ -11,7 +11,7 @@ import os
 from subprocess import Popen,PIPE
 
 from docutils import nodes
-from sphinx.util.compat import Directive
+from docutils.parsers.rst import Directive
 from docutils.parsers.rst import directives
 from sphinx.errors import SphinxError
 from pygments import highlight

--- a/doc/sphinxext/triqs_example/triqs_example.py
+++ b/doc/sphinxext/triqs_example/triqs_example.py
@@ -9,7 +9,7 @@ import codecs
 from os import path
 from subprocess import Popen,PIPE
 from docutils import nodes
-from sphinx.util.compat import Directive
+from docutils.parsers.rst import Directive
 from docutils.parsers.rst import directives
 from sphinx.errors import SphinxError
 

--- a/test/triqs/gfs/block2.cpp
+++ b/test/triqs/gfs/block2.cpp
@@ -1,0 +1,90 @@
+#include <triqs/test_tools/gfs.hpp>
+
+TEST(Block2, Base) {
+
+  double beta = 1;
+  auto G1     = gf<imfreq>({beta, Fermion}, {2, 2});
+  auto G2     = G1;
+  auto G3     = G1;
+
+  triqs::clef::placeholder<0> w_;
+  G1(w_) << 1. / (w_ + 2.);
+  G2(w_) << 2. / (w_ - 2.);
+
+  // Constructors
+  auto G_vec    = std::vector{G1, G2, G3};
+  auto G_vecvec = std::vector{G_vec, G_vec};
+
+  auto B1 = block2_gf{G_vecvec};
+  auto B2 = block2_gf{B1()};
+  auto B3 = block2_gf<imfreq>({{"0", "1"}, {"0", "1", "2"}}, G_vecvec);
+  auto B4 = make_block2_gf({"0", "1"}, {"0", "1", "2"}, G_vecvec);
+  auto B5 = make_block2_gf(2, 1, G1);
+
+  auto view_vec    = std::vector<gf_view<imfreq>>{G1, G2, G3};
+  auto view_vecvec = std::vector{view_vec, view_vec};
+  auto V1          = make_block2_gf_view(view_vecvec);
+
+  EXPECT_BLOCK2_GF_NEAR(B1, B2);
+  EXPECT_BLOCK2_GF_NEAR(B1, B3);
+  EXPECT_BLOCK2_GF_NEAR(B1, B4);
+  EXPECT_BLOCK2_GF_NEAR(B1, V1);
+
+  // H5 read write
+  EXPECT_BLOCK2_GF_NEAR(B1, rw_h5(B1, "block", "B1"));
+
+  // Data write/read access
+  B1(0, 0)[0] = 1.0;
+  EXPECT_ARRAY_NEAR(B1(0, 0)(0), matrix<double>{{1, 0}, {0, 1}});
+
+  // Operations
+  B1 = B1 / 2.0;
+  B1 = B1 * 4.0;
+  EXPECT_CLOSE(B1(0, 0)[0](0, 0), 2.0);
+  B1 = B1 + B1 * B1;
+  EXPECT_CLOSE(B1(0, 0)[0](0, 0), 6.0);
+  B1 = B1 + B1() * B1();
+  EXPECT_CLOSE(B1(0, 0)[0](0, 0), 42.0);
+
+  // View Access
+  V1(0, 0)[0] = 5.0;
+  EXPECT_CLOSE(G1[0](0,0), 5.0);
+
+  // Loops
+  for (auto &g : B1) { g[0] = 20; }
+  EXPECT_CLOSE(B1(0, 0)[0](0, 0), 20);
+  for (auto &g : B1()) { g[0] = 40; }
+  EXPECT_CLOSE(B1(0, 0)[0](0, 0), 40);
+
+  // Clef expressions
+  clef::placeholder<0> b1_;
+  clef::placeholder<1> b2_;
+  clef::placeholder<2> iw_;
+  B1(b1_, b2_)[iw_] << b1_ * b2_ / (iw_ + 2);
+  auto B11 = B1;
+  B1(b1_, b2_)(iw_) << B11(b1_, b2_)(iw_) * B1(b1_, b2_)(iw_) * B11(b1_, b2_)(iw_);
+
+  // Reinterpretation (compile checks)
+  auto G1_scalar = gf<imfreq, scalar_valued>{{beta, Fermion}, {}};
+  auto B1_scalar = make_block2_gf(3, 3, G1_scalar);
+  auto B1_interp = reinterpret_scalar_valued_gf_as_matrix_valued(B1_scalar);
+
+  // Inversion
+  auto inv_G1 = inverse(G1);
+  auto B      = make_block2_gf(3, 3, G1);
+  auto inv_B  = inverse(B);
+  for (auto &g : inv_B) EXPECT_GF_NEAR(g, inv_G1);
+}
+
+TEST(Block2, CopyAssignment) {
+  auto g        = gf<imfreq, scalar_valued>{{1, Fermion}};
+  auto G_vec    = std::vector{g, g};
+  auto G_vecvec = std::vector{G_vec, G_vec};
+  auto G        = make_block2_gf({"up", "down"}, {"up", "down"}, G_vecvec);
+  block2_gf<imfreq, scalar_valued> G2;
+  G2 = G;
+  ASSERT_EQ(G2.data().size(), G.data().size());
+  ASSERT_EQ(G2.block_names().size(), G.block_names().size());
+}
+
+MAKE_MAIN;

--- a/triqs/gfs/block/block_gf.hxx
+++ b/triqs/gfs/block/block_gf.hxx
@@ -61,11 +61,14 @@ namespace triqs {
     template <typename V, typename T> struct _is_block_gf_or_view<block2_gf_const_view<V, T>, 2> : std::true_type {};
 
     // Given a gf G, the corresponding block
-    template <typename G> using get_variable_t         = typename std14::decay_t<G>::variable_t;
-    template <typename G> using get_target_t           = typename std14::decay_t<G>::target_t;
-    template <typename G> using block_gf_of            = block_gf<get_variable_t<G>, get_target_t<G>>;
-    template <typename G> using block_gf_view_of       = block_gf_view<get_variable_t<G>, get_target_t<G>>;
-    template <typename G> using block_gf_const_view_of = block_gf_const_view<get_variable_t<G>, get_target_t<G>>;
+    template <typename G> using get_variable_t          = typename std::decay_t<G>::variable_t;
+    template <typename G> using get_target_t            = typename std::decay_t<G>::target_t;
+    template <typename G> using block_gf_of             = block_gf<get_variable_t<G>, get_target_t<G>>;
+    template <typename G> using block_gf_view_of        = block_gf_view<get_variable_t<G>, get_target_t<G>>;
+    template <typename G> using block_gf_const_view_of  = block_gf_const_view<get_variable_t<G>, get_target_t<G>>;
+    template <typename G> using block2_gf_of            = block2_gf<get_variable_t<G>, get_target_t<G>>;
+    template <typename G> using block2_gf_view_of       = block2_gf_view<get_variable_t<G>, get_target_t<G>>;
+    template <typename G> using block2_gf_const_view_of = block2_gf_const_view<get_variable_t<G>, get_target_t<G>>;
 
     // The trait that "marks" the Green function
     TRIQS_DEFINE_CONCEPT_AND_ASSOCIATED_TRAIT(BlockGreenFunction);
@@ -1195,7 +1198,13 @@ namespace triqs {
       block2_gf(block2_gf &&) = default;
 
       /// Construct from block_names and list of gf
-      block2_gf(block_names_t b, data_t d) : _block_names(std::move(b)), _glist(std::move(d)) {}
+      block2_gf(block_names_t b, data_t d) : _block_names(std::move(b)), _glist(std::move(d)) {
+        if (_glist.size() != _block_names[0].size())
+          TRIQS_RUNTIME_ERROR << "block2_gf(vector<vector<string>>, vector<vector<gf>>) : Outer vectors have different sizes !";
+        if (_glist.size() != 0)
+          if (_glist[0].size() != _block_names[1].size())
+            TRIQS_RUNTIME_ERROR << "block2_gf(vector<vector<string>>, vector<vector<gf>>) : Inner vectors have different sizes !";
+      }
 
       // ---------------  Constructors --------------------
 
@@ -1218,6 +1227,9 @@ namespace triqs {
 
       /// Constructs a n blocks with copies of g.
       block2_gf(int n, int p, g_t const &g) : _block_names(details::_make_block_names2(n, p)), _glist(n, std::vector<g_t>(p, g)) {}
+
+      /// Construct from a vector of gf
+      block2_gf(data_t V) : _block_names(details::_make_block_names2(V.size(), V[0].size())), _glist(std::move(V)) {}
 
       /// ---------------  Operator = --------------------
       private:
@@ -1545,7 +1557,13 @@ namespace triqs {
       block2_gf_view(block2_gf_view &&) = default;
 
       /// Construct from block_names and list of gf
-      block2_gf_view(block_names_t b, data_t d) : _block_names(std::move(b)), _glist(std::move(d)) {}
+      block2_gf_view(block_names_t b, data_t d) : _block_names(std::move(b)), _glist(std::move(d)) {
+        if (_glist.size() != _block_names[0].size())
+          TRIQS_RUNTIME_ERROR << "block2_gf(vector<vector<string>>, vector<vector<gf>>) : Outer vectors have different sizes !";
+        if (_glist.size() != 0)
+          if (_glist[0].size() != _block_names[1].size())
+            TRIQS_RUNTIME_ERROR << "block2_gf(vector<vector<string>>, vector<vector<gf>>) : Inner vectors have different sizes !";
+      }
 
       // ---------------  Constructors --------------------
 
@@ -1900,7 +1918,13 @@ namespace triqs {
       block2_gf_const_view(block2_gf_const_view &&) = default;
 
       /// Construct from block_names and list of gf
-      block2_gf_const_view(block_names_t b, data_t d) : _block_names(std::move(b)), _glist(std::move(d)) {}
+      block2_gf_const_view(block_names_t b, data_t d) : _block_names(std::move(b)), _glist(std::move(d)) {
+        if (_glist.size() != _block_names[0].size())
+          TRIQS_RUNTIME_ERROR << "block2_gf(vector<vector<string>>, vector<vector<gf>>) : Outer vectors have different sizes !";
+        if (_glist.size() != 0)
+          if (_glist[0].size() != _block_names[1].size())
+            TRIQS_RUNTIME_ERROR << "block2_gf(vector<vector<string>>, vector<vector<gf>>) : Inner vectors have different sizes !";
+      }
 
       // ---------------  Constructors --------------------
 
@@ -2169,30 +2193,52 @@ namespace triqs {
     // -------------------------------   Free Factories for block_gf_view and block_gf_const_view
     // --------------------------------------------------
 
-    /// Make a block view from the G. Indices are '1', '2', ....
+    /// Make a block view from the G. Indices are '0', '1', '2', ....
     template <typename G0, typename... G> block_gf_view_of<G0> make_block_gf_view(G0 &&g0, G &&... g) {
       return {details::_make_block_names1(sizeof...(G) + 1), {std::forward<G0>(g0), std::forward<G>(g)...}};
     }
 
-    ///
-    template <typename G> block_gf_view_of<G> make_block_gf_view(std::vector<G> v) { return {std::move(v)}; }
+    // Create block_gf_view from vector of views
+    template <typename Gf> block_gf_view_of<Gf> make_block_gf_view(std::vector<Gf> &v) {
+      static_assert(Gf::is_view);
+      return {details::_make_block_names1(v.size()), v};
+    }
+    template <typename Gf> block_gf_view_of<Gf> make_block_gf_view(std::vector<Gf> &&v) {
+      static_assert(Gf::is_view);
+      return {details::_make_block_names1(v.size()), std::move(v)};
+    }
 
-    /// Make a block view from block_names and a vector of G
-    /// G can be a view, or the regular type
-    template <typename G> block_gf_view_of<G> make_block_gf_view(std::vector<std::string> b, std::vector<G> v) {
+    // Create block_gf_view from block_names and vector of views
+    template <typename Gf> block_gf_view_of<Gf> make_block_gf_view(std::vector<std::string> b, std::vector<Gf> &v) {
+      static_assert(Gf::is_view);
+      return {std::move(b), v};
+    }
+    template <typename Gf> block_gf_view_of<Gf> make_block_gf_view(std::vector<std::string> b, std::vector<Gf> &&v) {
+      static_assert(Gf::is_view);
       return {std::move(b), std::move(v)};
     }
-    /// Make a block const_view from the G. Indices are '1', '2', ....
+    /// Make a block const_view from the G. Indices are '0', '1', '2', ....
     template <typename G0, typename... G> block_gf_const_view_of<G0> make_block_gf_const_view(G0 &&g0, G &&... g) {
       return {details::_make_block_names1(sizeof...(G) + 1), {std::forward<G0>(g0), std::forward<G>(g)...}};
     }
 
-    ///
-    template <typename G> block_gf_const_view_of<G> make_block_gf_const_view(std::vector<G> v) { return {std::move(v)}; }
+    // Create block_gf_const_view from vector of views
+    template <typename Gf> block_gf_const_view_of<Gf> make_block_gf_const_view(std::vector<Gf> &v) {
+      static_assert(Gf::is_view);
+      return {details::_make_block_names1(v.size()), v};
+    }
+    template <typename Gf> block_gf_const_view_of<Gf> make_block_gf_const_view(std::vector<Gf> &&v) {
+      static_assert(Gf::is_view);
+      return {details::_make_block_names1(v.size()), std::move(v)};
+    }
 
-    /// Make a block const_view from block_names and a vector of G
-    /// G can be a view, or the regular type
-    template <typename G> block_gf_const_view_of<G> make_block_gf_const_view(std::vector<std::string> b, std::vector<G> v) {
+    // Create block_gf_const_view from block_names and vector of views
+    template <typename Gf> block_gf_const_view_of<Gf> make_block_gf_const_view(std::vector<std::string> b, std::vector<Gf> &v) {
+      static_assert(Gf::is_view);
+      return {std::move(b), v};
+    }
+    template <typename Gf> block_gf_const_view_of<Gf> make_block_gf_const_view(std::vector<std::string> b, std::vector<Gf> &&v) {
+      static_assert(Gf::is_view);
       return {std::move(b), std::move(v)};
     }
 
@@ -2214,19 +2260,57 @@ namespace triqs {
       return {{block_names1, block_names2}, std::move(vv)};
     }
 
-    // -------------------------------   Free Factories for view type  --------------------------------------------------
+    // -------------------------------   Free Factories for block2_gf_view and block2_gf_const_view  --------------------------------------------------
 
-    // from block_names and data vector
-    template <typename GF>
-    block2_gf_view<typename GF::variable_t, typename GF::target_t>
-    make_block2_gf_view(std::vector<std::string> block_names1, std::vector<std::string> block_names2, std::vector<std::vector<GF>> v) {
+    // Create block2_gf_view from vector of views
+    template <typename Gf> block2_gf_view_of<Gf> make_block2_gf_view(std::vector<std::vector<Gf>> &v) {
+      static_assert(Gf::is_view);
+      if (v.size() == 0) return {details::_make_block_names2(0, 0), v};
+      return {details::_make_block_names2(v.size(), v[0].size()), v};
+    }
+    template <typename Gf> block2_gf_view_of<Gf> make_block2_gf_view(std::vector<std::vector<Gf>> &&v) {
+      static_assert(Gf::is_view);
+      if (v.size() == 0) return {details::_make_block_names2(0, 0), v};
+      return {details::_make_block_names2(v.size(), v[0].size()), std::move(v)};
+    }
+
+    // Create block2_gf_view from block_names and vector of views
+    template <typename Gf>
+    block2_gf_view_of<Gf> make_block2_gf_view(std::vector<std::string> block_names1, std::vector<std::string> block_names2,
+                                              std::vector<std::vector<Gf>> &v) {
+      static_assert(Gf::is_view);
+      return {{std::move(block_names1), std::move(block_names2)}, v};
+    }
+    template <typename Gf>
+    block2_gf_view_of<Gf> make_block2_gf_view(std::vector<std::string> block_names1, std::vector<std::string> block_names2,
+                                              std::vector<std::vector<Gf>> &&v) {
+      static_assert(Gf::is_view);
       return {{std::move(block_names1), std::move(block_names2)}, std::move(v)};
     }
 
-    // from block_names and data vector
-    template <typename GF>
-    block2_gf_const_view<typename GF::variable_t, typename GF::target_t>
-    make_block2_gf_const_view(std::vector<std::string> block_names1, std::vector<std::string> block_names2, std::vector<std::vector<GF>> v) {
+    // Create block2_gf_const_view from vector of views
+    template <typename Gf> block2_gf_const_view_of<Gf> make_block2_gf_const_view(std::vector<std::vector<Gf>> &v) {
+      static_assert(Gf::is_view);
+      if (v.size() == 0) return {details::_make_block_names2(0, 0), v};
+      return {details::_make_block_names2(v.size(), v[0].size()), v};
+    }
+    template <typename Gf> block2_gf_const_view_of<Gf> make_block2_gf_const_view(std::vector<std::vector<Gf>> &&v) {
+      static_assert(Gf::is_view);
+      if (v.size() == 0) return {details::_make_block_names2(0, 0), v};
+      return {details::_make_block_names2(v.size(), v[0].size()), std::move(v)};
+    }
+
+    // Create block2_gf_const_view from block_names and vector of views
+    template <typename Gf>
+    block2_gf_const_view_of<Gf> make_block2_gf_const_view(std::vector<std::string> block_names1, std::vector<std::string> block_names2,
+                                                          std::vector<std::vector<Gf>> &v) {
+      static_assert(Gf::is_view);
+      return {{std::move(block_names1), std::move(block_names2)}, v};
+    }
+    template <typename Gf>
+    block2_gf_const_view_of<Gf> make_block2_gf_const_view(std::vector<std::string> block_names1, std::vector<std::string> block_names2,
+                                                          std::vector<std::vector<Gf>> &&v) {
+      static_assert(Gf::is_view);
       return {{std::move(block_names1), std::move(block_names2)}, std::move(v)};
     }
   } // namespace gfs

--- a/triqs/gfs/block/block_gf.hxx
+++ b/triqs/gfs/block/block_gf.hxx
@@ -210,14 +210,13 @@ namespace triqs {
       private:
       template <typename RHS> void _assign_impl(RHS &&rhs) {
 
-        for (int w = 0; w < size(); ++w) {
-          _glist[w]       = rhs[w];
-          _block_names[w] = rhs.block_names()[w];
-        }
+        for (int w = 0; w < size(); ++w) _glist[w] = rhs[w];
+        _block_names = rhs.block_names();
       }
 
       public:
       /// Copy assignment
+      block_gf &operator=(block_gf &rhs) = default;
       block_gf &operator=(block_gf const &rhs) = default;
 
       /// Move assignment
@@ -558,10 +557,8 @@ namespace triqs {
       private:
       template <typename RHS> void _assign_impl(RHS &&rhs) {
 
-        for (int w = 0; w < size(); ++w) {
-          _glist[w]       = rhs[w];
-          _block_names[w] = rhs.block_names()[w];
-        }
+        for (int w = 0; w < size(); ++w) _glist[w] = rhs[w];
+        _block_names = rhs.block_names();
       }
 
       public:
@@ -919,10 +916,8 @@ namespace triqs {
       private:
       template <typename RHS> void _assign_impl(RHS &&rhs) {
 
-        for (int w = 0; w < size(); ++w) {
-          _glist[w]       = rhs[w];
-          _block_names[w] = rhs.block_names()[w];
-        }
+        for (int w = 0; w < size(); ++w) _glist[w] = rhs[w];
+        _block_names = rhs.block_names();
       }
 
       public:
@@ -1228,14 +1223,14 @@ namespace triqs {
       private:
       template <typename RHS> void _assign_impl(RHS &&rhs) {
 
-        for (int w = 0; w < size1(); ++w) {
+        for (int w = 0; w < size1(); ++w)
           for (int v = 0; v < size2(); ++v) _glist[w][v] = rhs(w, v);
-          _block_names[w] = rhs.block_names()[w];
-        }
+        _block_names = rhs.block_names();
       }
 
       public:
       /// Copy assignment
+      block2_gf &operator=(block2_gf &rhs) = default;
       block2_gf &operator=(block2_gf const &rhs) = default;
 
       /// Move assignment
@@ -1267,8 +1262,10 @@ namespace triqs {
    *
    */
       template <typename RHS> block2_gf &operator=(RHS &&rhs) {
-        _glist.resize(rhs.size());
-        _block_names.resize(rhs.size());
+        _glist.resize(rhs.size1());
+        for (auto &g_bl : _glist) g_bl.resize(rhs.size2());
+        _block_names[0].resize(rhs.size1());
+        _block_names[1].resize(rhs.size2());
         _assign_impl(rhs);
         return *this;
       }
@@ -1566,10 +1563,9 @@ namespace triqs {
       private:
       template <typename RHS> void _assign_impl(RHS &&rhs) {
 
-        for (int w = 0; w < size1(); ++w) {
+        for (int w = 0; w < size1(); ++w)
           for (int v = 0; v < size2(); ++v) _glist[w][v] = rhs(w, v);
-          _block_names[w] = rhs.block_names()[w];
-        }
+        _block_names = rhs.block_names();
       }
 
       public:
@@ -1920,10 +1916,9 @@ namespace triqs {
       private:
       template <typename RHS> void _assign_impl(RHS &&rhs) {
 
-        for (int w = 0; w < size1(); ++w) {
+        for (int w = 0; w < size1(); ++w)
           for (int v = 0; v < size2(); ++v) _glist[w][v] = rhs(w, v);
-          _block_names[w] = rhs.block_names()[w];
-        }
+        _block_names = rhs.block_names();
       }
 
       public:

--- a/triqs/gfs/block/block_gf.mako.hpp
+++ b/triqs/gfs/block/block_gf.mako.hpp
@@ -281,21 +281,18 @@ namespace triqs {
    template <typename RHS> void _assign_impl(RHS&& rhs) {
 
     // mako %if ARITY == 1 :
-    for (int w = 0; w < size(); ++w) {
-     _glist[w]       = rhs[w];
-     _block_names[w] = rhs.block_names()[w];
-    }
+    for (int w = 0; w < size(); ++w) _glist[w] = rhs[w];
     // mako %else:
-    for (int w = 0; w < size1(); ++w) {
+    for (int w = 0; w < size1(); ++w)
      for (int v = 0; v < size2(); ++v) _glist[w][v] = rhs(w,v);
-     _block_names[w] = rhs.block_names()[w];
-    }
     // mako %endif
+    _block_names = rhs.block_names();
    }
 
    public:
    // mako %if RVC == 'regular' :
    /// Copy assignment
+   MAKO_GF& operator=(MAKO_GF & rhs) = default;
    MAKO_GF& operator=(MAKO_GF const& rhs) = default;
 
    /// Move assignment
@@ -327,8 +324,15 @@ namespace triqs {
    *
    */
    template <typename RHS> MAKO_GF& operator=(RHS&& rhs) {
+    // mako %if ARITY == 1 :
     _glist.resize(rhs.size());
     _block_names.resize(rhs.size());
+    // mako %else:
+    _glist.resize(rhs.size1());
+    for( auto & g_bl : _glist ) g_bl.resize(rhs.size2());
+    _block_names[0].resize(rhs.size1());
+    _block_names[1].resize(rhs.size2());
+    // mako %endif
     _assign_impl(rhs);
     return *this;
    }

--- a/triqs/gfs/block/expr.hpp
+++ b/triqs/gfs/block/expr.hpp
@@ -34,6 +34,8 @@ namespace gfs {
    using target_t = void;
    S s;
    int size() const { return -1; }
+   int size1() const { return -1; }
+   int size2() const { return -1; }
    template <typename T> scalar_wrap(T &&x) : s(std::forward<T>(x)) {}
    template <typename KeyType> S operator[](KeyType &&key) const { return s; }
    template <typename... Args> inline S operator()(Args &&... args) const { return s; }
@@ -67,7 +69,9 @@ namespace gfs {
   template <typename LL, typename RR> bgf_expr(LL &&l_, RR &&r_) : l(std::forward<LL>(l_)), r(std::forward<RR>(r_)) {}
 
   auto size() const { return std::max(l.size(), r.size()); }
-  
+  auto size1() const { return std::max(l.size1(), r.size1()); }
+  auto size2() const { return std::max(l.size2(), r.size2()); }
+
   auto block_names() const { return l.block_names(); }
 
   template <typename K> decltype(auto) operator[](K &&key) const {

--- a/triqs/gfs/block/mapped_functions.hxx
+++ b/triqs/gfs/block/mapped_functions.hxx
@@ -47,6 +47,26 @@ namespace triqs {
       return map_block_gf(l, g);
     }
 
+    template <typename M, typename T> auto inverse(block2_gf<M, T> &g) {
+      auto l = [](auto &&x) { return inverse(x); };
+      return map_block_gf(l, g);
+    }
+
+    template <typename M, typename T> auto inverse(block2_gf<M, T> const &g) {
+      auto l = [](auto &&x) { return inverse(x); };
+      return map_block_gf(l, g);
+    }
+
+    template <typename M, typename T> auto inverse(block2_gf_view<M, T> g) {
+      auto l = [](auto &&x) { return inverse(x); };
+      return map_block_gf(l, g);
+    }
+
+    template <typename M, typename T> auto inverse(block2_gf_const_view<M, T> g) {
+      auto l = [](auto &&x) { return inverse(x); };
+      return map_block_gf(l, g);
+    }
+
     template <typename M, typename T> auto reinterpret_scalar_valued_gf_as_matrix_valued(block_gf<M, T> &g) {
       auto l = [](auto &&x) { return reinterpret_scalar_valued_gf_as_matrix_valued(x); };
       return map_block_gf(l, g);
@@ -63,6 +83,26 @@ namespace triqs {
     }
 
     template <typename M, typename T> auto reinterpret_scalar_valued_gf_as_matrix_valued(block_gf_const_view<M, T> g) {
+      auto l = [](auto &&x) { return reinterpret_scalar_valued_gf_as_matrix_valued(x); };
+      return map_block_gf(l, g);
+    }
+
+    template <typename M, typename T> auto reinterpret_scalar_valued_gf_as_matrix_valued(block2_gf<M, T> &g) {
+      auto l = [](auto &&x) { return reinterpret_scalar_valued_gf_as_matrix_valued(x); };
+      return map_block_gf(l, g);
+    }
+
+    template <typename M, typename T> auto reinterpret_scalar_valued_gf_as_matrix_valued(block2_gf<M, T> const &g) {
+      auto l = [](auto &&x) { return reinterpret_scalar_valued_gf_as_matrix_valued(x); };
+      return map_block_gf(l, g);
+    }
+
+    template <typename M, typename T> auto reinterpret_scalar_valued_gf_as_matrix_valued(block2_gf_view<M, T> g) {
+      auto l = [](auto &&x) { return reinterpret_scalar_valued_gf_as_matrix_valued(x); };
+      return map_block_gf(l, g);
+    }
+
+    template <typename M, typename T> auto reinterpret_scalar_valued_gf_as_matrix_valued(block2_gf_const_view<M, T> g) {
       auto l = [](auto &&x) { return reinterpret_scalar_valued_gf_as_matrix_valued(x); };
       return map_block_gf(l, g);
     }

--- a/triqs/gfs/block/mapped_functions.mako.hpp
+++ b/triqs/gfs/block/mapped_functions.mako.hpp
@@ -24,16 +24,16 @@
 namespace triqs {
 namespace gfs {
 
- //mako %for FntToMap in ['inverse', 'reinterpret_scalar_valued_gf_as_matrix_valued'] : 
+ //mako %for FntToMap in ['inverse', 'reinterpret_scalar_valued_gf_as_matrix_valued'] :
 
- //mako %for BGF in ['block_gf<M,T> &' , 'block_gf<M,T> const &' , 'block_gf_view<M,T>', 'block_gf_const_view<M,T>'] : 
-
- template <typename M, typename T> auto MAKO_FntToMap(MAKO_BGF g) { 
+ //mako %for BGF in ['block_gf<M,T> &' , 'block_gf<M,T> const &' , 'block_gf_view<M,T>', 'block_gf_const_view<M,T>', 'block2_gf<M,T> &' , 'block2_gf<M,T> const &' , 'block2_gf_view<M,T>', 'block2_gf_const_view<M,T>'] :
+ template <typename M, typename T> auto MAKO_FntToMap(MAKO_BGF g) {
    auto l= [](auto&&x) { return MAKO_FntToMap(x);};
-   return map_block_gf(l, g);   
+   return map_block_gf(l, g);
  }
 
  //mako %endfor
+
  //mako %endfor
 
 }

--- a/triqs/gfs/gf/gf.hxx
+++ b/triqs/gfs/gf/gf.hxx
@@ -233,7 +233,7 @@ namespace triqs {
       gf() {} // all arrays of zero size (empty)
 
       /// Copy constructor
-      gf(gf const &x) : _mesh(x.mesh()), _data(x.data()), _zero(x._zero), _singularity(x.singularity()), _indices(x.indices()) {}
+      gf(gf const &x) = default;
       /// Move constructor
       gf(gf &&) = default;
 
@@ -297,9 +297,9 @@ namespace triqs {
       /// ---------------  Operator = --------------------
 
       /// Copy assignment
-      gf &operator=(gf const &rhs) { return *this = gf(rhs); } // use move =
-      //
-      gf &operator=(gf &rhs) { return *this = gf(rhs); } // use move =
+      gf &operator=(gf &rhs) = default;
+      gf &operator=(gf const &rhs) = default;
+
       /// Move assignment
       gf &operator=(gf &&rhs) noexcept {
         this->swap_impl(rhs);
@@ -891,7 +891,7 @@ namespace triqs {
 
       public:
       /// Copy constructor
-      gf_view(gf_view const &x) : _mesh(x.mesh()), _data(x.data()), _zero(x._zero), _singularity(x.singularity()), _indices(x.indices()) {}
+      gf_view(gf_view const &x) = default;
       /// Move constructor
       gf_view(gf_view &&) = default;
 
@@ -1525,8 +1525,7 @@ namespace triqs {
 
       public:
       /// Copy constructor
-      gf_const_view(gf_const_view const &x)
-         : _mesh(x.mesh()), _data(x.data()), _zero(x._zero), _singularity(x.singularity()), _indices(x.indices()) {}
+      gf_const_view(gf_const_view const &x) = default;
       /// Move constructor
       gf_const_view(gf_const_view &&) = default;
 

--- a/triqs/gfs/gf/gf.mako.hpp
+++ b/triqs/gfs/gf/gf.mako.hpp
@@ -254,8 +254,7 @@ namespace triqs {
    // mako %endif
 
    /// Copy constructor
-   MAKO_GF(MAKO_GF const &x)
-      : _mesh(x.mesh()), _data(x.data()), _zero(x._zero), _singularity(x.singularity()), _indices(x.indices()) {} 
+   MAKO_GF(MAKO_GF const &x) = default;
    /// Move constructor
    MAKO_GF(MAKO_GF &&) = default;
 
@@ -326,9 +325,9 @@ namespace triqs {
    /// ---------------  Operator = --------------------
 
    /// Copy assignment
-   gf &operator=(gf const &rhs) { return *this = gf(rhs); } // use move =
-   //
-   gf &operator=(gf &rhs) { return *this = gf(rhs); } // use move =
+   gf &operator=(gf &rhs) = default;
+   gf &operator=(gf const &rhs) = default;
+
    /// Move assignment
    gf &operator=(gf &&rhs) noexcept {
     this->swap_impl(rhs);


### PR DESCRIPTION
@parcollet Please review changes in mako files below

-The general assignment operator of block2gf was not properly resizing ```_glist``` and ```_blocknames```.

-The general assignment operator of block2gf was preferred over copy assignment operator due to const qualifier

-Some cleaning in gf and blockgf mako file