### PR TITLE
[test] gf handling of scalar and matrices test

### DIFF
--- a/test/pytriqs/base/CMakeLists.txt
+++ b/test/pytriqs/base/CMakeLists.txt
@@ -36,6 +36,8 @@ add_python_test(gf_transpose)
 add_python_test(issue460)
 add_python_test(issue437)
 
+add_python_test(bug_gf_scalar_matrix)
+
 # Add evaluator for g
 add_python_test(gf_eval)
 

--- a/test/pytriqs/base/bug_gf_scalar_matrix.py
+++ b/test/pytriqs/base/bug_gf_scalar_matrix.py
@@ -1,0 +1,17 @@
+
+import numpy as np
+from pytriqs.gf import GfImFreq
+from pytriqs.utility.comparison_tests import assert_gfs_are_close
+
+scalar = 1.0
+matrix = np.random.random((2, 2))
+
+A = GfImFreq(name='up', statistic='Fermion', beta=1.0, n_points=400, indices=[0, 1])
+B = A.copy()
+
+A << scalar
+A << A + matrix
+
+B << scalar + matrix
+
+assert_gfs_are_close(A, B)


### PR DESCRIPTION
There is an inconsistency in the API how Green's functions are modified when scalars on the RHS of the `<<` operator. Here is a small test case that breaks on this inconsistent treatment.

In short for a matrix valued Green's function the operations
```python
A << scalar + matrix
```
and
```python
A << scalar
A << A + matrix
```
gives different results.

This pull request contains a test that breaks when these two operations are not the same.

Please merge.

The reason the two operations are different is due to that the Gf implicitly interprets a scalar as a scalar times the unit matrix. This does not work when using `numpy` in the right hand side as in the first case, where numpy`s broadcasting rules are used to evaluate the "scalar + matrix" expression element wise.

I would suggest that the special treatment of a scalar should be removed.

Best, Hugo