### PR TITLE
Fix bug in lattice tools dos for multi-orbital models

### DIFF
--- a/triqs/lattice/tight_binding.cpp
+++ b/triqs/lattice/tight_binding.cpp
@@ -130,7 +130,7 @@ namespace triqs {
         for (int j = 0; j < grid.size(); j++) {
           int a = int((eval(l, j) - epsmin) / deps);
           if (a == int(neps)) a = a - 1;
-          for (int k = 0; k < norb; k++) { rho(a, l) += real(conj(evec(l, k, j)) * evec(l, k, j)); }
+          for (int k = 0; k < norb; k++) { rho(a, k) += real(conj(evec(l, k, j)) * evec(l, k, j)); }
         }
       }
       rho /= grid.size() * deps;


### PR DESCRIPTION
Dear all,
this pull request fixes a wrong orbital index in the calculation of the dos for multi-orbital tight-binding models. The total density of states was ok, however the orbital resolved one was wrong.

This is a tiny 1-line bugfix, thus should be directly merge-able.
Please also consider backporting it to 2.2.x. and 2.1.x.

Thanks, Manuel