### PR TITLE
Dev bz mesh h5 bug

### DIFF
--- a/triqs/lattice/cluster_mesh.hpp
+++ b/triqs/lattice/cluster_mesh.hpp
@@ -163,7 +163,10 @@ namespace triqs {
       }
 
       /// Mesh comparison
-      bool operator==(cluster_mesh const &M) const { return ((dims == M.dims)); }
+      bool operator==(cluster_mesh const &M) const {
+	return ( (dims == M.dims) && (units == M.units) &&
+		 (periodization_matrix == M.periodization_matrix) );
+      }
       bool operator!=(cluster_mesh const &M) const { return !(operator==(M)); }
 
       /// Reduce point modulo to the lattice.
@@ -196,7 +199,7 @@ namespace triqs {
         h5::group gr = fg.open_group(subgroup_name);
         gr.assert_hdf5_scheme_as_string(_type, true);
         auto units                = h5::h5_read<matrix<double>>(gr, "units");
-        auto periodization_matrix = h5::h5_read<matrix<double>>(gr, "periodization_matrix");
+        auto periodization_matrix = h5::h5_read<matrix<int>>(gr, "periodization_matrix");
         m                         = cluster_mesh(units, periodization_matrix);
       }
 
@@ -211,7 +214,7 @@ namespace triqs {
         ar &s1;
       }
 
-      friend std::ostream &operator<<(std::ostream &sout, cluster_mesh const &m) { return sout << "cluster_mesh of size " << m.dims; }
+      friend std::ostream &operator<<(std::ostream &sout, cluster_mesh const &m) { return sout << "cluster_mesh of size " << m.dims << "\n units = " << m.units << "\n periodization_matrix = " << m.periodization_matrix << "\n"; }
     };
 
     // ---------------------------------------------------------------------------

--- a/triqs/lattice/gf_mesh_brillouin_zone.hpp
+++ b/triqs/lattice/gf_mesh_brillouin_zone.hpp
@@ -131,7 +131,7 @@ namespace triqs {
       // -------------------- print -------------------
 
       friend std::ostream &operator<<(std::ostream &sout, gf_mesh const &m) {
-        return sout << "Brillouin Zone Mesh  with linear dimensions " << m.dims << ", Domain: " << m.domain();
+        return sout << "Brillouin Zone Mesh with linear dimensions " << m.dims << ", Domain: " << m.domain();
       }
 
       // -------------- HDF5  --------------------------
@@ -140,9 +140,13 @@ namespace triqs {
 
       friend void h5_write(h5::group fg, std::string const &subgroup_name, gf_mesh const &m) {
         h5_write_impl(fg, subgroup_name, m, "MeshBrillouinZone");
+        h5::group gr = fg.open_group(subgroup_name);
+        h5_write(gr, "bz", m.bz);
       }
 
-      friend void h5_read(h5::group fg, std::string const &subgroup_name, gf_mesh &m) { h5_read_impl(fg, subgroup_name, m, "MeshBrillouinZone"); }
+      friend void h5_read(h5::group fg, std::string const &subgroup_name, gf_mesh &m) { h5_read_impl(fg, subgroup_name, m, "MeshBrillouinZone");
+        h5::group gr = fg.open_group(subgroup_name);
+        h5_read(gr, "bz", m.bz);
     };
   } // namespace gfs
 } // namespace triqs

--- a/triqs/lattice/gf_mesh_brillouin_zone.hpp
+++ b/triqs/lattice/gf_mesh_brillouin_zone.hpp
@@ -147,6 +147,7 @@ namespace triqs {
       friend void h5_read(h5::group fg, std::string const &subgroup_name, gf_mesh &m) { h5_read_impl(fg, subgroup_name, m, "MeshBrillouinZone");
         h5::group gr = fg.open_group(subgroup_name);
         h5_read(gr, "bz", m.bz);
+      }
     };
   } // namespace gfs
 } // namespace triqs


### PR DESCRIPTION
The `BrillouinZoneMesh` does not write and read its domain `BrillouinZone` to hdf5 so whenever it is read from disk the reciprocal basis vectors are initialized to unity.

This patch adds read/write steps in the h5_read/h5_write methods for the domain.

Please merge.
