### PR TITLE
Fix the delta(g) function in pytriqs.gf.tools after tail adjustments

### DIFF
--- a/pytriqs/gf/tools.py
+++ b/pytriqs/gf/tools.py
@@ -18,11 +18,10 @@
 # TRIQS. If not, see <http://www.gnu.org/licenses/>.
 #
 ################################################################################
-import lazy_expressions, descriptors
+import lazy_expressions, descriptors, gf_fnt
 from meshes import MeshImFreq, MeshReFreq, MeshImTime, MeshReTime, MeshLegendre
 from block_gf import BlockGf
 from gf import Gf
-from descriptor_base import A_Omega_Plus_B
 import numpy as np
 from itertools import product
 from backwd_compat.gf_refreq import GfReFreq 
@@ -59,6 +58,9 @@ def transpose(x):
 def delta(g):
     """
     Compute Delta_iw from G0_iw.
+    CAUTION: This function assumes the following properties of g
+      * The diagonal components of g should decay as 1/iOmega
+      * g should fullfill the property g[iw][i,j] = conj(g[-iw][j,i])
 
     Parameters
     ----------
@@ -71,14 +73,16 @@ def delta(g):
                Hybridization function.
     """
 
-    raise RuntimeError, "OBSOLETE : TO BE REPLACED"
     if isinstance(g, BlockGf):
-    	return BlockGf(name_block_generator = [ (n, delta(g0)) for n,g0 in g], make_copies=False)
+        return BlockGf(name_block_generator = [ (n, delta(g0)) for n,g0 in g], make_copies=False)
     elif isinstance(g.mesh, MeshImFreq):
-    	g0_iw_inv = inverse(g)
-    	delta_iw = g0_iw_inv.copy()
-    	delta_iw << A_Omega_Plus_B(g0_iw_inv.tail[-1], g0_iw_inv.tail[0])
-    	delta_iw -= g0_iw_inv
+        assert len(g.target_shape) in [0,2], "delta(g) requires a matrix or scalar_valued Green function"
+        assert gf_fnt.is_gf_hermitian(g), "delta(g) requires a Green function with the property g[iw][i,j] = conj(g[-iw][j,i])"
+        delta_iw = g.copy()
+        delta_iw << descriptors.iOmega_n - inverse(g)
+        tail, err = gf_fnt.fit_hermitian_tail(delta_iw)
+        delta_iw << delta_iw - tail[0]
+        if err > 1e-5: print "WARNING: delta extraction encountered a sizeable tail-fit error: ", err
         return delta_iw
     else:
         raise TypeError, "No function delta for g0 object of type %s"%type(g) 

--- a/test/pytriqs/base/tail_issues.py
+++ b/test/pytriqs/base/tail_issues.py
@@ -119,6 +119,15 @@ class test_tail_issues(unittest.TestCase):
         # print "Imag Delta", max_im
         self.assertTrue(max_im < 1e-12)
 
+        # Check Delta(iw) extracted through pytriqs.gf.tools.delta
+        D_exact = g.copy()
+        D_exact << -1.0 * inverse(iOmega_n + 2)
+        D = delta(g)
+        max_diff = np.max(np.abs(D.data - D_exact.data))
+        # print "Diff Delta Extraction", max_diff
+        self.assertTrue(max_diff < 1e-10)
+
+
     def test_noisy_gf(self):
         for noise in [1e-4, 1e-3, 1e-2]:
             self.noisy_gf(noise)


### PR DESCRIPTION
As of popular request this PR adds back the `delta(g)` pytriqs functionality after the 2.0 tail adjustments.
This new function is very rigorous in its checks of the tail-fit error and fundamental Green Function properties

* The property `g_ij(iw) = g_ji(iw)*` of the input is explicitly checked
* The underlying tailfit implicitly assumes the above property
* The least squares error of the underlying tailfit is evaluated and a Warning is thrown if it exceeds `1e-5`