### PR TITLE
Added missing import of h5py.highlevel

### DIFF
--- a/pytriqs/archive/hdf_archive_basic_layer_h5py.py
+++ b/pytriqs/archive/hdf_archive_basic_layer_h5py.py
@@ -21,7 +21,7 @@
 ################################################################################
 
 # h5py
-import numpy,string,h5py
+import numpy,string,h5py,h5py.highlevel
 class HDFArchiveGroupBasicLayer :
     _class_version = 1
 


### PR DESCRIPTION
Backport from 2.x to 1.4.x.