### PR TITLE
Total occupation number constraints in atom diag (fix of functionality regression)

### DIFF
--- a/test/triqs/atom_diag/f_shell.cpp
+++ b/test/triqs/atom_diag/f_shell.cpp
@@ -70,16 +70,13 @@ TEST(atom_diag_real, f_shell_kanamori) {
   
   auto H = make_hamiltonian<many_body_operator_real>(n_orb, mu, U, J);
 
-  //int n_min = 0, n_max = 2 * n_orb; // works
-  int n_min = 0, n_max = 3*2; // breaks
+  int n_min = 0, n_max = 3*2;
 
   auto ad = triqs::atom_diag::atom_diag<false>(H, fops, n_min, n_max);
 
   std::cout << "Found " << ad.n_subspaces() << " subspaces." << std::endl;
-
-  int op_linear_index = 0;
-  int sidx = 1000; // subspace index
-  std::cout << ad.c_matrix(op_linear_index, sidx) << "\n";
+  EXPECT_EQ(ad.n_subspaces(), 1040);
+  
 }
 
 MAKE_MAIN;

--- a/test/triqs/atom_diag/f_shell.cpp
+++ b/test/triqs/atom_diag/f_shell.cpp
@@ -1,0 +1,85 @@
+#include <triqs/test_tools/gfs.hpp>
+
+#include <triqs/atom_diag/atom_diag.hpp>
+#include <triqs/atom_diag/functions.hpp>
+#include <triqs/atom_diag/gf.hpp>
+#include <triqs/arrays/blas_lapack/dot.hpp>
+#include <triqs/h5.hpp>
+
+using namespace triqs::arrays;
+using namespace triqs::hilbert_space;
+using namespace triqs::atom_diag;
+using namespace triqs::operators;
+
+fundamental_operator_set make_fops(int n_orb) {
+  fundamental_operator_set fops;
+  for (int oidx : range(n_orb)) {
+    fops.insert("up", oidx);
+    fops.insert("dn", oidx);
+  }
+  return fops;
+}
+
+// 
+template <typename OP>
+OP make_hamiltonian(int n_orb, double mu, double U, double J) {
+
+  auto orbs = range(n_orb);
+
+  OP h;
+
+  for (int o : orbs) h += -mu * (n("up", o) + n("dn", o));
+
+  // Density-density interactions
+  for (int o : orbs) h += U * n("up", o) * n("dn", o);
+
+  for (int o1 : orbs) {
+    for (int o2 : orbs) {
+      if (o1 == o2) continue;
+      h += (U - 2 * J) * n("up", o1) * n("dn", o2);
+    }
+  }
+
+  for (int o1 : orbs)
+    for (int o2 : orbs) {
+      if (o2 >= o1) continue;
+      h += (U - 3 * J) * n("up", o1) * n("up", o2);
+      h += (U - 3 * J) * n("dn", o1) * n("dn", o2);
+    }
+
+  // spin-flip and pair-hopping
+  for (int o1 : orbs) {
+    for (int o2 : orbs) {
+      if (o1 == o2) continue;
+      h += -J * c_dag("up", o1) * c_dag("dn", o1) * c("up", o2) * c("dn", o2);
+      h += -J * c_dag("up", o1) * c_dag("dn", o2) * c("up", o2) * c("dn", o1);
+    }
+  }
+  
+  return h;
+}
+
+TEST(atom_diag_real, f_shell_kanamori) {
+
+  int n_orb = 7;
+  auto fops = make_fops(n_orb);
+
+  double U = 1.0;
+  double J = 0.2;
+  double mu = 0.5*U;
+  
+  auto H = make_hamiltonian<many_body_operator_real>(n_orb, mu, U, J);
+
+  //int n_min = 0, n_max = 2 * n_orb; // works
+  int n_min = 0, n_max = 3*2; // breaks
+
+  auto ad = triqs::atom_diag::atom_diag<false>(H, fops, n_min, n_max);
+
+  std::cout << "Found " << ad.n_subspaces() << " subspaces." << std::endl;
+
+  int op_linear_index = 0;
+  int sidx = 1000; // subspace index
+  std::cout << ad.c_matrix(op_linear_index, sidx) << "\n";
+}
+
+MAKE_MAIN;

--- a/triqs/atom_diag/atom_diag.hpp
+++ b/triqs/atom_diag/atom_diag.hpp
@@ -113,6 +113,8 @@ namespace triqs {
   */
       atom_diag(many_body_op_t const &h, fundamental_operator_set const &fops);
 
+      atom_diag(many_body_op_t const &h, fundamental_operator_set const &fops, int n_min, int n_max);
+      
       /// Reduce a given Hamiltonian to a block-diagonal form and diagonalize it
       /**
   * This constructor uses quantum number operators to partition the Hilbert space into

--- a/triqs/atom_diag/impl/atom_diag.cpp
+++ b/triqs/atom_diag/impl/atom_diag.cpp
@@ -48,6 +48,13 @@ namespace triqs {
       compute_vacuum();
     }
 
+    ATOM_DIAG_CONSTRUCTOR((many_body_op_t const &h, fundamental_operator_set const &fops, int n_min, int n_max))
+       : h_atomic(h), fops(fops), full_hs(fops), vacuum(full_hs.size()) {
+      atom_diag_worker<Complex>{this, n_min, n_max}.autopartition();
+      fill_first_eigenstate_of_subspace();
+      compute_vacuum();
+    }
+    
     // -----------------------------------------------------------------
 
     ATOM_DIAG_METHOD(void, fill_first_eigenstate_of_subspace()) {


### PR DESCRIPTION
Dear all,

This fixes the `atom_diag` feature of only considering a restricted range of the total occupation when building the Fock space.

The commit 8b28b5a exposes the interface and adds a test that uses the constrained occupation range constructor. The commit 64ffc6 is a patch from @krivenko that fixes the internal bug in `atom_diag` that caused it to segfault when encountering empty subsectors. With this modification the test passes.

@Wentzell I discussed the test and interface with you before. Here is both that and the required fix to make the test pass. Could you please have a look?

Best regards,
Hugo