### PR TITLE
[gf] Move factory functions into separate gf_factories module

### DIFF
--- a/pytriqs/gf/CMakeLists.txt
+++ b/pytriqs/gf/CMakeLists.txt
@@ -14,6 +14,7 @@ SET(PYTHON_SOURCES
 
 add_cpp2py_module(meshes)
 add_cpp2py_module(gf_fnt)
+add_cpp2py_module(gf_factories)
 add_cpp2py_module(wrapped_aux)
 
 install(FILES ${PYTHON_SOURCES} DESTINATION ${TRIQS_PYTHON_LIB_DEST}/gf)

--- a/pytriqs/gf/__init__.py
+++ b/pytriqs/gf/__init__.py
@@ -40,9 +40,11 @@ from backwd_compat.gf_refreq import *
 from backwd_compat.gf_retime import *
 from backwd_compat.gf_legendre import *
 
-from meshes import MeshBrillouinZone, MeshCyclicLattice
+from meshes import MeshBrillouinZone, MeshCyclicLattice, make_adjoint_mesh
 
-from gf_fnt import fit_tail, fit_hermitian_tail, density, make_adjoint_mesh, set_from_fourier, make_real_in_tau, is_gf_real_in_tau, make_gf_from_fourier, set_from_legendre, set_from_imfreq, set_from_imtime, make_hermitian, is_gf_hermitian, fit_tail_on_window, fit_hermitian_tail_on_window, replace_by_tail, replace_by_tail_in_fit_window, rebinning_tau, enforce_discontinuity, GfIndices
+from gf_fnt import fit_tail, fit_hermitian_tail, density, set_from_fourier, is_gf_real_in_tau, set_from_legendre, set_from_imfreq, set_from_imtime, is_gf_hermitian, fit_tail_on_window, fit_hermitian_tail_on_window, replace_by_tail, replace_by_tail_in_fit_window, rebinning_tau, enforce_discontinuity, GfIndices
+
+from gf_factories import make_real_in_tau, make_gf_from_fourier, make_hermitian
 
 import warnings
 def make_gf_from_inverse_fourier(*args):

--- a/pytriqs/gf/gf_factories_desc.py
+++ b/pytriqs/gf/gf_factories_desc.py
@@ -1,0 +1,90 @@
+from cpp2py.wrap_generator import *
+
+# This modules contains factory functions that generate a Green function
+m = module_(full_name = "pytriqs.gf.gf_factories", doc = "C++ wrapping of functions on Green functions ...", app_name="triqs")
+
+m.add_imports("pytriqs.gf.meshes")
+
+m.add_include("<triqs/gfs.hpp>")
+m.add_include("<triqs/gfs/legacy_for_python_api.hpp>")
+
+m.add_include("<cpp2py/converters/pair.hpp>")
+m.add_include("<cpp2py/converters/vector.hpp>")
+m.add_include("<triqs/cpp2py_converters.hpp>")
+
+m.add_using("namespace triqs::arrays")
+m.add_using("namespace triqs::gfs")
+
+# ---------------------- make_hermitian, make_real_in_tau --------------------
+for gf_type in ["gf", "block_gf", "block2_gf"]:
+    gf_view_type = gf_type +  '_view'
+    # make_hermitian
+    m.add_function("%s<imfreq, scalar_valued> make_hermitian(%s<imfreq, scalar_valued> g)"%(gf_type, gf_view_type),
+                doc = "Symmetrize the Green function in freq, to ensure its hermiticity (G_ij[iw] = G_ji[-iw]*)")
+    m.add_function("%s<imfreq, matrix_valued> make_hermitian(%s<imfreq, matrix_valued> g)"%(gf_type, gf_view_type),
+                doc = "Symmetrize the Green function in freq, to ensure its hermiticity (G_ij[iw] = G_ji[-iw]*)")
+
+    # make_real_in_tau
+    m.add_function("%s<imfreq, scalar_valued> make_real_in_tau(%s<imfreq, scalar_valued> g)"%(gf_type, gf_view_type),
+                doc = "Symmetrize the Green function in freq, to ensure its hermiticity (G_ij[iw] = G_ji[-iw]*)")
+    m.add_function("%s<imfreq, matrix_valued> make_real_in_tau(%s<imfreq, matrix_valued> g)"%(gf_type, gf_view_type),
+                doc = "Symmetrize the Green function in freq, to ensure its hermiticity (G_ij[iw] = G_ji[-iw]*)")
+
+
+# ---------------------- make_gf_from_fourier --------------------
+for Target in  ["scalar_valued", "matrix_valued", "tensor_valued<3>", "tensor_valued<4>"]:
+
+    # === Matsubara and ReTime/Freq Fourier
+    for Meshes in [["imtime", "imfreq"], ["imfreq", "imtime"], ["retime", "refreq"], ["refreq", "retime"]]:
+        for gf_type in ["gf", "block_gf", "block2_gf"]:
+	    gf_view_type = gf_type +  '_view'
+
+            # make_gf_from_fourier
+            m.add_function(name = "make_gf_from_fourier",
+                    signature="%s<%s, %s> make_gf_from_fourier(%s<%s, %s> g_in)"%(gf_type, Meshes[0], Target, gf_view_type, Meshes[1], Target),
+                    doc ="""Create Green function from the Fourier transform of g_in""")
+
+        # make_gf_from_fourier with known moments
+        m.add_function(name = "make_gf_from_fourier",
+               signature="gf<%s, %s> make_gf_from_fourier(gf_view<%s, %s> g_in, gf_mesh<%s> mesh, array_const_view<dcomplex, %s::rank + 1> known_moments)"%(Meshes[0], Target, Meshes[1], Target, Meshes[0], Target),
+               doc ="""Create Green function from the Fourier transform of g_in using the known high-frequency moments""")
+
+        # FIXME We are making copies of the tail
+        m.add_function(name = "make_gf_from_fourier",
+                signature="block_gf<%s, %s> make_gf_from_fourier(block_gf_view<%s, %s> g_in, gf_mesh<%s> mesh, std::vector<array<dcomplex, %s::rank + 1>> known_moments)"%(Meshes[0], Target, Meshes[1], Target, Meshes[0], Target),
+               doc ="""Create Green function from the Fourier transform of g_in using the known high-frequency moments""")
+
+        # FIXME We are making copies of the tail
+        m.add_function(name = "make_gf_from_fourier",
+                signature="block2_gf<%s, %s> make_gf_from_fourier(block2_gf_view<%s, %s> g_in, gf_mesh<%s> mesh, std::vector<std::vector<array<dcomplex, %s::rank + 1>>> known_moments)"%(Meshes[0], Target, Meshes[1], Target, Meshes[0], Target),
+               doc ="""Create Green function from the Fourier transform of g_in using the known high-frequency moments""")
+
+    # Additional overloads for make_gf_from_fourier
+    m.add_function(name = "make_gf_from_fourier",
+                   signature="gf<imfreq, %s> make_gf_from_fourier(gf_view<imtime, %s> g_in, int n_iw)"%(Target, Target),
+                   doc ="""Create Green function from the Fourier transform of g_tau""")
+    m.add_function(name = "make_gf_from_fourier",
+                   signature="gf<imtime, %s> make_gf_from_fourier(gf_view<imfreq, %s> g_in, int n_tau)"%(Target, Target),
+                   doc ="""Create Green function from the Fourier transform of g_iw""")
+
+    m.add_function(name = "make_gf_from_fourier",
+                   signature="gf<refreq, %s> make_gf_from_fourier(gf_view<retime, %s> g_in, bool shift_half_bin)"%(Target, Target),
+                   doc ="""Create Green function from the Fourier transform of g_t""")
+    m.add_function(name = "make_gf_from_fourier",
+                   signature="gf<retime, %s> make_gf_from_fourier(gf_view<refreq, %s> g_in, bool shift_half_bin)"%(Target, Target),
+                   doc ="""Create Green function from the Fourier transform of g_w""")
+
+    # === Lattice Fourier
+    for Meshes in [["cyclic_lattice", "brillouin_zone"], ["brillouin_zone", "cyclic_lattice"]]:
+        for gf_type in ["gf", "block_gf", "block2_gf"]:
+	    gf_view_type = gf_type +  '_view'
+            # make_gf_from_fourier
+            m.add_function(name = "make_gf_from_fourier",
+                    signature="%s<%s, %s> make_gf_from_fourier(%s<%s, %s> g_in)"%(gf_type, Meshes[0], Target, gf_view_type, Meshes[1], Target),
+                    doc ="""Create Green function from the Fourier transform of g_in""")
+
+########################
+##   Code generation
+########################
+
+m.generate_code()

--- a/pytriqs/gf/meshes_desc.py
+++ b/pytriqs/gf/meshes_desc.py
@@ -224,7 +224,17 @@ m.add_property(name = "domain",
 
 module.add_class(m)
 
+############################
+##   Mesh Factory Functions
+############################
+
+# ---------------------- make_adjoint_mesh --------------------
+module.add_function("gf_mesh<brillouin_zone> make_adjoint_mesh(gf_mesh<cyclic_lattice> m)", doc = "Create the adjoint k-mesh")
+module.add_function("gf_mesh<cyclic_lattice> make_adjoint_mesh(gf_mesh<brillouin_zone> m)", doc = "Create the adjoint r-mesh")
+module.add_function("gf_mesh<imfreq> make_adjoint_mesh(gf_mesh<imtime> m, int n_iw = -1)", doc = "Create the adjoint iw-mesh")
+module.add_function("gf_mesh<imtime> make_adjoint_mesh(gf_mesh<imfreq> m, int n_tau = -1)", doc = "Create the adjoint tau-mesh")
+module.add_function("gf_mesh<refreq> make_adjoint_mesh(gf_mesh<retime> m, bool shift_half_bin = false)", doc = "Create the adjoint w-mesh")
+module.add_function("gf_mesh<refreq> make_adjoint_mesh(gf_mesh<retime> m, bool shift_half_bin = false)", doc = "Create the adjoint t-mesh")
 
 ##   Code generation
 module.generate_code()
-


### PR DESCRIPTION
This PR moves all the factory functions (e.g. make_gf_from_fourier) from the
gf_fnt module into a separate gf_factories module. This fixes #713 