### PR TITLE
[detmanip] Don't regenerate on singular det, Throw in regeneration

### DIFF
--- a/test/triqs/det_manip/det_manip3.cpp
+++ b/test/triqs/det_manip/det_manip3.cpp
@@ -7,7 +7,10 @@ using triqs::det_manip::det_manip;
 struct func {
   // gives the coefficients of the matrix (function F of the documentation)
   double operator()(int x, int y) const {
-    return x + y;
+    if ((x < 0) and (y < 0))
+      return 1;
+    else
+      return x + y;
   }
 };
 
@@ -20,21 +23,21 @@ det_manip<func> init_dm() {
   return dm;
 }
 
-det_manip<func> make_zero(det_manip<func> dm) {
+det_manip<func> remove_second_row_col(det_manip<func> dm) {
   dm.remove(1, 1);
   std::cerr << "matrix = " << dm.matrix() << std::endl;
   std::cerr << "det    = " << dm.determinant() << std::endl;
   return dm;
 }
 
-det_manip<func> insert_nonzero(det_manip<func> dm) {
+det_manip<func> insert_second_row_col(det_manip<func> dm) {
   dm.insert(1, 1, 6, 4);
   std::cerr << "matrix = " << dm.matrix() << std::endl;
   std::cerr << "det    = " << dm.determinant() << std::endl;
   return dm;
 }
 
-det_manip<func> make_empty_from_zero(det_manip<func> dm) {
+det_manip<func> remove_first_row_col(det_manip<func> dm) {
   dm.remove(0, 0);
   std::cerr << "matrix = " << dm.matrix() << std::endl;
   std::cerr << "det    = " << dm.determinant() << std::endl;
@@ -48,22 +51,22 @@ TEST(det_manip, det_manip_zero_mat) {
   // using std::abs;
 
   auto dm1                        = init_dm();
-  auto dm2                        = make_zero(dm1);
-  auto dm3                        = insert_nonzero(dm2);
-  auto dm4                        = make_empty_from_zero(dm2);
-  arrays::matrix<double> true_dm1 = {{-7, 1}, {-3, 5}};
-  arrays::matrix<double> true_dm2 = {{-7}};
-  arrays::matrix<double> true_dm3 = {{-7, 2}, {1, 10}};
+  auto dm2                        = remove_second_row_col(dm1);
+  auto dm3                        = insert_second_row_col(dm2);
+  auto dm4                        = remove_first_row_col(dm2);
+  arrays::matrix<double> true_dm1 = {{1, 1}, {-3, 5}};
+  arrays::matrix<double> true_dm2 = {{1}};
+  arrays::matrix<double> true_dm3 = {{1, 2}, {1, 10}};
   arrays::matrix<double> true_dm4 = {};
 
   EXPECT_ARRAY_NEAR(dm1.matrix(), true_dm1);
-  EXPECT_EQ(dm1.determinant(), -32);
+  EXPECT_EQ(dm1.determinant(), 8);
 
   EXPECT_ARRAY_NEAR(dm2.matrix(), true_dm2);
-  EXPECT_EQ(dm2.determinant(), -7);
+  EXPECT_EQ(dm2.determinant(), 1);
 
   EXPECT_ARRAY_NEAR(dm3.matrix(), true_dm3);
-  EXPECT_EQ(dm3.determinant(), -72);
+  EXPECT_EQ(dm3.determinant(), 8);
 
   EXPECT_ARRAY_NEAR(dm4.matrix(), true_dm4);
   EXPECT_EQ(dm4.determinant(), 1);


### PR DESCRIPTION
-det_manip should never explicitly go through a singular matrix
-singular matrices should be SKIPPED OVER by the proper operations,
e.g. try_insert2 instead of 2x (try_insert + complete operation)
-throw exception if we encounter a singular determinant in the
regeneration
-regenerate if determinant is zero in the accessor function
-minor formatting