### PR TITLE
Bugfix in linear interpolation, adjust rouding error margin, FIX #668

### DIFF
--- a/triqs/gfs/meshes/linear_interpolation.hpp
+++ b/triqs/gfs/meshes/linear_interpolation.hpp
@@ -77,15 +77,17 @@ namespace triqs::gfs {
     long i   = std::floor(a);
     bool in  = (i >= 0) && (i < imax);
     double w = a - i;
+    // We include both x_min and x_max and account
+    // for a small rounding error margin of 1e-10 for w
     if (i == imax) {
       --i;
-      in = (std::abs(w) < 1.e-12);
+      in = (std::abs(w) < 1.e-8);
       w  = 1.0;
     }
     if (i == -1) {
       i  = 0;
-      in = (std::abs(1 - w) < 1.e-12);
-      w  = 1.0;
+      in = (std::abs(1 - w) < 1.e-8);
+      w  = 0.0;
     }
     if (!in) TRIQS_RUNTIME_ERROR << "out of window x= " << x << " xmin = " << x_min << " xmax = " << x_min + imax * delta_x;
     return {{i, i + 1}, {1 - w, w}};

--- a/triqs/gfs/meshes/linear_interpolation.hpp
+++ b/triqs/gfs/meshes/linear_interpolation.hpp
@@ -78,7 +78,7 @@ namespace triqs::gfs {
     bool in  = (i >= 0) && (i < imax);
     double w = a - i;
     // We include both x_min and x_max and account
-    // for a small rounding error margin of 1e-10 for w
+    // for a small rounding error margin of 1e-8 for w
     if (i == imax) {
       --i;
       in = (std::abs(w) < 1.e-8);


### PR DESCRIPTION
This is both a FIX to #668 and a Bugfix in the linear interpolation weights for one corner-case.

Issue #668 occurs as for large `n_tau` the rounding error accumulated in
```c++
double del = (x_min - x_max) / (n_tau - 1);
double x_max_new = x_min + del * (n_tau - 1);
```
is large than what we permit [here](https://github.com/TRIQS/triqs/blob/b99a06744eac6a07f7d4fb5015e1ef95cde45f2a/triqs/gfs/meshes/linear_interpolation.hpp#L82). This PR raises this margin significantly from `1e-12 -> 1e-8`.

This PR further fixes an error in the linear interpolation weights for the case where `x` is marginally smaller than `x_min`. [Here](https://github.com/TRIQS/triqs/blob/b99a06744eac6a07f7d4fb5015e1ef95cde45f2a/triqs/gfs/meshes/linear_interpolation.hpp#L91) the weight of the left point (i.e. `1-w`) should be `1` and not `0`.