### PR TITLE
Removed deprecation warning from the latest version of h5py

### DIFF
--- a/pytriqs/archive/hdf_archive_basic_layer_h5py.py
+++ b/pytriqs/archive/hdf_archive_basic_layer_h5py.py
@@ -21,7 +21,7 @@
 ################################################################################
 
 # h5py
-import numpy,string,h5py,h5py.highlevel
+import numpy,string,h5py
 class HDFArchiveGroupBasicLayer :
     _class_version = 1
 
@@ -29,7 +29,7 @@ class HDFArchiveGroupBasicLayer :
         """  """
         self.options = parent.options
         self._group = parent._group[subpath] if subpath else parent._group
-        assert type(self._group) in [h5py.highlevel.Group,h5py.highlevel.File], "Internal error"
+        assert type(self._group) in [h5py.Group,h5py.File], "Internal error"
         self.ignored_keys = [] 
         self.cached_keys = self._group.keys()
 
@@ -54,12 +54,12 @@ class HDFArchiveGroupBasicLayer :
     def is_group(self,p) :
         """Is p a subgroup ?"""
         assert len(p)>0 and p[0]!='/'
-        return p in self.cached_keys and type(self._group[p]) == h5py.highlevel.Group
+        return p in self.cached_keys and type(self._group[p]) == h5py.Group
 
     def is_data(self,p) :
         """Is p a leaf ?"""
         assert len(p)>0 and p[0]!='/'
-        return p in self.cached_keys and type(self._group[p]) == h5py.highlevel.Dataset
+        return p in self.cached_keys and type(self._group[p]) == h5py.Dataset
 
     def write_attr (self, key, val) :
         self._group.attrs.create(key, val)

--- a/pytriqs/archive/hdf_archive_basic_layer_h5py.py
+++ b/pytriqs/archive/hdf_archive_basic_layer_h5py.py
@@ -70,7 +70,7 @@ class HDFArchiveGroupBasicLayer :
 
     def _read (self, key) :
         A = self._group[key]
-        val =  numpy.array(A) if A.shape!=() else A.value
+        val =  numpy.array(A) if A.shape!=() else A[()]
         if self.options["UseAlpsNotationForComplex"] and '__complex__' in self._group[key].attrs :
             assert type(val) == numpy.ndarray, 'complex tag is set, but I have not an array'
             assert not numpy.iscomplexobj(val), 'complex tag is set, but I have a complex !'

--- a/pytriqs/archive/hdf_archive_basic_layer_h5py.py
+++ b/pytriqs/archive/hdf_archive_basic_layer_h5py.py
@@ -21,7 +21,7 @@
 ################################################################################
 
 # h5py
-import numpy,string,h5py
+import numpy,string,h5py,h5py.highlevel
 class HDFArchiveGroupBasicLayer :
     _class_version = 1
 

--- a/triqs/python_tools/converters/h5.hpp
+++ b/triqs/python_tools/converters/h5.hpp
@@ -37,7 +37,7 @@ template <> struct py_converter<triqs::h5::group> {
 
  static bool is_convertible(PyObject *ob, bool raise_exception) {
   if (group_type.is_null()) {
-   group_type = pyref::module("h5py").attr("highlevel").attr("Group");
+   group_type = pyref::module("h5py").attr("Group");
    if (PyErr_Occurred()) TRIQS_RUNTIME_ERROR << "Cannot load h5py module and find the group in it";
   }
   int cmp = PyObject_RichCompareBool((PyObject *)ob->ob_type, group_type, Py_EQ);


### PR DESCRIPTION
As the title says, the use of deprecated "value" and "h5py.highlevel" has been removed.