### PR TITLE
[many_body_operator] Replace gf_struct_t by vector<pair<...>> Fix #342

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -28,6 +28,24 @@ API changes
 
 * g.indices -> g.indices[0]
 
+* Change gf_struct_t in fundamental_operator_set.hpp from
+	```
+	std::map<std::string,std::vector<std::variant<int, std::string>>>
+	```
+  to
+	```
+	std::vector<std::pair<std::string,std::vector<std::variant<int, std::string>>>>
+	```
+
+  to properly maintain the order of blocks.
+  In any Python script, replace e.g.
+	```
+	gf_struct = { "up" : [0, 1], "dn" : [0, 1] }
+	```
+  by
+	```
+	gf_struct = [ ["up", [0, 1]], ["dn" : [0, 1]] ]
+	```
 
 Deprecation
 

--- a/pytriqs/operators/util/op_struct.py
+++ b/pytriqs/operators/util/op_struct.py
@@ -55,17 +55,17 @@ def set_operator_structure(spin_names,orb_names,off_diag):
 
     Returns
     -------
-    op_struct : dict
-                The structure of the operators {block:[inner]}.
+    op_struct : list
+                The structure of the operators [block:[inner], ... ].
 
     """
 
-    op_struct = {}
+    op_struct = []
     if off_diag: # outer blocks are spin blocks
         for sn in spin_names:
-            op_struct[sn] = [on for on in orb_names]
+            op_struct.append([sn, [on for on in orb_names]])
     else: # outer blocks are spin-orbital blocks
         for sn, on in product(spin_names,orb_names):
-            op_struct[sn+'_%s'%on] = [0]
+            op_struct.append([sn+'_%s'%on, [0]])
 
     return op_struct

--- a/test/pytriqs/atom_diag/atom_diag_python.py
+++ b/test/pytriqs/atom_diag/atom_diag_python.py
@@ -39,7 +39,7 @@ def make_hamiltonian(mu, U, J, b, t):
 ad_r = AtomDiag(make_hamiltonian(0.4, 1.0, 0.3, 0.03, 0.2), fops)
 ad_c = AtomDiag(make_hamiltonian(0.4, 1.0, 0.3, 0.03, 0.2j), fops)
 
-gf_struct = {'dn':[0,1,2],'up':[0,1,2]}
+gf_struct = ['dn':[0,1,2],'up':[0,1,2]]
 beta = 10
 
 # GF (real)

--- a/test/pytriqs/atom_diag/atom_diag_python.py
+++ b/test/pytriqs/atom_diag/atom_diag_python.py
@@ -39,7 +39,7 @@ def make_hamiltonian(mu, U, J, b, t):
 ad_r = AtomDiag(make_hamiltonian(0.4, 1.0, 0.3, 0.03, 0.2), fops)
 ad_c = AtomDiag(make_hamiltonian(0.4, 1.0, 0.3, 0.03, 0.2j), fops)
 
-gf_struct = ['dn':[0,1,2],'up':[0,1,2]]
+gf_struct = [['dn',[0,1,2]],['up',[0,1,2]]]
 beta = 10
 
 # GF (real)

--- a/test/triqs/atom_diag/atom_diag_complex.cpp
+++ b/test/triqs/atom_diag/atom_diag_complex.cpp
@@ -318,7 +318,7 @@ TEST(atom_diag_complex, Functions) {
  EXPECT_ARRAY_NEAR(st_ref, st);
 
  // GF
- gf_struct_t gf_struct = {{"up",{0,1,2}},{"dn",{0,1,2}}};
+ gf_struct_t gf_struct = {{"dn",{0,1,2}},{"up",{0,1,2}}};
 
  int n_tau = 1000;
  int n_iw = 400;

--- a/test/triqs/atom_diag/atom_diag_real.cpp
+++ b/test/triqs/atom_diag/atom_diag_real.cpp
@@ -318,7 +318,7 @@ TEST(atom_diag_real, Functions) {
  EXPECT_ARRAY_NEAR(st_ref, st);
 
  // GF
- gf_struct_t gf_struct = {{"up",{0,1,2}},{"dn",{0,1,2}}};
+ gf_struct_t gf_struct = {{"dn",{0,1,2}},{"up",{0,1,2}}};
 
  int n_tau = 1000;
  int n_iw = 400;

--- a/test/triqs/h5/h5_io.cpp
+++ b/test/triqs/h5/h5_io.cpp
@@ -25,6 +25,35 @@
 
 namespace h5 = triqs::h5;
 
+TEST(H5Io, Pair) {
+
+  // write
+  std::pair<std::string, int> m                  = {"a", 1};
+  std::pair<std::string, std::vector<double>> mv = {"a", {1.0, 2.0}};
+
+  {
+    h5::file file{"test_pair.h5", H5F_ACC_TRUNC};
+    h5::group grp{file};
+    h5_write(grp, "pair_int_str", m);
+    h5_write(grp, "pair_str_vec", mv);
+  }
+
+  // read
+  std::pair<std::string, int> mm;
+  std::pair<std::string, std::vector<double>> mmv;
+
+  {
+    h5::file file{"test_pair.h5", H5F_ACC_RDONLY};
+    h5::group grp{file};
+    h5_read(grp, "pair_int_str", mm);
+    h5_read(grp, "pair_str_vec", mmv);
+  }
+
+  // compare
+  EXPECT_EQ(m, mm);
+  EXPECT_EQ(mv, mmv);
+}
+
 TEST(H5Io, Tuple) {
 
   // write

--- a/triqs/h5.hpp
+++ b/triqs/h5.hpp
@@ -27,6 +27,7 @@
 #include "./h5/string.hpp"
 #include "./h5/vector.hpp"
 #include "./h5/map.hpp"
+#include "./h5/pair.hpp"
 #include "./h5/tuple.hpp"
 #include "./h5/optional.hpp"
 #include "./h5/generic.hpp"

--- a/triqs/h5/pair.hpp
+++ b/triqs/h5/pair.hpp
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ *
+ * TRIQS: a Toolbox for Research in Interacting Quantum Systems
+ *
+ * Copyright (C) 2018 by N. Wentzell, O. Parcollet
+ *
+ * TRIQS is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * TRIQS is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * TRIQS. If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+#pragma once
+#include "group.hpp"
+#include "string.hpp"
+#include <utility>
+
+namespace triqs::h5 {
+
+  template <typename T1, typename T2> struct hdf5_scheme_impl<std::pair<T1, T2>> {
+    static std::string invoke() { return "PythonTupleWrap"; }
+  };
+
+  /**
+   * Write Pair of T1 and T2 as a subgroup with numbers
+   */
+  template <typename T1, typename T2> void h5_write(group f, std::string const &name, std::pair<T1, T2> const &p) {
+    auto gr = f.create_group(name);
+    gr.write_hdf5_scheme(p);
+    h5_write(gr, "0", p.first);
+    h5_write(gr, "1", p.second);
+  }
+
+  /**
+   * Read Pair of T1 and T2 from group
+   */
+  template <typename T1, typename T2> void h5_read(group f, std::string const &name, std::pair<T1, T2> &p) {
+    auto gr = f.open_group(name);
+    if (gr.get_all_subgroup_dataset_names().size() != 2)
+      TRIQS_RUNTIME_ERROR << "ERROR in std::pair h5_read: Incompatible number of group elements";
+    h5_read(gr, "0", p.first);
+    h5_read(gr, "1", p.second);
+  }
+} // namespace triqs::h5

--- a/triqs/hilbert_space/fundamental_operator_set.hpp
+++ b/triqs/hilbert_space/fundamental_operator_set.hpp
@@ -48,7 +48,7 @@ namespace triqs {
 namespace hilbert_space {
 
 /// Structure of the Green's function
-using gf_struct_t = std::map<std::string,std::vector<std::variant<int, std::string>>>;
+using gf_struct_t = std::vector<std::pair<std::string,std::vector<std::variant<int, std::string>>>>;
 
 /// This class represents an ordered set of **indices** of the canonical operators (see [[many_body_operator]]) used to build the Fock states.
 /**


### PR DESCRIPTION
- Replace gf_struct_t (was `map<string, vector<variant<int, string>>>`)
  by `vector<pair<string, vector<variant<int, string>>>>` in order to
  maintain block-order
- Adjust set_operator_structure correspondingly
- Adjust tests
- Add to Changelog