### PR TITLE
check block names first, if comparing two block structures

### DIFF
--- a/pytriqs/utility/comparison_tests.py
+++ b/pytriqs/utility/comparison_tests.py
@@ -15,7 +15,9 @@ def assert_gfs_are_close(a, b, precision = 1.e-6):
 def assert_block_gfs_are_close(a, b, precision = 1.e-6):
     assert len(a) == len(b), "Block GFs have different number of blocks"
     for (nx,x),(ny,y) in zip(a,b):
-      assert_gfs_are_close(x, y, precision)
+        # first check if the names of the two blocks match
+        assert nx == ny, "block name {} does not match {}".format(nx,ny)
+        assert_gfs_are_close(x, y, precision)
 
 def assert_block2_gfs_are_close(a, b, precision = 1.e-6):
     assert_block_gfs_are_close(a, b, precision)

--- a/test/pytriqs/base/gf_block.py
+++ b/test/pytriqs/base/gf_block.py
@@ -23,10 +23,10 @@ class test_Gf_Block(unittest.TestCase):
         
         G_vec = [G1, G2, G3]
         
-        B1 = BlockGf(name_list=['0', '1', '2'], block_list=G_vec)
+        B1 = BlockGf(name_list=['1', '2', '3'], block_list=G_vec)
         B2 = B1.copy()
         
-        gf_struct = [ ['1', ['0', '1']], ['2',['0', '1']], ['3',['0', '1']] ]
+        gf_struct = [ ('1', ['0', '1']), ('2',['0', '1']), ('3',['0', '1']) ]
         B3 = BlockGf(mesh=self.iw_mesh, gf_struct=gf_struct)
 
         B3['1'] << inverse(iOmega_n + 2.)
@@ -36,7 +36,7 @@ class test_Gf_Block(unittest.TestCase):
         assert_block_gfs_are_close(B1, B3)
 
         # Scalar-valued blocks
-        gf_struct = [ ['1', []], ['2',[]], ['3',[]] ]
+        gf_struct = [ ('1', []), ('2',[]), ('3',[]) ]
         B4 = BlockGf(mesh=self.iw_mesh, gf_struct=gf_struct)
 
         # Map_block functionality

--- a/triqs/gfs/gf_tests.hpp
+++ b/triqs/gfs/gf_tests.hpp
@@ -37,6 +37,7 @@ namespace triqs {
     template <typename X, typename Y> void assert_block_gfs_are_close(X const &x, Y const &y, double precision) {
 
       if (x.size() != y.size()) TRIQS_RUNTIME_ERROR << "Block GFs have different number of blocks";
+      if (x.block_names() != y.block_names()) TRIQS_RUNTIME_ERROR << "Block GFs have different block_names";
       for (int u = 0; u < x.size(); ++u) assert_gfs_are_close(x[u], y[u], precision);
     }
 
@@ -44,6 +45,7 @@ namespace triqs {
     template <typename X, typename Y> void assert_block2_gfs_are_close(X const &x, Y const &y, double precision) {
 
       if (x.size() != y.size()) TRIQS_RUNTIME_ERROR << "Block2 GFs have different number of blocks";
+      if (x.block_names() != y.block_names()) TRIQS_RUNTIME_ERROR << "Block2 GFs have different block_names";
       for (int i = 0; i < x.size1(); ++i)
         for (int j = 0; j < x.size2(); ++j) assert_gfs_are_close(x(i, j), y(i, j), precision);
     }


### PR DESCRIPTION
When comparing to BlockGfs check if the names of the blocks match as well. Before, only the order of the blocks mattered. (not sure if this shoud go directly in unstable or in py3 branch)