### PR TITLE
Move import of mpi into a function

### DIFF
--- a/pytriqs/dos/hilbert_transform.py
+++ b/pytriqs/dos/hilbert_transform.py
@@ -24,7 +24,6 @@ from pytriqs.gf import *
 import types, string, inspect, itertools
 from operator import isSequenceType
 from pytriqs.dos import DOS, DOSFromFunction
-import pytriqs.utility.mpi as mpi
 import numpy
 
 class HilbertTransform:
@@ -128,6 +127,7 @@ class HilbertTransform:
                 assert 0, "field cannot be added to the Green function blocks !. Cf Doc"
 
         def HT(res):
+            import pytriqs.utility.mpi as mpi
             # First compute the eps_hat array
             eps_hat = epsilon_hat(self.dos.eps) if epsilon_hat else numpy.array( [ x* numpy.identity (N1) for x in self.dos.eps] )
             assert eps_hat.shape[0] == self.dos.eps.shape[0], "epsilon_hat function behaves incorrectly"


### PR DESCRIPTION
I've moved the import of pytriqs.utility.mpi into the function "HT" because the mpi library is used only in that function.