### PR TITLE
[test] analytic tail coeff

### DIFF
--- a/test/pytriqs/base/CMakeLists.txt
+++ b/test/pytriqs/base/CMakeLists.txt
@@ -21,6 +21,7 @@ add_python_test(gf_base_op)
 add_python_test(gf_fourier)
 add_python_test(gf_slicing)
 add_python_test(g_tau_mul_py)
+add_python_test(high_frequency_coeffs)
 
 # a simple dos on square lattice
 add_python_test(dos)

--- a/test/pytriqs/base/high_frequency_coeffs.py
+++ b/test/pytriqs/base/high_frequency_coeffs.py
@@ -1,0 +1,41 @@
+""" Tail fit of the simplest Green's function imaginable
+
+G(i\omega_n) = 1/(i\omega_n - 1)
+
+which has the high frequency expansion
+
+G(i\omega_n) = \sum_{k=1}^\infty 1/(i\omega_n)^k
+
+i.e. its high frequency coefficients are equal to unity. """
+
+import numpy as np
+
+from pytriqs.gf import Gf, MeshImFreq, inverse, iOmega_n
+
+def get_error_per_order(beta, n_w):
+
+    mesh = MeshImFreq(beta, 'Fermion', n_w)
+    G = Gf(mesh=mesh, target_shape=[1, 1])
+
+    G << inverse( iOmega_n - 1.0 )
+    tail, err = G.fit_tail()
+
+    tail_ref = np.array([[ [0.] + [1.]*(tail.shape[0]-1) ]]).T
+
+    tail_err = np.abs(tail_ref - tail)
+
+    print 'beta =', beta
+    print 'n_w =', n_w
+    print 'error in coeffs ='
+    print tail_err[:, :, 0]
+
+    np.testing.assert_array_almost_equal(tail_err, np.zeros_like(tail_err))
+    
+# -----
+
+n_w = 1000
+beta_vec = [100., 10., 1., 0.1]
+
+for beta in beta_vec:
+    get_error_per_order(beta, n_w)
+


### PR DESCRIPTION
Dear all,

Here is a small test with a sanity check for the tail fit. It compares the tail fit high frequency coefficients with the exact coefficients on a simple Green's function 

G(iw) = 1/(iw - 1) 

with known analytic high frequency moments. Its high frequency expansion is simply G(iw) = \sum_k 1/(iw)^k.

I think that fitting the tail of this function should be a feature of the tail fit.

Please merge.