### PR TITLE
[h5] Fix issue #675

### DIFF
--- a/test/triqs/h5/h5_io.cpp
+++ b/test/triqs/h5/h5_io.cpp
@@ -141,4 +141,44 @@ TEST(H5Io, Vector) {
   EXPECT_EQ(mv, mmv);
 }
 
+TEST(H5Io, Attribute) {
+  // write
+  std::vector<std::vector<std::string>> vvs  = {{"a", "b"}, {"c", "d"}, {"e", "f"}};
+  std::vector<std::vector<std::string>> evvs = {};
+  std::vector<std::vector<std::string>> vevs = {{}, {}, {}};
+  std::vector<std::vector<std::string>> vves = {{"", ""}, {"", ""}, {"", ""}};
+
+  {
+    h5::file file{"test_attribute.h5", H5F_ACC_TRUNC};
+    h5::group grp{file};
+    h5_write(grp, "vec", 0);
+
+    auto id = grp.open_dataset("vec");
+    h5_write_attribute(id, "attr_vvs", vvs);
+    h5_write_attribute(id, "attr_evvs", evvs);
+    h5_write_attribute(id, "attr_vevs", vevs);
+    h5_write_attribute(id, "attr_vves", vves);
+  }
+
+  // read
+  std::vector<std::vector<std::string>> rvvs, revvs, rvevs, rvves;
+
+  {
+    h5::file file{"test_attribute.h5", H5F_ACC_RDONLY};
+    h5::group grp{file};
+
+    auto id = grp.open_dataset("vec");
+    h5_read_attribute(id, "attr_vvs", rvvs);
+    h5_read_attribute(id, "attr_evvs", revvs);
+    h5_read_attribute(id, "attr_vevs", rvevs);
+    h5_read_attribute(id, "attr_vves", rvves);
+  }
+
+  // compare
+  EXPECT_EQ(vvs, rvvs);
+  EXPECT_EQ(evvs, revvs);
+  EXPECT_EQ(vevs, rvevs);
+  EXPECT_EQ(vves, rvves);
+}
+
 MAKE_MAIN;

--- a/triqs/h5/vector.cpp
+++ b/triqs/h5/vector.cpp
@@ -65,12 +65,7 @@ namespace triqs {
           // auto status = H5Tset_size (strdatatype, s);
           // auto status = H5Tset_size (strdatatype, H5T_VARIABLE);
 
-          if(V.empty() || lv == 0) {
-            buf.resize(1);
-            hsize_t totdimsf[] = {V.size(), 0};
-            d_space = H5Screate_simple(2, totdimsf, NULL);
-            return;
-          }
+          if(V.empty() || lv == 0) buf.resize(1);
 
           buf.resize(V.size() * lv * (s + 1), 0x00);
           for (int i = 0, k = 0; i < V.size(); i++)
@@ -78,11 +73,8 @@ namespace triqs {
               if (j < V[i].size()) strcpy(&buf[k * (s + 1)], V[i][j].c_str());
             }
 
-          // for (auto x : buf) std::cout << "buf "<< int(x) << std::endl;
-
-          hsize_t L[2] = {V.size(), lv};
-          hsize_t S[2] = {lv, 1};
-          d_space      = dataspace_from_LS(2, false, L, L, S);
+          hsize_t totdimsf[2] = {V.size(), lv};
+          d_space = H5Screate_simple(2, totdimsf, NULL);
         }
       };
     } // namespace
@@ -180,8 +172,8 @@ namespace triqs {
 
       // buffer
       size_t size = H5Aget_storage_size(attr);
+      if(size == 0) return;
       std::vector<char> buf(size, 0x00);
-      if(buf.empty()) return;
 
       auto err = H5Aread(attr, datatype, (void *)(&buf[0]));
       if (err < 0) TRIQS_RUNTIME_ERROR << "Cannot read the attribute " << name;

--- a/triqs/h5/vector.cpp
+++ b/triqs/h5/vector.cpp
@@ -65,6 +65,13 @@ namespace triqs {
           // auto status = H5Tset_size (strdatatype, s);
           // auto status = H5Tset_size (strdatatype, H5T_VARIABLE);
 
+          if(V.empty() || lv == 0) {
+            buf.resize(1);
+            hsize_t totdimsf[] = {V.size(), 0};
+            d_space = H5Screate_simple(2, totdimsf, NULL);
+            return;
+          }
+
           buf.resize(V.size() * lv * (s + 1), 0x00);
           for (int i = 0, k = 0; i < V.size(); i++)
             for (int j = 0; j < lv; j++, k++) {
@@ -174,6 +181,7 @@ namespace triqs {
       // buffer
       size_t size = H5Aget_storage_size(attr);
       std::vector<char> buf(size, 0x00);
+      if(buf.empty()) return;
 
       auto err = H5Aread(attr, datatype, (void *)(&buf[0]));
       if (err < 0) TRIQS_RUNTIME_ERROR << "Cannot read the attribute " << name;
@@ -187,7 +195,7 @@ namespace triqs {
         for (int j = 0; j < dims_out[1]; ++j, ++k) {
           std::string x = "";
           x.append(&buf[k * (s_size)]);
-          if (!x.empty()) v.push_back(x);
+          v.push_back(x);
         }
         V.push_back(v);
       }


### PR DESCRIPTION
This commit makes

`void h5_write_attribute(hid_t ob, std::string const & name, std::vector<std::vector<std::string>> const & V)`
`void h5_read_attribute(hid_t ob, std::string const & name, std::vector<std::vector<std::string>> & V)`

properly handle corner cases when some of the vectors/strings are empty. `h5_io` test has been extended to cover the changed functions.

