### PR TITLE
[clef] bug in imtime bubble

### DIFF
--- a/test/triqs/gfs/gf_bubble.cpp
+++ b/test/triqs/gfs/gf_bubble.cpp
@@ -1,0 +1,61 @@
+
+// Bug # : Clef expression for the bubble diagram in imaginary time
+
+#include <triqs/test_tools/gfs.hpp>
+#include <triqs/gfs.hpp>
+
+namespace h5 = triqs::h5;
+using namespace triqs::gfs;
+using namespace triqs::clef;
+using namespace triqs::arrays;
+
+int ntau    = 5;
+double beta = 1.2345;
+
+placeholder_prime<0> tau;
+
+auto g = gf<imtime, scalar_valued>{{beta, Fermion, ntau}};
+auto chi_ref = gf<imtime, scalar_valued>{{beta, Boson, ntau}};
+auto chi = gf<imtime, scalar_valued>{{beta, Boson, ntau}};
+
+// ----------------------------------------------------
+
+TEST(Gf, bubble) {
+
+  for (auto tau : g.mesh()) g[tau] = 1.;
+
+  // this should give g(0<tau<beta) * g(-beta<tau<0) = (+1) * (-1) = -1
+  
+  chi(tau) << g(tau) * g(-tau); // This is not working correctly on the boundaries!
+
+  for (auto tau : chi_ref.mesh()) chi_ref[tau] = -1.;
+
+  EXPECT_ARRAY_NEAR(chi.data(), chi_ref.data());
+}
+
+// ----------------------------------------------------
+
+TEST(Gf, bubble_boundary_hack) {
+
+  for (auto tau : g.mesh()) g[tau] = 1.;
+
+  // this should give g(0<tau<beta) * g(-beta<tau<0) = (+1) * (-1) = -1
+
+  double eps = 1e-9;
+  
+  for( auto tau : g.mesh() ) {
+    double tau_num = tau;
+
+    // -- Hack shifting points on the boundary inside [0, beta]
+    if( abs(tau_num - beta) < eps ) tau_num -= eps;
+    if( abs(tau_num) < eps ) tau_num += eps;
+    
+    chi[tau] = g(tau_num) * g(-tau_num); 
+  }
+  
+  for (auto tau : chi_ref.mesh()) chi_ref[tau] = -1.;
+
+  EXPECT_ARRAY_NEAR(chi.data(), chi_ref.data());
+}
+
+MAKE_MAIN;


### PR DESCRIPTION
Dear All,

This is a failing test for the bubble diagram computed in imaginary time `chi(tau) = g(tau) * g(-tau)`. When using `clef` to compute this product the end points of the imaginary time interval are wrong, since the evaluator for `gf<imtime>` defines evaluation at `tau=beta` as evaluation at `tau=0^-`.

After the failing test there is an example `hack` implementation that shifts the time when it is on the boundary and gives the expected correct result.

To fix this we would have to modify how the `imtime` evaluator works on the boundaries.

Is anyone depending on the current behavior at the boundaries?

Please merge this test so that we will remember fixing this in one way or another.

Best, Hugo