### PR TITLE
Remove unnecessary modulo operations from index_to_linear of cluster_mesh

### DIFF
--- a/test/pytriqs/base/brillouin_zone.py
+++ b/test/pytriqs/base/brillouin_zone.py
@@ -1,37 +1,24 @@
 from numpy import *
 from numpy.linalg import *
-#from matplotlib.pyplot import *
 from pytriqs.gf import *
 from pytriqs.lattice import *
-units =[
-        matrix([[1.,0.,0.],[0.,1.,0.],[0.,0.,1.]], float), #square lattice
-        matrix([[1.,0.,0.],[0.5,sqrt(3)/2.,0.],[0.,0.,1.]], float)  #triangular lattice
-       ]
-per_mats = [
-     matrix([[16,0,0],[0,16,0],[0,0,1]], int32),
-     matrix([[2,0,0],[0,4,0],[0,0,1]], int32),
-     matrix([[1,2,0],[-2,1,0],[0,0,1]], int32),
-     matrix([[6,6,0],[-6,6,0],[0,0,1]], int32)
-]
-        
-#gs=GridSpec(2,4)
-#isub=0
-for unit in units:
- bz=BrillouinZone(BravaisLattice(unit))
- for per_mat in per_mats:
-#  subplot(gs[isub], aspect="equal");isub+=1
-#  title(r"$N_c=%s$"%(det(per_mat)))
-  k_mesh = MeshBrillouinZone(bz, per_mat)
-#  for k in k_mesh:
-#    plot(k[0],k[1],'or')
-#  xticks([0,pi,2*pi])  
-#  yticks([0,pi,2*pi])  
-#  #xticklabels(["0",r"$\pi$",r"$2\pi$"])  
-#  grid()
-#tight_layout()
-assert k_mesh.locate_neighbours([0.,5.,0.]) == [4,4,0]
+from math import pi
+
+# ---- square lattice : 16 x 16 x 1
+units = matrix([[1.,0.,0.],[0.,1.,0.],[0.,0.,1.]], float)
+per_mat = matrix([[16, 0, 0],[0, 16, 0],[0, 0, 1]], int32)
+bz=BrillouinZone(BravaisLattice(units))
+k_mesh = MeshBrillouinZone(bz, per_mat)
+
+assert k_mesh.locate_neighbours([pi/2,  pi, 0.0]) == [4, 8, 0]
+assert k_mesh.locate_neighbours([pi/8,2*pi, 0.0]) == [1, 16, 0]
+
+# ---- triangular lattice : 6 x 6 x 1
+units = matrix([[1.,0.,0.],[0.5,sqrt(3)/2.,0.],[0.,0.,1.]], float)
+per_mat=  matrix([[6, 6, 0],[-6, 6, 0],[0, 0, 1]], int32)
+bz=BrillouinZone(BravaisLattice(units))
+k_mesh = MeshBrillouinZone(bz, per_mat)
+
+assert k_mesh.locate_neighbours([0.,5.,0.]) == [4, 4, 0]
 assert k_mesh.locate_neighbours([2.,1.,0.]) == [4, 0, 0]
 assert k_mesh.locate_neighbours([2.,0.,0.]) == [3, -1, 0]
-
-assert k_mesh.index_to_linear(k_mesh.locate_neighbours([2.,1.,0.])) == 24
-assert k_mesh.index_to_linear(k_mesh.locate_neighbours([2.,0.,0.])) == 23

--- a/test/triqs/gfs/g_r_k.cpp
+++ b/test/triqs/gfs/g_r_k.cpp
@@ -31,11 +31,11 @@ TEST(Gf, r_k) {
   EXPECT_ARRAY_NEAR(gk.data(), gk2.data());
 
   // check gr
-  auto gr_test        = gf<cyclic_lattice>{{N, N}, {S, S}};
-  gr_test[{1, 0, 0}]  = -1;
-  gr_test[{-1, 0, 0}] = -1;
-  gr_test[{0, 1, 0}]  = -1;
-  gr_test[{0, -1, 0}] = -1;
+  auto gr_test           = gf<cyclic_lattice>{{N, N}, {S, S}};
+  gr_test[{1, 0, 0}]     = -1;
+  gr_test[{N - 1, 0, 0}] = -1;
+  gr_test[{0, 1, 0}]     = -1;
+  gr_test[{0, N - 1, 0}] = -1;
 
   EXPECT_ARRAY_NEAR(gr.data(), gr_test.data());
 

--- a/test/triqs/gfs/gf_empty.cpp
+++ b/test/triqs/gfs/gf_empty.cpp
@@ -9,6 +9,6 @@ TEST(Gf, Exceptions) {
 
   auto g = gf<imtime, scalar_valued>{};
 
-  EXPECT_THROW(g[closest_mesh_pt(5.3)], triqs::arrays::key_error);
+  ASSERT_DEATH(g[closest_mesh_pt(5.3)], "");
 }
 MAKE_MAIN;

--- a/triqs/gfs/gf/_gf_view_common.hpp
+++ b/triqs/gfs/gf/_gf_view_common.hpp
@@ -40,7 +40,10 @@ template <typename... Args> decltype(auto) operator()(Args &&... args) && {
 // ------------- All the [] operators without lazy arguments -----------------------------
 
 // pass a index_t of the mesh
-decltype(auto) operator[](mesh_index_t const &arg) { return dproxy_t::invoke(_data, _mesh.index_to_linear(arg)); }
+decltype(auto) operator[](mesh_index_t const &arg) {
+  EXPECTS(_mesh.is_within_boundary(arg));
+  return dproxy_t::invoke(_data, _mesh.index_to_linear(arg));
+}
 decltype(auto) operator[](mesh_index_t const &arg) const { return dproxy_t::invoke(_data, _mesh.index_to_linear(arg)); }
 
 // pass a mesh_point of the mesh

--- a/triqs/gfs/gf/_gf_view_common.hpp
+++ b/triqs/gfs/gf/_gf_view_common.hpp
@@ -1,5 +1,5 @@
 
-// common to many classes 
+// common to many classes
 
 // ------------- All the call operators arguments -----------------------------
 
@@ -216,5 +216,3 @@ friend mpi_lazy<mpi::tag::scatter, const_view_type> mpi_scatter(this_t const &a,
 friend mpi_lazy<mpi::tag::gather, const_view_type> mpi_gather(this_t const &a, mpi::communicator c = {}, int root = 0, bool all = false) {
   return {a(), c, root, all};
 }
-
-

--- a/triqs/gfs/meshes/discrete.hpp
+++ b/triqs/gfs/meshes/discrete.hpp
@@ -51,9 +51,19 @@ namespace triqs {
       ///
       utility::mini_vector<size_t, 1> size_of_components() const { return {size()}; }
 
+      /// Is the point in the mesh ?
+      bool is_within_boundary(all_t) const { return true; }
+      bool is_within_boundary(index_t idx) const { return ((idx >= 0) && (idx < size())); }
+
       /// Conversions point <-> index <-> discrete_index
-      long index_to_point(index_t ind) const { return ind; }
-      long index_to_linear(index_t ind) const { return ind; }
+      long index_to_point(index_t idx) const {
+        EXPECTS(is_within_boundary(idx));
+        return idx;
+      }
+      long index_to_linear(index_t idx) const {
+        EXPECTS(is_within_boundary(idx));
+        return idx;
+      }
 
       // -------------------- mesh_point -------------------
 
@@ -70,12 +80,9 @@ namespace triqs {
 
       // -------------- Evaluation of a function on the grid --------------------------
 
-      /// Is the point in the mesh ?
-      bool is_within_boundary(index_t const &p) const { return ((p >= 0) && (p < size())); }
-      //bool is_within_boundary(index_t const &p) const { return ((p >= first_index_window()) && (p <= last_index_window())); }
-
       long get_interpolation_data(long n) const { return n; }
       template <typename F> auto evaluate(F const &f, long n) const { return f[n]; }
+
       // -------------------- MPI -------------------
 
       // -------------------- HDF5 -------------------

--- a/triqs/gfs/meshes/discrete.hpp
+++ b/triqs/gfs/meshes/discrete.hpp
@@ -52,7 +52,7 @@ namespace triqs {
       utility::mini_vector<size_t, 1> size_of_components() const { return {size()}; }
 
       /// Is the point in the mesh ?
-      bool is_within_boundary(all_t) const { return true; }
+      static constexpr bool is_within_boundary(all_t) { return true; }
       bool is_within_boundary(index_t idx) const { return ((idx >= 0) && (idx < size())); }
 
       /// Conversions point <-> index <-> discrete_index

--- a/triqs/gfs/meshes/discrete.hpp
+++ b/triqs/gfs/meshes/discrete.hpp
@@ -25,15 +25,15 @@
 namespace triqs {
   namespace gfs {
 
-   template <typename Domain> struct discrete{};
+    template <typename Domain> struct discrete {};
 
-  template <typename Domain> struct gf_mesh<discrete<Domain>> {
+    template <typename Domain> struct gf_mesh<discrete<Domain>> {
 
       using domain_t       = Domain;
       using index_t        = long;
       using linear_index_t = long;
       using mesh_point_t   = mesh_point<gf_mesh<discrete<Domain>>>;
-      using var_t = discrete<Domain>;
+      using var_t          = discrete<Domain>;
 
       // -------------------- Constructors -------------------
 
@@ -104,10 +104,10 @@ namespace triqs {
         m = gf_mesh(std::move(dom));
       }
 
-      friend void h5_write(h5::group fg, std::string const &subgroup_name, gf_mesh const &m) { h5_write_impl(fg, subgroup_name, m, "MeshDiscrete");}
+      friend void h5_write(h5::group fg, std::string const &subgroup_name, gf_mesh const &m) { h5_write_impl(fg, subgroup_name, m, "MeshDiscrete"); }
 
       friend void h5_read(h5::group fg, std::string const &subgroup_name, gf_mesh &m) { h5_read_impl(fg, subgroup_name, m, "MeshDiscrete"); }
- 
+
       // -------------------- boost serialization -------------------
 
       friend class boost::serialization::access;
@@ -123,7 +123,8 @@ namespace triqs {
     };
 
     template <typename Domain>
-    struct mesh_point<gf_mesh<discrete<Domain>>> : tag::mesh_point, public utility::arithmetic_ops_by_cast<mesh_point<gf_mesh<discrete<Domain>>>, long> {
+    struct mesh_point<gf_mesh<discrete<Domain>>> : tag::mesh_point,
+                                                   public utility::arithmetic_ops_by_cast<mesh_point<gf_mesh<discrete<Domain>>>, long> {
       using discrete_mesh_t = gf_mesh<discrete<Domain>>;
       using index_t         = typename discrete_mesh_t::index_t;
       discrete_mesh_t const *m;

--- a/triqs/gfs/meshes/imfreq.hpp
+++ b/triqs/gfs/meshes/imfreq.hpp
@@ -134,14 +134,26 @@ namespace triqs::gfs {
     ///
     utility::mini_vector<size_t, 1> size_of_components() const { return {size_t(size())}; }
 
+    /// Is the point in mesh ?
+    bool is_within_boundary(all_t) const { return true; }
+    bool is_within_boundary(long n) const { return ((n >= first_index()) && (n <= last_index())); }
+    bool is_within_boundary(index_t idx) const { return is_within_boundary(idx.value); }
+    bool is_within_boundary(matsubara_freq const &f) const { return is_within_boundary(f.n); }
+
     /// From an index of a point in the mesh, returns the corresponding point in the domain
-    domain_pt_t index_to_point(index_t ind) const { return 1_j * M_PI * (2 * ind.value + (_dom.statistic == Fermion)) / _dom.beta; }
+    domain_pt_t index_to_point(index_t idx) const {
+      EXPECTS(is_within_boundary(idx));
+      return 1_j * M_PI * (2 * idx.value + (_dom.statistic == Fermion)) / _dom.beta;
+    }
 
     /// Flatten the index in the positive linear index for memory storage (almost trivial here).
-    long index_to_linear(index_t ind) const { return ind.value - first_index(); }
+    long index_to_linear(index_t idx) const {
+      EXPECTS(is_within_boundary(idx));
+      return idx.value - first_index();
+    }
 
     /// Reverse of index_to_linear
-    index_t linear_to_index(long lind) const { return {lind + first_index()}; }
+    index_t linear_to_index(long lidx) const { return {lidx + first_index()}; }
 
     // -------------------- Accessors (other) -------------------
 
@@ -184,11 +196,6 @@ namespace triqs::gfs {
     inline const_iterator cend() const;
 
     // -------------- Evaluation of a function on the grid --------------------------
-
-    /// Is the point in mesh ?
-    bool is_within_boundary(all_t) const { return true; }
-    bool is_within_boundary(long n) const { return ((n >= first_index()) && (n <= last_index())); }
-    bool is_within_boundary(matsubara_freq const &f) const { return is_within_boundary(f.n); }
 
     // For multivar evaluation
     interpol_data_all_t get_interpolation_data(all_t) const { return {}; }

--- a/triqs/gfs/meshes/imfreq.hpp
+++ b/triqs/gfs/meshes/imfreq.hpp
@@ -135,7 +135,7 @@ namespace triqs::gfs {
     utility::mini_vector<size_t, 1> size_of_components() const { return {size_t(size())}; }
 
     /// Is the point in mesh ?
-    bool is_within_boundary(all_t) const { return true; }
+    static constexpr bool is_within_boundary(all_t) { return true; }
     bool is_within_boundary(long n) const { return ((n >= first_index()) && (n <= last_index())); }
     bool is_within_boundary(index_t idx) const { return is_within_boundary(idx.value); }
     bool is_within_boundary(matsubara_freq const &f) const { return is_within_boundary(f.n); }

--- a/triqs/gfs/meshes/imtime.hpp
+++ b/triqs/gfs/meshes/imtime.hpp
@@ -55,7 +55,9 @@ namespace triqs {
       gf_mesh(double beta, statistic_enum S, long n_time_slices) : gf_mesh({beta, S}, n_time_slices) {}
 
       /// For imtime the point is always in the mesh, since we use anti-periodicity or periodicity. Needed for cartesian product.
-      bool is_within_boundary(double x) const { return true; }
+      static constexpr bool is_within_boundary(all_t) { return true; }
+      static constexpr bool is_within_boundary(double) { return true; }
+      static constexpr bool is_within_boundary(index_t) { return true; }
 
       /// evaluation
       template <typename F> auto evaluate(F const &f, double x) const {

--- a/triqs/gfs/meshes/imtime.hpp
+++ b/triqs/gfs/meshes/imtime.hpp
@@ -54,11 +54,6 @@ namespace triqs {
     */
       gf_mesh(double beta, statistic_enum S, long n_time_slices) : gf_mesh({beta, S}, n_time_slices) {}
 
-      /// For imtime the point is always in the mesh, since we use anti-periodicity or periodicity. Needed for cartesian product.
-      static constexpr bool is_within_boundary(all_t) { return true; }
-      static constexpr bool is_within_boundary(double) { return true; }
-      static constexpr bool is_within_boundary(index_t) { return true; }
-
       /// evaluation
       template <typename F> auto evaluate(F const &f, double x) const {
         auto id = this->get_interpolation_data(x);

--- a/triqs/gfs/meshes/linear.hpp
+++ b/triqs/gfs/meshes/linear.hpp
@@ -45,22 +45,6 @@ namespace triqs {
       }
       bool operator!=(linear_mesh const &M) const { return !(operator==(M)); }
 
-      // -------------------- Accessors (from concept) -------------------
-
-      /// The corresponding domain
-      domain_t const &domain() const { return _dom; }
-
-      /// Size (linear) of the mesh of the window
-      long size() const { return L; }
-
-      utility::mini_vector<size_t, 1> size_of_components() const { return {size_t(size())}; }
-
-      /// From an index of a point in the mesh, returns the corresponding point in the domain
-      domain_pt_t index_to_point(index_t ind) const { return xmin + ind * del; }
-
-      /// Flatten the index in the positive linear index for memory storage (almost trivial here).
-      long index_to_linear(index_t ind) const { return ind; }
-
       // -------------------- Accessors (other) -------------------
 
       /// Step of the mesh
@@ -71,6 +55,33 @@ namespace triqs {
 
       /// Max of the mesh
       double x_max() const { return xmax; }
+
+      // -------------------- Accessors (from concept) -------------------
+
+      /// The corresponding domain
+      domain_t const &domain() const { return _dom; }
+
+      /// Size (linear) of the mesh of the window
+      long size() const { return L; }
+
+      utility::mini_vector<size_t, 1> size_of_components() const { return {size_t(size())}; }
+
+      /// Is the point in mesh ?
+      bool is_within_boundary(all_t) const { return true; }
+      bool is_within_boundary(double x) const { return ((x >= x_min()) && (x <= x_max())); }
+      bool is_within_boundary(index_t idx) const { return ((idx >= 0) && (idx < L)); }
+
+      /// From an index of a point in the mesh, returns the corresponding point in the domain
+      domain_pt_t index_to_point(index_t idx) const {
+        EXPECTS(is_within_boundary(idx));
+        return xmin + idx * del;
+      }
+
+      /// Flatten the index in the positive linear index for memory storage (almost trivial here).
+      long index_to_linear(index_t idx) const {
+        EXPECTS(is_within_boundary(idx));
+        return idx;
+      }
 
       // -------------------- mesh_point -------------------
 
@@ -86,12 +97,6 @@ namespace triqs {
       const_iterator end() const { return const_iterator(this, true); }
       const_iterator cbegin() const { return const_iterator(this); }
       const_iterator cend() const { return const_iterator(this, true); }
-
-      // ----------------------------------------
-
-      /// Is the point in mesh ?
-      bool is_within_boundary(double x) const { return ((x >= x_min()) && (x <= x_max())); }
-      //bool is_within_boundary(double x) const { return ((x >= x_min_window()) && (x <= x_max_window())); }
 
       // -------------- Evaluation of a function on the grid --------------------------
 

--- a/triqs/gfs/meshes/linear.hpp
+++ b/triqs/gfs/meshes/linear.hpp
@@ -67,7 +67,7 @@ namespace triqs {
       utility::mini_vector<size_t, 1> size_of_components() const { return {size_t(size())}; }
 
       /// Is the point in mesh ?
-      bool is_within_boundary(all_t) const { return true; }
+      static constexpr bool is_within_boundary(all_t) { return true; }
       bool is_within_boundary(double x) const { return ((x >= x_min()) && (x <= x_max())); }
       bool is_within_boundary(index_t idx) const { return ((idx >= 0) && (idx < L)); }
 

--- a/triqs/lattice/cluster_mesh.hpp
+++ b/triqs/lattice/cluster_mesh.hpp
@@ -174,9 +174,6 @@ namespace triqs {
       }
       bool operator!=(cluster_mesh const &M) const { return !(operator==(M)); }
 
-      /// Reduce point modulo to the lattice.
-      inline mesh_point_t modulo_reduce(index_t const &r) const;
-
       /// locate the closest point
       inline index_t locate_neighbours(point_t const &x) const {
         auto inv_units = inverse(units);
@@ -257,21 +254,17 @@ namespace triqs {
       double operator()(int d) const { return m->index_to_point(index())[d]; }
       double operator[](int d) const { return operator()(d); }
       friend std::ostream &operator<<(std::ostream &out, mesh_point const &x) { return out << (lattice_point)x; }
-      mesh_point operator-() const { return mesh_point{*m, m->modulo_reduce({-index()[0], -index()[1], -index()[2]})}; }
+      mesh_point operator-() const { return mesh_point{*m, m->index_modulo({-index()[0], -index()[1], -index()[2]})}; }
       mesh_t const &mesh() const { return *m; }
     };
 
     // --- impl
-    inline mesh_point<cluster_mesh> cluster_mesh::operator[](index_t i) const { return mesh_point<cluster_mesh>{*this, this->modulo_reduce(i)}; }
+    inline mesh_point<cluster_mesh> cluster_mesh::operator[](index_t i) const { return mesh_point<cluster_mesh>{*this, this->index_modulo(i)}; }
 
     inline cluster_mesh::const_iterator cluster_mesh::begin() const { return const_iterator(this); }
     inline cluster_mesh::const_iterator cluster_mesh::end() const { return const_iterator(this, true); }
     inline cluster_mesh::const_iterator cluster_mesh::cbegin() const { return const_iterator(this); }
     inline cluster_mesh::const_iterator cluster_mesh::cend() const { return const_iterator(this, true); }
 
-    /// Reduce point modulo to the lattice.
-    inline cluster_mesh::mesh_point_t cluster_mesh::modulo_reduce(index_t const &r) const {
-      return mesh_point_t{*this, {_modulo(r[0], 0), _modulo(r[1], 1), _modulo(r[2], 2)}};
-    }
   } // namespace gfs
 } // namespace triqs

--- a/triqs/lattice/cluster_mesh.hpp
+++ b/triqs/lattice/cluster_mesh.hpp
@@ -124,10 +124,10 @@ namespace triqs {
 
       /// from the index (n_i) to the cartesian coordinates
       /** for a point M of coordinates n_i in the {a_i} basis, the cartesian coordinates are
-    *     $$ OM_i = \sum_j n_j X_{ji} $$
-    * @param index_t the (integer) coordinates of the point (in basis a_i)
-    * @warning can be made faster by writing this a matrix-vector multiplication
-    */
+       *     $$ OM_i = \sum_j n_j X_{ji} $$
+       * @param index_t the (integer) coordinates of the point (in basis a_i)
+       * @warning can be made faster by writing this a matrix-vector multiplication
+       */
       point_t index_to_point(index_t const &n) const {
         point_t M(3);
         M() = 0.0;
@@ -204,7 +204,7 @@ namespace triqs {
       //  BOOST Serialization
       friend class boost::serialization::access;
       template <class Archive> void serialize(Archive &ar, const unsigned int version) {
-	ar &units;
+        ar &units;
         ar &periodization_matrix;
         ar &dims;
         ar &_size;
@@ -254,7 +254,7 @@ namespace triqs {
       mesh_t const &mesh() const { return *m; }
     };
 
-    // impl
+    // --- impl
     inline mesh_point<cluster_mesh> cluster_mesh::operator[](index_t i) const { return mesh_point<cluster_mesh>{*this, this->modulo_reduce(i)}; }
 
     inline cluster_mesh::const_iterator cluster_mesh::begin() const { return const_iterator(this); }

--- a/triqs/lattice/cluster_mesh.hpp
+++ b/triqs/lattice/cluster_mesh.hpp
@@ -140,7 +140,7 @@ namespace triqs {
       linear_index_t index_to_linear(index_t const &i) const { return _modulo(i[0], 0) * s2 + _modulo(i[1], 1) * s1 + _modulo(i[2], 2); }
 
       /// Is the point in the mesh ? Always true
-      template <typename T> bool is_within_boundary(T const &) const { return true; }
+      template <typename T> static constexpr bool is_within_boundary(T const &) { return true; }
 
       using mesh_point_t = mesh_point<cluster_mesh>;
 

--- a/triqs/lattice/cluster_mesh.hpp
+++ b/triqs/lattice/cluster_mesh.hpp
@@ -118,6 +118,9 @@ namespace triqs {
       using index_t        = utility::mini_vector<long, 3>;
       using linear_index_t = long;
 
+      /// Reduce index modulo to the lattice.
+      index_t index_modulo(index_t const &r) const { return index_t{_modulo(r[0], 0), _modulo(r[1], 1), _modulo(r[2], 2)}; }
+
       size_t size() const { return _size; }
 
       utility::mini_vector<size_t, 1> size_of_components() const { return {size()}; }
@@ -129,6 +132,7 @@ namespace triqs {
        * @warning can be made faster by writing this a matrix-vector multiplication
        */
       point_t index_to_point(index_t const &n) const {
+        EXPECTS(n == index_modulo(n));
         point_t M(3);
         M() = 0.0;
         for (int i = 0; i < 3; i++)
@@ -137,7 +141,10 @@ namespace triqs {
       }
 
       /// flatten the index
-      linear_index_t index_to_linear(index_t const &i) const { return _modulo(i[0], 0) * s2 + _modulo(i[1], 1) * s1 + _modulo(i[2], 2); }
+      linear_index_t index_to_linear(index_t const &i) const {
+        EXPECTS(i == index_modulo(i));
+        return i[0] * s2 + i[1] * s1 + i[2];
+      }
 
       /// Is the point in the mesh ? Always true
       template <typename T> static constexpr bool is_within_boundary(T const &) { return true; }

--- a/triqs/lattice/cluster_mesh.hpp
+++ b/triqs/lattice/cluster_mesh.hpp
@@ -259,7 +259,10 @@ namespace triqs {
     };
 
     // --- impl
-    inline mesh_point<cluster_mesh> cluster_mesh::operator[](index_t i) const { return mesh_point<cluster_mesh>{*this, this->index_modulo(i)}; }
+    inline mesh_point<cluster_mesh> cluster_mesh::operator[](index_t i) const {
+      EXPECTS(i == index_modulo(i));
+      return mesh_point<cluster_mesh>{*this, i};
+    }
 
     inline cluster_mesh::const_iterator cluster_mesh::begin() const { return const_iterator(this); }
     inline cluster_mesh::const_iterator cluster_mesh::end() const { return const_iterator(this, true); }

--- a/triqs/lattice/gf_mesh_brillouin_zone.hpp
+++ b/triqs/lattice/gf_mesh_brillouin_zone.hpp
@@ -105,7 +105,7 @@ namespace triqs {
         for (int i = 0; i < 2; ++i)
           for (int j = 0; j < 2; ++j)
             for (int k = 0; k < 2; ++k) {
-              result.idx[c] = index_t{ia[i][0], ia[j][1], ia[k][2]};
+              result.idx[c] = index_modulo(index_t{ia[i][0], ia[j][1], ia[k][2]});
               result.w[c]   = wa[i][0] * wa[j][1] * wa[k][2];
               c++;
             }

--- a/triqs/lattice/gf_mesh_cyclic_lattice.hpp
+++ b/triqs/lattice/gf_mesh_cyclic_lattice.hpp
@@ -56,9 +56,6 @@ namespace triqs {
 
       // -------------- Evaluation of a function on the grid --------------------------
 
-      /// Reduce index modulo to the lattice.
-      index_t index_modulo(index_t const &r) const { return index_t{_modulo(r[0], 0), _modulo(r[1], 1), _modulo(r[2], 2)}; }
-
       interpol_data_0d_t<index_t> get_interpolation_data(index_t const &x) const { return {index_modulo(x)}; }
 
       template <typename F> auto evaluate(F const &f, index_t const &x) const {

--- a/triqs/lattice/gf_mesh_cyclic_lattice.hpp
+++ b/triqs/lattice/gf_mesh_cyclic_lattice.hpp
@@ -45,7 +45,7 @@ namespace triqs {
 
       ///Construct gf_mesh<cyclic_lattice> from three linear sizes assuming a cubic lattice (backward compatibility)
       gf_mesh(int L1 = 1, int L2 = 1, int L3 = 1)
-	 : bl{make_unit_matrix<double>(3)}, cluster_mesh{make_unit_matrix<double>(3), matrix<int>{{{L1, 0, 0}, {0, L2, 0}, {0, 0, L3}}}} {}
+         : bl{make_unit_matrix<double>(3)}, cluster_mesh{make_unit_matrix<double>(3), matrix<int>{{{L1, 0, 0}, {0, L2, 0}, {0, 0, L3}}}} {}
 
       ///Construct gf_mesh<cyclic_lattice> from domain (bravais_lattice) and int L (linear size of Cluster mesh)
       gf_mesh(bravais_lattice const &bl_, int L)
@@ -68,9 +68,7 @@ namespace triqs {
 
       // ------------------- Comparison -------------------
 
-      bool operator==(gf_mesh<cyclic_lattice> const &M) const {
-	return bl == M.domain() && cluster_mesh::operator==(M);
-      }
+      bool operator==(gf_mesh<cyclic_lattice> const &M) const { return bl == M.domain() && cluster_mesh::operator==(M); }
 
       bool operator!=(gf_mesh<cyclic_lattice> const &M) const { return !(operator==(M)); }
 
@@ -96,7 +94,7 @@ namespace triqs {
         h5::group gr = fg.open_group(subgroup_name);
         try { // Care for Backward Compatibility
           h5_read(gr, "bl", m.bl);
-	  return;
+          return;
         } catch (triqs::runtime_error const &re) {}
         try {
           h5_read(gr, "bravais_lattice", m.bl);

--- a/triqs/utility/macros.hpp
+++ b/triqs/utility/macros.hpp
@@ -18,10 +18,10 @@
  * TRIQS. If not, see <http://www.gnu.org/licenses/>.
  *
  ******************************************************************************/
-#ifndef TRIQS_UTILITY_MACROS_H
-#define TRIQS_UTILITY_MACROS_H
+#pragma once
 
 #include <triqs/utility/first_include.hpp>
+#include <triqs/utility/stack_trace.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <type_traits>
 #include <iostream>
@@ -68,14 +68,31 @@ namespace triqs {
 
 #define FORCEINLINE __inline__ __attribute__((always_inline))
 
-#define TERMINATE(X) std::cerr << "Terminating at " << __FILE__ << ":" << __LINE__ << "\n"; std::cerr << X; std::terminate(); }
+#define TERMINATE(X)                                                                                                                                 \
+  std::cerr << "Terminating at " << __FILE__ << ":" << __LINE__ << "\n";                                                                             \
+  std::cerr << X;                                                                                                                                    \
+  std::terminate();                                                                                                                                  \
+  }
 
 // Macros mimicing the c++20 contracts behavior
-// FIXME c++20 : replace by [[ expects : X ]]
-#define EXPECTS(X) if(!(X)){ std::cerr << "Precondition " << AS_STRING(X) << " violated at " << __FILE__ << ":" << __LINE__ << "\n"; std::terminate(); }
-// FIXME c++20 : replace by [[ assert : X ]]
-#define ASSERT(X) if(!(X)){ std::cerr << "Assertion " << AS_STRING(X) << " violated at " << __FILE__ << ":" << __LINE__ << "\n"; std::terminate(); }
-// FIXME c++20 : replace by [[ ensures : X ]]
-#define ENSURES(X) if(!(X)){ std::cerr << "Postcondition " << AS_STRING(X) << " violated at " << __FILE__ << ":" << __LINE__ << "\n"; std::terminate(); }
-
+#ifdef TRIQS_DEBUG
+#define EXPECTS(X)                                                                                                                                   \
+  if (!(X)) {                                                                                                                                        \
+    std::cerr << "Precondition " << AS_STRING(X) << " violated at " << __FILE__ << ":" << __LINE__ << "\n" << triqs::utility::stack_trace();         \
+    std::terminate();                                                                                                                                \
+  }
+#define ASSERT(X)                                                                                                                                    \
+  if (!(X)) {                                                                                                                                        \
+    std::cerr << "Assertion " << AS_STRING(X) << " violated at " << __FILE__ << ":" << __LINE__ << "\n" << triqs::utility::stack_trace();            \
+    std::terminate();                                                                                                                                \
+  }
+#define ENSURES(X)                                                                                                                                   \
+  if (!(X)) {                                                                                                                                        \
+    std::cerr << "Postcondition " << AS_STRING(X) << " violated at " << __FILE__ << ":" << __LINE__ << "\n" << triqs::utility::stack_trace();        \
+    std::terminate();                                                                                                                                \
+  }
+#else
+#define EXPECTS(X)
+#define ASSERT(X)
+#define ENSURES(X)
 #endif

--- a/triqs/utility/stack_trace.cpp
+++ b/triqs/utility/stack_trace.cpp
@@ -33,7 +33,6 @@ namespace triqs::utility {
     // On Os X, we use lldb, on linux gdb to decipher the call stack for us
     // We launch it with a pipe, and get back the output
 #ifdef __APPLE__
-
     std::string cmd             = "lldb -p " + std::to_string(getpid()) + " --batch -o \"bt\" 2>&1";
     const char *PYTHON_SENTINEL = "Python";
 #else


### PR DESCRIPTION
* Explicitly check is_within_boundary for index_to_linear and index_to_point in Debug mode
* Print stack_trace in contract macros EXPECTS, ENSURES, ASSERT and disable without debugging
* Minor formatting corrections
