### PR TITLE
Adjust fundamental operator set to respect order in gf_struct #342

### DIFF
--- a/test/triqs/atom_diag/hamiltonian.hpp
+++ b/test/triqs/atom_diag/hamiltonian.hpp
@@ -9,10 +9,8 @@ using namespace triqs::operators;
 // Prepare funcdamental operator set
 fundamental_operator_set make_fops() {
   fundamental_operator_set fops;
-  for (int o : range(3)) {
-    fops.insert("up", o);
-    fops.insert("dn", o);
-  }
+  for (int o : range(3)) fops.insert("dn", o);
+  for (int o : range(3)) fops.insert("up", o);
   return fops;
 }
 

--- a/test/triqs/hilbert_space/hilbert_test.cpp
+++ b/test/triqs/hilbert_space/hilbert_test.cpp
@@ -38,7 +38,7 @@ TEST(hilbert_space, fundamental_operator_set) {
   fundamental_operator_set fop4;
   for (int i = 0; i < 2; ++i) fop4.insert("up", i);
   for (int i = 0; i < 2; ++i) fop4.insert("down", i);
-  EXPECT_EQ(0, (fop4[{"down", 0}]));
+  EXPECT_EQ(2, (fop4[{"down", 0}]));
   EXPECT_EQ(4, fop4.size());
 }
 
@@ -170,10 +170,10 @@ TEST(hilbert_space, sub_hilbert_space) {
 
 TEST(hilbert_space, QuarticOperators) {
   fundamental_operator_set fops;
-  fops.insert("up", 0);
   fops.insert("down", 0);
-  fops.insert("up", 1);
   fops.insert("down", 1);
+  fops.insert("up", 0);
+  fops.insert("up", 1);
 
   using triqs::hilbert_space::hilbert_space;
   hilbert_space hs(fops);

--- a/test/triqs/hilbert_space/space_partition.cpp
+++ b/test/triqs/hilbert_space/space_partition.cpp
@@ -37,10 +37,8 @@ int main(int argc, char **argv) {
   triqs::mpi::environment env(argc, argv);
   ::testing::InitGoogleTest(&argc, argv);
 
-  for (int o = 0; o < 3; ++o) {
-    fops.insert("up", o);
-    fops.insert("dn", o);
-  }
+  for (int o = 0; o < 3; ++o) fops.insert("dn", o);
+  for (int o = 0; o < 3; ++o) fops.insert("up", o);
 
   for (int o = 0; o < 3; ++o) { H += -mu * (n("up", o) + n("dn", o)); }
   for (int o = 0; o < 3; ++o) { H += U * n("up", o) * n("dn", o); }

--- a/test/triqs/operators/operator_test.cpp
+++ b/test/triqs/operators/operator_test.cpp
@@ -233,7 +233,8 @@ TEST(Operator, RealOrComplex) {
   many_body_operator op3;
   h5_read(f, "OP_fs", op3, fs2);
   EXPECT_TRUE((op1 - op3).is_zero());
-  EXPECT_EQ(fundamental_operator_set::reduction_t(fs), fundamental_operator_set::reduction_t(fs2));
+  EXPECT_EQ(fundamental_operator_set::data_t(fs), fundamental_operator_set::data_t(fs2));
+  EXPECT_EQ(fs.data(), fs2.data());
 }
 
 MAKE_MAIN;

--- a/triqs/cpp2py_converters/fundamental_operator_set.hpp
+++ b/triqs/cpp2py_converters/fundamental_operator_set.hpp
@@ -8,5 +8,5 @@ namespace cpp2py {
   template <>
   struct py_converter<triqs::hilbert_space::fundamental_operator_set>
      : py_converter_generic_cast_construct<triqs::hilbert_space::fundamental_operator_set,
-                                           triqs::hilbert_space::fundamental_operator_set::reduction_t> {};
+                                           triqs::hilbert_space::fundamental_operator_set::data_t> {};
 } // namespace cpp2py

--- a/triqs/hilbert_space/fundamental_operator_set.cpp
+++ b/triqs/hilbert_space/fundamental_operator_set.cpp
@@ -63,8 +63,8 @@ namespace triqs {
     } // namespace
 
     // private constructor
-    fundamental_operator_set::fundamental_operator_set(std::vector<std::vector<std::string>> const &v) {
-      for (int n = 0; n < v.size(); ++n) { map_index_n.insert({to_indices(v[n]), n}); }
+    fundamental_operator_set::fundamental_operator_set(std::vector<std::vector<std::string>> const &vvs) {
+      for(auto const& vs: vvs) vec.push_back(to_indices(vs));
     }
 
     // --- h5

--- a/triqs/hilbert_space/fundamental_operator_set.hpp
+++ b/triqs/hilbert_space/fundamental_operator_set.hpp
@@ -145,7 +145,7 @@ namespace triqs::hilbert_space {
     struct _cdress {
       indices_t const &index;
       int linear_index;
-      using base_const_iterator = decltype(triqs::utility::enumerate(vec).cbegin());
+      using base_const_iterator = triqs::utility::enum_iter<data_t::const_iterator>;
       _cdress(base_const_iterator _it) : linear_index(std::get<0>(*_it)), index(std::get<1>(*_it)) {}
     };
 

--- a/triqs/hilbert_space/fundamental_operator_set.hpp
+++ b/triqs/hilbert_space/fundamental_operator_set.hpp
@@ -24,6 +24,7 @@
 #include <triqs/utility/dressed_iterator.hpp>
 #include <triqs/utility/exceptions.hpp>
 #include <triqs/utility/variant_extensions.hpp>
+#include <triqs/utility/itertools.hpp>
 #include <triqs/h5/base_public.hpp>
 #include <vector>
 #include <set>
@@ -32,8 +33,11 @@
 namespace triqs {
   namespace hilbert_space {
 
-    /// Structure of the Green's function
-    using gf_struct_t = std::vector<std::pair<std::string, std::vector<std::variant<int, std::string>>>>;
+    /// The index type of an operator
+    using indices_t = std::vector<std::variant<int, std::string>>;
+
+    /// Type type describing the structure of a Block Green's function
+    using gf_struct_t = std::vector<std::pair<std::string, indices_t>>;
 
     /// This class represents an ordered set of **indices** of the canonical operators (see [[many_body_operator]]) used to build the Fock states.
     /**
@@ -44,14 +48,13 @@ namespace triqs {
     class fundamental_operator_set {
       public:
       /// Sequence of indices (`std::vector` of int/string variant objects)
-      using indices_t = std::vector<std::variant<int, std::string>>;
+      using indices_t = triqs::hilbert_space::indices_t;
 
-      /// The set represented as a plain `std::vector`
+      /// The basic container `std::vector<indices_t>`
       using reduction_t = std::vector<indices_t>;
 
       private:
-      using map_t = std::map<indices_t, int>; // the table index <-> n
-      map_t map_index_n;
+      reduction_t vec = {};
 
       // internal only
       fundamental_operator_set(std::vector<std::vector<std::string>> const &);
@@ -62,8 +65,8 @@ namespace triqs {
 
       /// Construct a set with each stored index being a pair of integers `(i,j)`
       /**
-   @param v `i` runs from 0 to `v.size()-1`; `j` runs from 0 to `v[i].size()-1` for each `i`
-  */
+       * @param v `i` runs from 0 to `v.size()-1`; `j` runs from 0 to `v[i].size()-1` for each `i`
+       */
       fundamental_operator_set(std::vector<int> const &v) {
         for (int i = 0; i < v.size(); ++i)
           for (int j = 0; j < v[i]; ++j) insert(i, j);
@@ -71,130 +74,120 @@ namespace triqs {
 
       /// Construct from a set of generic index sequences
       /**
-   @param s Set of indices
-  */
+       * @param s Set of indices
+       */
       template <typename IndexType> fundamental_operator_set(std::set<IndexType> const &s) {
         for (auto const &i : s) insert(i);
       }
 
       /// Construct from a vector of index sequences
       /**
-   @param v Vector of indices
-  */
-      explicit fundamental_operator_set(reduction_t const &v) {
-        for (auto const &i : v) insert_from_indices_t(i);
-      }
+       * @param v Vector of indices
+       */
+      explicit fundamental_operator_set(reduction_t const &v): vec(v) {}
 
       /// Construct fundamental_operator_set on a GF structure
       /**
-   @param gf_struct GF structure object
-  */
+       * @param gf_struct GF structure object
+       */
       fundamental_operator_set(gf_struct_t const &gf_struct) {
         for (auto const &block : gf_struct)
           for (auto const &inner : block.second) insert(block.first, inner);
       }
 
       /// Reduce to a `std::vector<indices_t>`
-      explicit operator reduction_t() const { return reverse_map(); }
+      explicit operator reduction_t() const { return vec; }
 
       /// Insert a new index sequence given as `indices_t`
       /**
-   @param ind `indices_t` object
-  */
-      void insert_from_indices_t(indices_t const &ind) {
-        map_index_n.insert({ind, size()});
-        // reorder the indices, which are always given in the order of the indices tuple
-        map_t m;
-        int i = 0;
-        for (auto const &p : map_index_n) m.insert({p.first, i++});
-        std::swap(m, map_index_n);
-      }
+       * @param ind `indices_t` object
+       */
+      void insert_from_indices_t(indices_t const &ind) { if(!has_indices(ind)) vec.push_back(ind); }
 
       /// Insert a new index sequence given as multiple `int`/`std::string` arguments
       template <typename... IndexType> void insert(IndexType const &... ind) { insert_from_indices_t(indices_t{ind...}); }
 
       /// Number of elements in this set
       /**
-   @return Size of the set
-  */
-      int size() const { return map_index_n.size(); }
+       * @return Size of the set
+       */
+      int size() const { return vec.size(); }
 
       /// Check if a given index sequence is in this set
       /**
-   @param t Index sequence to look up
-   @return `true` if `t` is in this set
-  */
-      bool has_indices(indices_t const &t) const { return map_index_n.count(t) == 1; }
+       * @param t Index sequence to look up
+       * @return `true` if `t` is in this set
+       */
+      bool has_indices(indices_t const &t) const { return std::find(vec.begin(), vec.end(), t) != vec.end(); }
 
       /// Request position of a given index sequence
       /**
-   @param t Index sequence to look up
-   @return Position of the requested index sequence
-  */
+       * @param t Index sequence to look up
+       * @return Position of the requested index sequence
+       */
       int operator[](indices_t const &t) const {
-        try {
-          return map_index_n.at(t);
-        } catch (std::out_of_range &) { TRIQS_RUNTIME_ERROR << "Operator with indices (" << t << ") does not belong to this fundamental set!"; }
+	auto it = std::find(vec.begin(), vec.end(), t);
+	if(it == vec.end()) TRIQS_RUNTIME_ERROR << "Operator with indices (" << t << ") does not belong to this fundamental set!";
+	return std::distance(vec.begin(), it);
       }
 
       /// Comparison with another fundamental operator set
-      bool operator==(fundamental_operator_set const &fops) const { return map_index_n == fops.map_index_n; }
+      bool operator==(fundamental_operator_set const &fops) const { return vec == fops.vec; }
 
       /// Build and return the reverse map: `int` -> `indices_t`
       /**
-   @return The reverse map
-  */
-      std::vector<indices_t> reverse_map() const {
-        std::vector<indices_t> r(size());
-        for (auto const &x : map_index_n) r[x.second] = x.first;
-        return r;
+       * @return The reverse map
+       */
+      reduction_t reverse_map() const {
+        return vec;
       }
 
       // Dereference type for const_iterator
       struct _cdress {
         indices_t const &index;
         int linear_index;
-        _cdress(typename map_t::const_iterator _it) : index(_it->first), linear_index(_it->second) {}
+	using base_const_iterator = triqs::utility::details::enum_iter<reduction_t::const_iterator>;
+        _cdress(base_const_iterator _it) : linear_index(std::get<0>(*_it)), index(std::get<1>(*_it)) {}
       };
 
       /// Constant bidirectional iterator over all stored index sequences. For an iterator `it`, `it->index` gives the `indices_t` object pointed by this iterator, and `it->linear_index` is its position in the set.
-      using const_iterator = triqs::utility::dressed_iterator<typename map_t::const_iterator, _cdress>;
+      using const_iterator = triqs::utility::dressed_iterator<_cdress::base_const_iterator, _cdress>;
 
       /// Return `const_iterator` to the first element of this set
       /**
-   @return Iterator to the first index sequence
-  */
-      const_iterator begin() const noexcept { return map_index_n.begin(); }
+       * @return Iterator to the first index sequence
+       */
+      const_iterator begin() const noexcept { return triqs::utility::enumerate(vec).begin(); }
       /// Return `const_iterator` to the past-the-end element of this set
       /**
-   @return Iterator to the past-the-end element
-  */
-      const_iterator end() const noexcept { return map_index_n.end(); }
+       * @return Iterator to the past-the-end element
+       */
+      const_iterator end() const noexcept { return triqs::utility::enumerate(vec).end(); }
       /// Equivalent to [[fundamental_operator_set_begin]]
       /**
-   @return Iterator to the first index sequence
-  */
-      const_iterator cbegin() const noexcept { return map_index_n.cbegin(); }
+       * @return Iterator to the first index sequence
+       */
+      const_iterator cbegin() const noexcept { return triqs::utility::enumerate(vec).cbegin(); }
       /// Equivalent to [[fundamental_operator_set_end]]
       /**
-   @return Iterator to the past-the-end element
-  */
-      const_iterator cend() const noexcept { return map_index_n.cend(); }
+       * @return Iterator to the past-the-end element
+       */
+      const_iterator cend() const noexcept { return triqs::utility::enumerate(vec).cend(); }
 
       /// Write this set as an HDF5 attribute
       /**
-   @param id ID of an HDF5 object to attach the attribute to
-   @param name Name of the attribute
-   @param f Fundamental set to write
-  */
+       * @param id ID of an HDF5 object to attach the attribute to
+       * @param name Name of the attribute
+       * @param f Fundamental set to write
+       */
 
       friend void h5_write_attribute(hid_t id, std::string const &name, fundamental_operator_set const &f);
       /// Read a set from an HDF5 attribute
       /**
-   @param id ID of an HDF5 object the attribute is attached to
-   @param name Name of the attribute
-   @param f Reference to a fundamental set to be read
-  */
+       * @param id ID of an HDF5 object the attribute is attached to
+       * @param name Name of the attribute
+       * @param f Reference to a fundamental set to be read
+       */
       friend void h5_read_attribute(hid_t id, std::string const &name, fundamental_operator_set &f);
     };
   } // namespace hilbert_space

--- a/triqs/hilbert_space/fundamental_operator_set.hpp
+++ b/triqs/hilbert_space/fundamental_operator_set.hpp
@@ -30,165 +30,166 @@
 #include <set>
 #include <map>
 
-namespace triqs {
-  namespace hilbert_space {
+namespace triqs::hilbert_space {
 
-    /// The index type of an operator
-    using indices_t = std::vector<std::variant<int, std::string>>;
+  /// The index type of an operator
+  using indices_t = std::vector<std::variant<int, std::string>>;
 
-    /// Type type describing the structure of a Block Green's function
-    using gf_struct_t = std::vector<std::pair<std::string, indices_t>>;
+  /// Type type describing the structure of a Block Green's function
+  using gf_struct_t = std::vector<std::pair<std::string, indices_t>>;
 
-    /// This class represents an ordered set of **indices** of the canonical operators (see [[many_body_operator]]) used to build the Fock states.
+  /// This class represents an ordered set of **indices** of the canonical operators (see [[many_body_operator]]) used to build the Fock states.
+  /**
+   * Every element of the set is an arbitrarily long sequence of integers/strings (types can be mixed within one sequence).
+   * The elements maintain the order they are inserted in
+   * @include triqs/hilbert_space/fundamental_operator_set.hpp
+   */
+  class fundamental_operator_set {
+    public:
+    /// Sequence of indices (`std::vector` of int/string variant objects)
+    using indices_t = triqs::hilbert_space::indices_t;
+
+    /// The basic container `std::vector<indices_t>`
+    using data_t = std::vector<indices_t>;
+
+    private:
+    data_t vec = {};
+
+    // internal only
+    fundamental_operator_set(std::vector<std::vector<std::string>> const &);
+
+    public:
+    /// Construct an empty set
+    fundamental_operator_set() {}
+
+    /// Construct a set with each stored index being a pair of integers `(i,j)`
     /**
- Every element of the set is an arbitrarily long sequence of integers/strings (types can be mixed within one sequence).
- The elements are ordered according to the result of `std::lexicographical_compare`.
- @include triqs/hilbert_space/fundamental_operator_set.hpp
- */
-    class fundamental_operator_set {
-      public:
-      /// Sequence of indices (`std::vector` of int/string variant objects)
-      using indices_t = triqs::hilbert_space::indices_t;
+     * @param v `i` runs from 0 to `v.size()-1`; `j` runs from 0 to `v[i].size()-1` for each `i`
+     */
+    fundamental_operator_set(std::vector<int> const &v) {
+      for (int i = 0; i < v.size(); ++i)
+        for (int j = 0; j < v[i]; ++j) insert(i, j);
+    }
 
-      /// The basic container `std::vector<indices_t>`
-      using reduction_t = std::vector<indices_t>;
+    /// Construct from a set of generic index sequences
+    /**
+     * @param s Set of indices
+     */
+    template <typename IndexType> fundamental_operator_set(std::set<IndexType> const &s) {
+      for (auto const &i : s) insert(i);
+    }
 
-      private:
-      reduction_t vec = {};
+    /// Construct from a vector of index sequences
+    /**
+     * @param v Vector of indices
+     */
+    explicit fundamental_operator_set(data_t const &v) : vec(v) {}
 
-      // internal only
-      fundamental_operator_set(std::vector<std::vector<std::string>> const &);
+    /// Construct fundamental_operator_set on a GF structure
+    /**
+     * @param gf_struct GF structure object
+     */
+    fundamental_operator_set(gf_struct_t const &gf_struct) {
+      for (auto const &block : gf_struct)
+        for (auto const &inner : block.second) insert(block.first, inner);
+    }
 
-      public:
-      /// Construct an empty set
-      fundamental_operator_set() {}
+    /// Reduce to a `std::vector<indices_t>`
+    explicit operator data_t() const { return vec; }
 
-      /// Construct a set with each stored index being a pair of integers `(i,j)`
-      /**
-       * @param v `i` runs from 0 to `v.size()-1`; `j` runs from 0 to `v[i].size()-1` for each `i`
-       */
-      fundamental_operator_set(std::vector<int> const &v) {
-        for (int i = 0; i < v.size(); ++i)
-          for (int j = 0; j < v[i]; ++j) insert(i, j);
-      }
+    /// Insert a new index sequence given as `indices_t`
+    /**
+     * @param ind `indices_t` object
+     */
+    void insert_from_indices_t(indices_t const &ind) {
+      if (!has_indices(ind)) vec.push_back(ind);
+    }
 
-      /// Construct from a set of generic index sequences
-      /**
-       * @param s Set of indices
-       */
-      template <typename IndexType> fundamental_operator_set(std::set<IndexType> const &s) {
-        for (auto const &i : s) insert(i);
-      }
+    /// Insert a new index sequence given as multiple `int`/`std::string` arguments
+    template <typename... IndexType> void insert(IndexType const &... ind) { insert_from_indices_t(indices_t{ind...}); }
 
-      /// Construct from a vector of index sequences
-      /**
-       * @param v Vector of indices
-       */
-      explicit fundamental_operator_set(reduction_t const &v): vec(v) {}
+    /// Number of elements in this set
+    /**
+     * @return Size of the set
+     */
+    int size() const { return vec.size(); }
 
-      /// Construct fundamental_operator_set on a GF structure
-      /**
-       * @param gf_struct GF structure object
-       */
-      fundamental_operator_set(gf_struct_t const &gf_struct) {
-        for (auto const &block : gf_struct)
-          for (auto const &inner : block.second) insert(block.first, inner);
-      }
+    /// Check if a given index sequence is in this set
+    /**
+     * @param t Index sequence to look up
+     * @return `true` if `t` is in this set
+     */
+    bool has_indices(indices_t const &t) const { return std::find(vec.begin(), vec.end(), t) != vec.end(); }
 
-      /// Reduce to a `std::vector<indices_t>`
-      explicit operator reduction_t() const { return vec; }
+    /// Request position of a given index sequence
+    /**
+     * @param t Index sequence to look up
+     * @return Position of the requested index sequence
+     */
+    int operator[](indices_t const &t) const {
+      auto it = std::find(vec.begin(), vec.end(), t);
+      if (it == vec.end()) TRIQS_RUNTIME_ERROR << "Operator with indices (" << t << ") does not belong to this fundamental set!";
+      return std::distance(vec.begin(), it);
+    }
 
-      /// Insert a new index sequence given as `indices_t`
-      /**
-       * @param ind `indices_t` object
-       */
-      void insert_from_indices_t(indices_t const &ind) { if(!has_indices(ind)) vec.push_back(ind); }
+    /// Comparison with another fundamental operator set
+    bool operator==(fundamental_operator_set const &fops) const { return vec == fops.vec; }
 
-      /// Insert a new index sequence given as multiple `int`/`std::string` arguments
-      template <typename... IndexType> void insert(IndexType const &... ind) { insert_from_indices_t(indices_t{ind...}); }
+    /// Return the data vector: `v[int]` -> `indices_t`
+    /**
+     * @return The data vector
+     */
+    data_t const &data() const { return vec; }
 
-      /// Number of elements in this set
-      /**
-       * @return Size of the set
-       */
-      int size() const { return vec.size(); }
-
-      /// Check if a given index sequence is in this set
-      /**
-       * @param t Index sequence to look up
-       * @return `true` if `t` is in this set
-       */
-      bool has_indices(indices_t const &t) const { return std::find(vec.begin(), vec.end(), t) != vec.end(); }
-
-      /// Request position of a given index sequence
-      /**
-       * @param t Index sequence to look up
-       * @return Position of the requested index sequence
-       */
-      int operator[](indices_t const &t) const {
-	auto it = std::find(vec.begin(), vec.end(), t);
-	if(it == vec.end()) TRIQS_RUNTIME_ERROR << "Operator with indices (" << t << ") does not belong to this fundamental set!";
-	return std::distance(vec.begin(), it);
-      }
-
-      /// Comparison with another fundamental operator set
-      bool operator==(fundamental_operator_set const &fops) const { return vec == fops.vec; }
-
-      /// Build and return the reverse map: `int` -> `indices_t`
-      /**
-       * @return The reverse map
-       */
-      reduction_t reverse_map() const {
-        return vec;
-      }
-
-      // Dereference type for const_iterator
-      struct _cdress {
-        indices_t const &index;
-        int linear_index;
-	using base_const_iterator = triqs::utility::details::enum_iter<reduction_t::const_iterator>;
-        _cdress(base_const_iterator _it) : linear_index(std::get<0>(*_it)), index(std::get<1>(*_it)) {}
-      };
-
-      /// Constant bidirectional iterator over all stored index sequences. For an iterator `it`, `it->index` gives the `indices_t` object pointed by this iterator, and `it->linear_index` is its position in the set.
-      using const_iterator = triqs::utility::dressed_iterator<_cdress::base_const_iterator, _cdress>;
-
-      /// Return `const_iterator` to the first element of this set
-      /**
-       * @return Iterator to the first index sequence
-       */
-      const_iterator begin() const noexcept { return triqs::utility::enumerate(vec).begin(); }
-      /// Return `const_iterator` to the past-the-end element of this set
-      /**
-       * @return Iterator to the past-the-end element
-       */
-      const_iterator end() const noexcept { return triqs::utility::enumerate(vec).end(); }
-      /// Equivalent to [[fundamental_operator_set_begin]]
-      /**
-       * @return Iterator to the first index sequence
-       */
-      const_iterator cbegin() const noexcept { return triqs::utility::enumerate(vec).cbegin(); }
-      /// Equivalent to [[fundamental_operator_set_end]]
-      /**
-       * @return Iterator to the past-the-end element
-       */
-      const_iterator cend() const noexcept { return triqs::utility::enumerate(vec).cend(); }
-
-      /// Write this set as an HDF5 attribute
-      /**
-       * @param id ID of an HDF5 object to attach the attribute to
-       * @param name Name of the attribute
-       * @param f Fundamental set to write
-       */
-
-      friend void h5_write_attribute(hid_t id, std::string const &name, fundamental_operator_set const &f);
-      /// Read a set from an HDF5 attribute
-      /**
-       * @param id ID of an HDF5 object the attribute is attached to
-       * @param name Name of the attribute
-       * @param f Reference to a fundamental set to be read
-       */
-      friend void h5_read_attribute(hid_t id, std::string const &name, fundamental_operator_set &f);
+    // Dereference type for const_iterator
+    struct _cdress {
+      indices_t const &index;
+      int linear_index;
+      using base_const_iterator = decltype(triqs::utility::enumerate(vec).cbegin());
+      _cdress(base_const_iterator _it) : linear_index(std::get<0>(*_it)), index(std::get<1>(*_it)) {}
     };
-  } // namespace hilbert_space
-} // namespace triqs
+
+    /// Constant bidirectional iterator over all stored index sequences. For an iterator `it`, `it->index` gives the `indices_t` object pointed by this iterator, and `it->linear_index` is its position in the set.
+    using const_iterator = triqs::utility::dressed_iterator<_cdress::base_const_iterator, _cdress>;
+
+    /// Return `const_iterator` to the first element of this set
+    /**
+     * @return Iterator to the first index sequence
+     */
+    const_iterator begin() const noexcept { return triqs::utility::enumerate(vec).begin(); }
+
+    /// Return `const_iterator` to the past-the-end element of this set
+    /**
+     * @return Iterator to the past-the-end element
+     */
+    const_iterator end() const noexcept { return triqs::utility::enumerate(vec).end(); }
+
+    /// Equivalent to [[fundamental_operator_set_begin]]
+    /**
+     * @return Iterator to the first index sequence
+     */
+    const_iterator cbegin() const noexcept { return triqs::utility::enumerate(vec).cbegin(); }
+
+    /// Equivalent to [[fundamental_operator_set_end]]
+    /**
+     * @return Iterator to the past-the-end element
+     */
+    const_iterator cend() const noexcept { return triqs::utility::enumerate(vec).cend(); }
+
+    /// Write this set as an HDF5 attribute
+    /**
+     * @param id ID of an HDF5 object to attach the attribute to
+     * @param name Name of the attribute
+     * @param f Fundamental set to write
+     */
+    friend void h5_write_attribute(hid_t id, std::string const &name, fundamental_operator_set const &f);
+
+    /// Read a set from an HDF5 attribute
+    /**
+     * @param id ID of an HDF5 object the attribute is attached to
+     * @param name Name of the attribute
+     * @param f Reference to a fundamental set to be read
+     */
+    friend void h5_read_attribute(hid_t id, std::string const &name, fundamental_operator_set &f);
+  };
+} // namespace triqs::hilbert_space

--- a/triqs/operators/many_body_operator.cpp
+++ b/triqs/operators/many_body_operator.cpp
@@ -161,7 +161,7 @@ namespace triqs {
 
       // ---- Now we must reverse the operations of write
 
-      auto r_fops = fops.reverse_map(); // a map int -> indices inverting fops[int] -> indices
+      auto r_fops = fops.data(); // the data vector v[int] -> indices inverting fops[indices] -> n
 
       for (auto const &mon : datavec) {
         monomial_t monomial;                                      // vector of canonical_ops_t

--- a/triqs/utility/iterator_facade.hpp
+++ b/triqs/utility/iterator_facade.hpp
@@ -3,6 +3,8 @@
  * TRIQS: a Toolbox for Research in Interacting Quantum Systems
  *
  * Copyright (C) 2017 by O. Parcollet
+ * Copyright (C) 2019 by Simons Foundation
+ *   author : N. Wentzell
  *
  * TRIQS is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software
@@ -18,45 +20,46 @@
  * TRIQS. If not, see <http://www.gnu.org/licenses/>.
  *
  ******************************************************************************/
+
 #pragma once
 #include "./first_include.hpp"
 #include <iterator>
 
-namespace triqs {
-  namespace utility {
+namespace triqs::utility {
 
-    template <class Iter, class Value, class Tag, class Reference = Value &, class Difference = std::ptrdiff_t> class iterator_facade;
+  template <typename Iter, typename Value, typename Reference = Value &, typename Difference = std::ptrdiff_t,
+            typename Tag = std::forward_iterator_tag>
+  struct iterator_facade {
 
-    // need only specialization for the moment.
-    template <class Iter, class Value, class Reference, class Difference>
-    struct iterator_facade<Iter, Value, std::forward_iterator_tag, Reference, Difference> {
+    private:
+    Iter &self() { return static_cast<Iter &>(*this); }
+    Iter const &self() const { return static_cast<const Iter &>(*this); }
 
-      Iter &self() { return static_cast<Iter &>(*this); }
-      Iter const &self() const { return static_cast<const Iter &>(*this); }
+    public:
+    using value_type        = Value;
+    using reference         = Reference;
+    using pointer           = Value *;
+    using difference_type   = Difference;
+    using iterator_category = Tag;
 
-      public:
-      using value_type        = Value; // decltype(*(std::declval<Iterator_facade>()));
-      using iterator_category = std::forward_iterator_tag;
-      using pointer           = value_type *;
-      using difference_type   = Difference;
-      using reference         = Reference;
+    Iter &operator++() {
+      self().increment();
+      return self();
+    }
 
-      Iter &operator++() {
-        self().increment();
-        return self();
-      }
+    Iter operator++(int) {
+      Iter c = *this;
+      self().increment();
+      return c;
+    }
 
-      Iter operator++(int) {
-        Iter c = self();
-        self().increment();
-        return c;
-      }
+    template <typename U> bool operator==(U const &other) const { return self().equal(other); }
+    template <typename U> bool operator!=(U const &other) const { return (!operator==(other)); }
 
-      bool operator==(Iter const &other) const { return self().equal(other); }
-      bool operator!=(Iter const &other) const { return (!operator==(other)); }
+    decltype(auto) operator*() { return self().dereference(); }
+    decltype(auto) operator*() const { return self().dereference(); }
+    decltype(auto) operator-> () { return operator*(); }
+    decltype(auto) operator-> () const { return operator*(); }
+  };
 
-      decltype(auto) operator*() const { return self().dereference(); }
-      decltype(auto) operator-> () const { return operator*(); }
-    };
-  } // namespace utility
-} // namespace triqs
+} // namespace triqs::utility


### PR DESCRIPTION
In accordance with the type-change of ```gf_struct_t``` to
```c++
gf_struct_t = vector<pair<int,vector<indices_t>>>
```
that was introduced in a746ba5 this commit adjusts the 
```fundamental_operator_set``` to respect the order of blocks in gf_struct

This PR still contains ***unfixed test failures*** for the atom_diag part of triqs.

@krivenko Could you comment on/review this PR and have a look at the test failures in atom_diag?