### PR TITLE
[mc] make measure timer optional

### DIFF
--- a/triqs/mc_tools/mc_generic.hpp
+++ b/triqs/mc_tools/mc_generic.hpp
@@ -119,9 +119,9 @@ namespace triqs {
    * @param name                     Name of the measure
    *
    */
-      template <typename MeasureType> typename measure_set<MCSignType>::measure_ptr_t add_measure(MeasureType &&m, std::string name) {
+      template <typename MeasureType> typename measure_set<MCSignType>::measure_ptr_t add_measure(MeasureType &&m, std::string name, bool enable_timer = true) {
         static_assert(!std::is_pointer<MeasureType>::value, "add_measure in mc_generic takes ONLY values !");
-        return AllMeasures.insert(std::forward<MeasureType>(m), name);
+        return AllMeasures.insert(std::forward<MeasureType>(m), name, enable_timer);
       }
 
       /**

--- a/triqs/mc_tools/mc_measure_set.hpp
+++ b/triqs/mc_tools/mc_measure_set.hpp
@@ -3,6 +3,7 @@
  * TRIQS: a Toolbox for Research in Interacting Quantum Systems
  *
  * Copyright (C) 2011-2013 by M. Ferrero, O. Parcollet
+ * Copyright (C) 2018- The Simons Foundation, Author: H. UR Strand
  *
  * TRIQS is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software
@@ -38,10 +39,11 @@ namespace triqs {
       std::function<void(h5::group, std::string const &)> h5_r, h5_w;
 
       uint64_t count_;
+      bool enable_timer;
       utility::timer Timer;
 
       public:
-      template <typename MeasureType> measure(bool, MeasureType &&m) {
+      template <typename MeasureType> measure(bool, MeasureType &&m, bool enable_timer = true) : enable_timer(enable_timer) {
         static_assert(std::is_move_constructible<MeasureType>::value, "This measure is not MoveConstructible");
         static_assert(has_accumulate<MCSignType, MeasureType>::value, " This measure has no accumulate method !");
         static_assert(has_collect_result<MeasureType>::value, " This measure has no collect_results method !");
@@ -64,14 +66,14 @@ namespace triqs {
       void accumulate(MCSignType signe) {
         assert(impl_);
         count_++;
-        Timer.start();
+        if(enable_timer) Timer.start();
         accumulate_(signe);
-        Timer.stop();
+        if(enable_timer) Timer.stop();
       }
       void collect_results(mpi::communicator const &c) {
-        Timer.start();
+        if(enable_timer) Timer.start();
         collect_results_(c);
-        Timer.stop();
+        if(enable_timer) Timer.stop();
       }
 
       uint64_t count() const { return count_; }

--- a/triqs/mc_tools/mc_measure_set.hpp
+++ b/triqs/mc_tools/mc_measure_set.hpp
@@ -43,7 +43,7 @@ namespace triqs {
       utility::timer Timer;
 
       public:
-      template <typename MeasureType> measure(bool, MeasureType &&m, bool enable_timer = true) : enable_timer(enable_timer) {
+      template <typename MeasureType> measure(bool, MeasureType &&m, bool enable_timer) : enable_timer(enable_timer) {
         static_assert(std::is_move_constructible<MeasureType>::value, "This measure is not MoveConstructible");
         static_assert(has_accumulate<MCSignType, MeasureType>::value, " This measure has no accumulate method !");
         static_assert(has_collect_result<MeasureType>::value, " This measure has no collect_results method !");
@@ -107,11 +107,11 @@ namespace triqs {
       /**
     * Register the Measure M with a name
     */
-      template <typename MeasureType> measure_ptr_t insert(MeasureType &&M, std::string const &name) {
+      template <typename MeasureType> measure_ptr_t insert(MeasureType &&M, std::string const &name, bool enable_timer) {
         if (has(name)) TRIQS_RUNTIME_ERROR << "measure_set : insert : measure '" << name << "' already inserted";
         // workaround for all gcc
         // m_map.insert(std::make_pair(name, measure_type(true, std::forward<MeasureType>(M))));
-        auto iter_b = m_map.emplace(name, measure_type(true, std::forward<MeasureType>(M)));
+        auto iter_b = m_map.emplace(name, measure_type(true, std::forward<MeasureType>(M), enable_timer));
         return iter_b.first;
       }
 


### PR DESCRIPTION
This is a fix for issue #604 making it possible to disable the timers for the mc measures by passing an additional flag in the constructor. As suggested in the triqs meeting discussion Nov 16.

@amoutenet Could you please try this fix and check that it solves your speed issue?

Best, H