### PR TITLE
Bad bug in TightBinding, checking hopping matrix dims, not active

### DIFF
--- a/test/pytriqs/base/CMakeLists.txt
+++ b/test/pytriqs/base/CMakeLists.txt
@@ -35,6 +35,7 @@ add_python_test(gf_transpose)
 
 add_python_test(issue460)
 add_python_test(issue437)
+add_python_test(bug_tight_binding)
 
 # Add evaluator for g
 add_python_test(gf_eval)

--- a/test/pytriqs/base/bug_tight_binding.py
+++ b/test/pytriqs/base/bug_tight_binding.py
@@ -1,0 +1,23 @@
+
+""" Test the hopping matrix size control in the tight binding class. """
+
+import numpy as np
+from pytriqs.lattice.tight_binding import TightBinding, BravaisLattice
+
+number_of_orbitals = 4
+
+bl = BravaisLattice(
+    units = [(1,0,0),(0,1,0)],
+    orbital_positions = [(0,0,0)]*number_of_orbitals)
+
+# Hopping matrix with wrong size!!!!
+hopping = { (0, 0): np.eye(2) }
+
+got_dimension_error = False
+
+try:
+    tb = TightBinding(bl, hopping)
+except:
+    got_dimension_error = True
+
+assert( got_dimension_error )


### PR DESCRIPTION
I spent a few hours trying to understand why my dmft loop crashed about 20% of the times the script was run.

It turns out I was passing hopping matrices with incorrect dimensions to `TightBinding` and for some reason it is accepted without any complaints. This causes the lattice Green's function computed by `Sumk` to have uninitialized data, hence the intermittent crashing behavior.

Someone was proactive and added checks for the dimensions on the c++ side but this seems for some reason not be active. 

This pull request is a test that fails when `TightBinding` accepts incorrect hopping dimensions without throwing.

Please merge.