### PR TITLE
[atom_diag] block matrix repr for operators

### DIFF
--- a/test/triqs/atom_diag/atom_diag_op_matrix.cpp
+++ b/test/triqs/atom_diag/atom_diag_op_matrix.cpp
@@ -62,17 +62,33 @@ TEST(atom_diag, op_matrix) {
   auto ad = triqs::atom_diag::atom_diag<false>(H, fops);
   std::cout << "Found " << ad.n_subspaces() << " subspaces." << std::endl;
 
+  EXPECT_EQ(ad.n_subspaces(), 4);
+
   // -----------------------------------------------------------------------------
 
-  std::cout << "n(up,0) = \n" << ad.get_op_mat( n("up", 0) ) << "\n";
-  std::cout << "n(up,0) = \n" << ad.get_op_mat( n("dn", 0) ) << "\n";
-  
-  std::cout << "S_z = \n" << ad.get_op_mat( 0.5 * (n("up", 0) - n("dn", 0)) ) << "\n";
-  std::cout << "docc = \n" << ad.get_op_mat( n("up", 0) * n("dn", 0) ) << "\n";
+  {
+    auto op = ad.get_op_mat(n("up", 0));
 
-  std::cout << "c(up,0) = \n" << ad.get_op_mat( c("up", 0) ) << "\n";
-  std::cout << "cdag(up,0) = \n" << ad.get_op_mat( c_dag("up", 0) ) << "\n";
-  
+    std::cout << "op =\n" << op << "\n";
+
+    EXPECT_EQ(op.n_blocks(), 4);
+    for (auto b : range(op.n_blocks())) {
+      if (op.connection(b) != -1) EXPECT_EQ(op.block_mat[b], matrix<double>({{1.}}));
+    }
+  }
+
+  // -----------------------------------------------------------------------------
+
+  {
+    auto op = ad.get_op_mat(n("dn", 0));
+
+    std::cout << "op =\n" << op << "\n";
+
+    EXPECT_EQ(op.n_blocks(), 4);
+    for (auto b : range(op.n_blocks())) {
+      if (op.connection(b) != -1) EXPECT_EQ(op.block_mat[b], matrix<double>({{1.}}));
+    }
+  }
 }
 
 MAKE_MAIN;

--- a/test/triqs/atom_diag/atom_diag_op_matrix.cpp
+++ b/test/triqs/atom_diag/atom_diag_op_matrix.cpp
@@ -1,0 +1,78 @@
+// -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+
+#include <triqs/test_tools/gfs.hpp>
+
+#include <triqs/atom_diag/atom_diag.hpp>
+#include <triqs/hilbert_space/fundamental_operator_set.hpp> // gf_struct_t
+using gf_struct_t = triqs::hilbert_space::gf_struct_t;
+
+using namespace triqs::arrays;
+using namespace triqs::hilbert_space;
+using namespace triqs::atom_diag;
+using namespace triqs::operators;
+
+// -----------------------------------------------------------------------------
+
+using h_scalar_t = double;
+
+using linindex_t = std::map<std::pair<int, int>, int>;
+
+using block_index_map_t = std::map<std::variant<int, std::string>, int>;
+
+// -----------------------------------------------------------------------------
+linindex_t make_linear_index(const gf_struct_t &gf_struct, const fundamental_operator_set &fops) {
+  linindex_t linindex;
+  int block_index = 0;
+  for (auto const &bl : gf_struct) {
+    int inner_index = 0;
+    for (auto const &a : bl.second) {
+      linindex[std::make_pair(block_index, inner_index)] = fops[{bl.first, a}];
+      inner_index++;
+    }
+    block_index++;
+  }
+  return linindex;
+}
+
+// -----------------------------------------------------------------------------
+TEST(atom_diag, op_matrix) {
+
+  gf_struct_t gf_struct{{"up", {0}}, {"dn", {0}}};
+  fundamental_operator_set fops(gf_struct);
+  auto linindex = make_linear_index(gf_struct, fops);
+
+  block_index_map_t bidx_map;
+  int bidx = 0;
+  for (auto const &bl : gf_struct) {
+    bidx_map[bl.first] = bidx;
+    bidx++;
+  }
+
+  // -----------------------------------------------------------------------------
+  // atom_diag
+
+  double U  = 1.0;
+  double mu = 0.5 * U;
+
+  many_body_operator_real H;
+  H += -mu * (n("up", 0) + n("dn", 0)) + U * n("up", 0) * n("dn", 0);
+
+  auto ad = triqs::atom_diag::atom_diag<false>(H, fops);
+  std::cout << "Found " << ad.n_subspaces() << " subspaces." << std::endl;
+
+  // -----------------------------------------------------------------------------
+
+  std::cout << "n(up,0) = \n" << ad.get_op_mat( n("up", 0) ) << "\n";
+  std::cout << "n(up,0) = \n" << ad.get_op_mat( n("dn", 0) ) << "\n";
+  
+  std::cout << "S_z = \n" << ad.get_op_mat( 0.5 * (n("up", 0) - n("dn", 0)) ) << "\n";
+  std::cout << "docc = \n" << ad.get_op_mat( n("up", 0) * n("dn", 0) ) << "\n";
+
+  std::cout << "c(up,0) = \n" << ad.get_op_mat( c("up", 0) ) << "\n";
+  std::cout << "cdag(up,0) = \n" << ad.get_op_mat( c_dag("up", 0) ) << "\n";
+  
+}
+
+MAKE_MAIN;

--- a/triqs/atom_diag/atom_diag.hpp
+++ b/triqs/atom_diag/atom_diag.hpp
@@ -51,12 +51,12 @@ namespace triqs {
 
     /// Lightweight exact diagonalization solver
     /**
- * This class is provided as a simple tool to diagonalize Hamiltonians of
- * finite fermionic systems of a moderate size.
- *
- * @tparam Complex Allow the Hamiltonian to be complex.
- * @include triqs/atom_diag/atom_diag.hpp
- */
+     * This class is provided as a simple tool to diagonalize Hamiltonians of
+     * finite fermionic systems of a moderate size.
+     *
+     * @tparam Complex Allow the Hamiltonian to be complex.
+     * @include triqs/atom_diag/atom_diag.hpp
+     */
     template <bool Complex> class atom_diag {
 
       friend struct atom_diag_worker<Complex>;
@@ -97,33 +97,54 @@ namespace triqs {
         }
       };
 
+      /// Block matrix representation for operators
+      struct op_block_mat_t {
+	op_block_mat_t(int n_blocks) : connection(n_blocks), block_mat(n_blocks) { connection(range()) = -1; };
+	array<long, 1> connection;
+	std::vector<matrix_t> block_mat;
+	int n_blocks() const { return block_mat.size(); }
+	friend std::ostream &operator<<(std::ostream &out, op_block_mat_t const & op_mat) {
+	  out << "Operator block matrix:\n"
+	      << " n_blocks = " << op_mat.n_blocks() << "\n";
+	  for( int bidx : range(op_mat.n_blocks()) ) {
+	    auto &m = op_mat.block_mat[bidx];
+	    auto b2 = op_mat.connection(bidx);
+	    out << "Block: "
+		<< "blocks (" << bidx << ", " << b2 << ") "
+		<< "size (" << first_dim(m) << ", " << second_dim(m) << ") "
+	        << op_mat.block_mat[bidx] << "\n";
+	  }
+	  return out;
+	};
+      };
+
       /// Construct in an uninitialized state.
       TRIQS_CPP2PY_IGNORE atom_diag() = default;
 
       /// Reduce a given Hamiltonian to a block-diagonal form and diagonalize it
       /**
-  * This constructor calls the auto-partition procedure, and the QR algorithm
-  * to diagonalize the blocks. The invariant subspaces of the Hamiltonian are
-  * chosen such that all creation and annihilation operators from the provided
-  * fundamental operator set map one subspace to one subspace.
-  *
-  * @param h Hamiltonian operator to be diagonalized.
-  * @param fops Fundamental operator set; Must at least contain all fundamental operators met in `h`.
-  * @note See :ref:`space_partition` for more details on the auto-partition scheme.
-  */
+       * This constructor calls the auto-partition procedure, and the QR algorithm
+       * to diagonalize the blocks. The invariant subspaces of the Hamiltonian are
+       * chosen such that all creation and annihilation operators from the provided
+       * fundamental operator set map one subspace to one subspace.
+       *
+       * @param h Hamiltonian operator to be diagonalized.
+       * @param fops Fundamental operator set; Must at least contain all fundamental operators met in `h`.
+       * @note See :ref:`space_partition` for more details on the auto-partition scheme.
+       */
       atom_diag(many_body_op_t const &h, fundamental_operator_set const &fops);
 
       /// Reduce a given Hamiltonian to a block-diagonal form and diagonalize it
       /**
-  * This constructor uses quantum number operators to partition the Hilbert space into
-  * invariant subspaces, and the QR algorithm to diagonalize the blocks of the Hamiltonian.
-  * The quantum numbers must be chosen such that all creation and annihilation operators from
-  * the provided fundamental operator set map one subspace to one subspace.
-  *
-  * @param h Hamiltonian operator to be diagonalized.
-  * @param fops Fundamental operator set; Must at least contain all fundamental operators met in `h`.
-  * @param qn_vector Vector of quantum number operators.
-  */
+       * This constructor uses quantum number operators to partition the Hilbert space into
+       * invariant subspaces, and the QR algorithm to diagonalize the blocks of the Hamiltonian.
+       * The quantum numbers must be chosen such that all creation and annihilation operators from
+       * the provided fundamental operator set map one subspace to one subspace.
+       *
+       * @param h Hamiltonian operator to be diagonalized.
+       * @param fops Fundamental operator set; Must at least contain all fundamental operators met in `h`.
+       * @param qn_vector Vector of quantum number operators.
+       */
       atom_diag(many_body_op_t const &h, fundamental_operator_set const &fops, std::vector<many_body_op_t> const &qn_vector);
 
       /// The Hamiltonian used at construction
@@ -143,8 +164,8 @@ namespace triqs {
 
       /// The dimension of a subspace
       /**
-  * @param sp_index Index of the invariant subspace.
-  */
+       * @param sp_index Index of the invariant subspace.
+       */
       int get_subspace_dim(int sp_index) const { return eigensystems[sp_index].eigenvalues.size(); }
 
       /// The list of Fock states for each subspace
@@ -163,15 +184,15 @@ namespace triqs {
 
       /// Returns the state index in the full Hilbert space given a subspace index and an inner index
       /**
-  * @param sp_index Index of the invariant subspace.
-  * @param i State index within the subspace.
-  */
+       * @param sp_index Index of the invariant subspace.
+       * @param i State index within the subspace.
+       */
       int flatten_subspace_index(int sp_index, int i) const { return first_eigenstate_of_subspace[sp_index] + i; }
 
       /// Return the range of indices of subspace sp_index
       /**
-  * @param sp_index Index of the invariant subspace.
-  */
+       * @param sp_index Index of the invariant subspace.
+       */
       TRIQS_CPP2PY_IGNORE range index_range_of_subspace(int sp_index) const {
         return range{first_eigenstate_of_subspace[sp_index], first_eigenstate_of_subspace[sp_index] + get_subspace_dim(sp_index)};
       }
@@ -181,21 +202,21 @@ namespace triqs {
 
       /// Get the i-th eigenvalue of subspace sp_index
       /**
-  * @param sp_index Index of the invariant subspace.
-  * @param i State index within the subspace.
-  */
+       * @param sp_index Index of the invariant subspace.
+       * @param i State index within the subspace.
+       */
       double get_eigenvalue(int sp_index, int i) const { return eigensystems[sp_index].eigenvalues[i]; }
 
       /// A vector of all the energies, grouped by subspace
       /**
-  * @return result[sp_index][i] is the energy.
-  */
+       * @return result[sp_index][i] is the energy.
+       */
       std::vector<std::vector<double>> get_energies() const;
 
       /// A vector of all the quantum numbers, grouped by subspace
       /**
-  * @return result[sp_index][qn_index] is the qunatum number value.
-  */
+       * @return result[sp_index][qn_index] is the qunatum number value.
+       */
       std::vector<std::vector<quantum_number_t>> const &get_quantum_numbers() const { return quantum_numbers; }
 
       /// Ground state energy (i.e. min of all subspaces)
@@ -206,42 +227,51 @@ namespace triqs {
 
       /// Returns the vacuum state as a vector in the full Hilbert space
       /**
-  * This vector is written in the eigenbasis of the Hamiltonian.
- */
+       * This vector is written in the eigenbasis of the Hamiltonian.
+       */
       full_hilbert_space_state_t const &get_vacuum_state() const { return vacuum; }
 
       /// Subspace-to-subspace connections for fundamental operator :math:`C`
       /**
-  * @param op_linear_index The linear index (i.e. number) of the annihilation operator, as defined by the fundamental operator set.
-  * @param sp_index The index of the initial subspace.
-  * @return The index of the final subspace.
-  */
+       * @param op_linear_index The linear index (i.e. number) of the annihilation operator, as defined by the fundamental operator set.
+       * @param sp_index The index of the initial subspace.
+       * @return The index of the final subspace.
+       */
       long c_connection(int op_linear_index, int sp_index) const { return annihilation_connection(op_linear_index, sp_index); }
 
       /// Subspace-to-subspace connections for fundamental operator :math:`C^\dagger`
       /** *
-  * @param op_linear_index The linear index (i.e. number) of the creation operator, as defined by the fundamental operator set.
-  * @param sp_index The index of the initial subspace.
-  * @return The index of the final subspace.
-  */
+       * @param op_linear_index The linear index (i.e. number) of the creation operator, as defined by the fundamental operator set.
+       * @param sp_index The index of the initial subspace.
+       * @return The index of the final subspace.
+       */
       long cdag_connection(int op_linear_index, int sp_index) const { return creation_connection(op_linear_index, sp_index); }
 
       /// Matrix block for fundamental operator :math:`C`
       /**
-  * @param op_linear_index The linear index (i.e. number) of the annihilation operator, as defined by the fundamental operator set.
-  * @param sp_index The index of the initial subspace.
-  * @return The index of the final subspace.
-  */
+       * @param op_linear_index The linear index (i.e. number) of the annihilation operator, as defined by the fundamental operator set.
+       * @param sp_index The index of the initial subspace.
+       * @return The index of the final subspace.
+       */
       matrix_t const &c_matrix(int op_linear_index, int sp_index) const { return c_matrices[op_linear_index][sp_index]; }
 
       /// Matrix block for fundamental operator :math:`C^\dagger`
       /**
-  *
-  * @param op_linear_index The linear index (i.e. number) of the creation operator, as defined by the fundamental operator set.
-  * @param sp_index The index of the initial subspace.
-  * @return The index of the final subspace.
-  */
+       *
+       * @param op_linear_index The linear index (i.e. number) of the creation operator, as defined by the fundamental operator set.
+       * @param sp_index The index of the initial subspace.
+       * @return The index of the final subspace.
+       */
       matrix_t const &cdag_matrix(int op_linear_index, int sp_index) const { return cdag_matrices[op_linear_index][sp_index]; }
+
+
+      /// Get block matrix representation for general operator
+      /**
+       * @param op Many body operator
+       * @return The block matrix representation of the operator (in the Hamiltonian eigen basis)
+       */
+      op_block_mat_t get_op_mat(many_body_op_t const &op) const;
+      
 
       private:
       /// ------------------  DATA  -----------------
@@ -264,6 +294,7 @@ namespace triqs {
       std::vector<int> first_eigenstate_of_subspace; // Index of the first eigenstate of each subspace
       void fill_first_eigenstate_of_subspace();
       void compute_vacuum();
+      std::pair<int, matrix_t> get_matrix_element_of_monomial(operators::monomial_t const &op_vec, int B) const;
 
       /* Friend declarations of a template class are a bit ugly */
       friend std::ostream &operator<<<Complex>(std::ostream &os, atom_diag const &ss);

--- a/triqs/atom_diag/atom_diag.hpp
+++ b/triqs/atom_diag/atom_diag.hpp
@@ -3,6 +3,8 @@
  * TRIQS: a Toolbox for Research in Interacting Quantum Systems
  *
  * Copyright (C) 2016, P. Seth, I. Krivenko, M. Ferrero and O. Parcollet
+ * Copyright (C) 2018, The Simons Foundation
+ * Author: H. U.R. Strand
  *
  * TRIQS is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software
@@ -269,6 +271,8 @@ namespace triqs {
       /**
        * @param op Many body operator
        * @return The block matrix representation of the operator (in the Hamiltonian eigen basis)
+       *
+       * Throws, in case the provided operator does not respect the block symmetries used in the diagonalization.
        */
       op_block_mat_t get_op_mat(many_body_op_t const &op) const;
       

--- a/triqs/atom_diag/impl/atom_diag.cpp
+++ b/triqs/atom_diag/impl/atom_diag.cpp
@@ -79,6 +79,57 @@ namespace triqs {
       return R;
     }
 
+    // -----------------------------------------------------------------
+    // Given a monomial (ccccc), and a subspace B, returns
+    //   - the subspace connected by ccccc from B
+    //   - the corresponding matrix (not necessarily square)
+
+    template <bool Complex>
+    auto atom_diag<Complex>::get_matrix_element_of_monomial(operators::monomial_t const &op_vec, int B) const
+      -> std::pair<int, matrix_t> {
+
+      auto m = triqs::arrays::make_unit_matrix<scalar_t>(get_subspace_dim(B));
+
+      auto const &fops = get_fops();
+      for (int i = op_vec.size() - 1; i >= 0; --i) {
+        int ind = fops[op_vec[i].indices];
+        int Bp  = (op_vec[i].dagger ? cdag_connection(ind, B) : c_connection(ind, B));
+        if (Bp == -1) return {-1, std::move(m)};
+        m = (op_vec[i].dagger ? cdag_matrix(ind, B) : c_matrix(ind, B)) * m;
+        B = Bp;
+      }
+      return {B, std::move(m)};
+    }
+
+    // -----------------------------------------------------------------
+
+    ATOM_DIAG_METHOD(op_block_mat_t, get_op_mat(many_body_op_t const &op) const) {
+      op_block_mat_t op_mat(n_subspaces());
+
+      for(int b : range(n_subspaces()) ) {
+	for( auto const &term : op ) {
+	  auto b_mat = get_matrix_element_of_monomial(term.monomial, b);
+	  if(b_mat.first == -1) continue;
+	  
+	  if( op_mat.connection(b) == -1 ) {
+	    op_mat.connection(b) = b_mat.first;
+	    op_mat.block_mat[b] = term.coef * b_mat.second;
+	  } else if ( op_mat.connection(b) != b_mat.first ) {
+	    TRIQS_RUNTIME_ERROR << "ERROR: <atom_diag::get_op_mat> Monomials in operator does not connect the same subspaces.";
+	  } else {
+	    op_mat.block_mat[b] += term.coef * b_mat.second;
+	  }
+	}
+	// Transform to Hamiltonian eigen basis
+	if( op_mat.connection(b) != -1 ) {
+	  auto U_left = dagger(eigensystems[op_mat.connection(b)].unitary_matrix);
+	  auto U_right = eigensystems[b].unitary_matrix;
+	  op_mat.block_mat[b] = U_left * op_mat.block_mat[b] * U_right;
+	}
+      }
+      return std::move(op_mat);
+    }
+
 #undef ATOM_DIAG_METHOD
 
     // -----------------------------------------------------------------

--- a/triqs/atom_diag/impl/atom_diag.cpp
+++ b/triqs/atom_diag/impl/atom_diag.cpp
@@ -3,6 +3,8 @@
  * TRIQS: a Toolbox for Research in Interacting Quantum Systems
  *
  * Copyright (C) 2016, P. Seth, I. Krivenko, M. Ferrero and O. Parcollet
+ * Copyright (C) 2018, The Simons Foundation
+ * Author: H. U.R. Strand
  *
  * TRIQS is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software
@@ -108,16 +110,16 @@ namespace triqs {
 
       for(int b : range(n_subspaces()) ) {
 	for( auto const &term : op ) {
-	  auto b_mat = get_matrix_element_of_monomial(term.monomial, b);
-	  if(b_mat.first == -1) continue;
+	  auto [bb, mat] = get_matrix_element_of_monomial(term.monomial, b);
+	  if(bb == -1) continue;
 	  
 	  if( op_mat.connection(b) == -1 ) {
-	    op_mat.connection(b) = b_mat.first;
-	    op_mat.block_mat[b] = term.coef * b_mat.second;
-	  } else if ( op_mat.connection(b) != b_mat.first ) {
+	    op_mat.connection(b) = bb;
+	    op_mat.block_mat[b] = term.coef * mat;
+	  } else if ( op_mat.connection(b) != bb ) {
 	    TRIQS_RUNTIME_ERROR << "ERROR: <atom_diag::get_op_mat> Monomials in operator does not connect the same subspaces.";
 	  } else {
-	    op_mat.block_mat[b] += term.coef * b_mat.second;
+	    op_mat.block_mat[b] += term.coef * mat;
 	  }
 	}
 	// Transform to Hamiltonian eigen basis


### PR DESCRIPTION
Dear all,

Here is the separated pull request for atomdiag and the new op_block_mat_t for handling the matrix representation of general operators. This is used in cthyb to do sampling by insertion.

Please give feedback on this.

Best, Hugo