### PR TITLE
Serialize atomdiag to be able to bcast atomdiag containers

### DIFF
--- a/cpp2py/cpp2py/wrap_generator.py
+++ b/cpp2py/cpp2py/wrap_generator.py
@@ -324,6 +324,9 @@ class class_ :
            Whether and how the object is to be serialized.  Possible values are :
            - "tuple" : reduce it to a tuple of smaller objects, using the
               boost serialization compatible template in C++, and the converters of the smaller objects.
+           - "h5" : serialize via a string, made by
+              triqs::serialize/triqs::deserialize.
+              Requires hdf5 >1.8.9.
            - "repr" : serialize via a string produced by python repr, reconstructed by eval.
 
         is_printable : boolean
@@ -341,7 +344,7 @@ class class_ :
       self.py_type = py_type
       c_to_py_type[self.c_type] = self.py_type # register the name translation for the doc generation
       self.hdf5 = hdf5
-      assert serializable in [None, "tuple", "repr"]
+      assert serializable in [None, "h5", "tuple", "repr"]
       self.serializable = serializable
       self.is_printable = is_printable
       self.comparisons = comparisons

--- a/pytriqs/atom_diag/atom_diag_desc.py
+++ b/pytriqs/atom_diag/atom_diag_desc.py
@@ -57,6 +57,7 @@ for c_py, c_cpp, in (('Real','false'),('Complex','true')):
         c_type = c_type,
         is_printable = True,
         hdf5 = True,
+        serializable = "h5",
         doc = "Lightweight exact diagonalization solver (%s version)" % c_py
     )
 

--- a/test/pytriqs/atom_diag/CMakeLists.txt
+++ b/test/pytriqs/atom_diag/CMakeLists.txt
@@ -3,3 +3,5 @@ file(GLOB all_h5_files RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.h5)
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/${all_h5_files} DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
 add_python_test(atom_diag)
+
+add_python_test(atom_diag_bcast MPI_NUMPROC 4)

--- a/test/pytriqs/atom_diag/atom_diag_bcast.py
+++ b/test/pytriqs/atom_diag/atom_diag_bcast.py
@@ -1,6 +1,5 @@
 from pytriqs.operators import *
 from pytriqs.gf import *
-from pytriqs.archive import *
 from pytriqs.atom_diag import *
 from pytriqs.utility.comparison_tests import *
 import numpy as np
@@ -47,16 +46,11 @@ G_iw = atomic_g_iw(ad, beta, gf_struct, 100)
 G_l = atomic_g_l(ad, beta, gf_struct, 20)
 G_w = atomic_g_w(ad, beta, gf_struct, (-2, 2), 400, 0.01)
 
-# HDF5
-if mpi.is_master_node():
-    with HDFArchive('atom_diag_bcast.h5', 'w') as ar:
-        ar['ad'] = ad
-
-
 ad_bcast = None
 if mpi.is_master_node():
-    with HDFArchive('atom_diag_bcast.h5', 'r') as ar:
-        ad_bcast = ar['ad']
+        ad_bcast = ad
+else:
+    ad = None
 
 ad_bcast = mpi.bcast(ad_bcast)
 

--- a/test/pytriqs/atom_diag/atom_diag_bcast.py
+++ b/test/pytriqs/atom_diag/atom_diag_bcast.py
@@ -1,0 +1,75 @@
+from pytriqs.operators import *
+from pytriqs.gf import *
+from pytriqs.archive import *
+from pytriqs.atom_diag import *
+from pytriqs.utility.comparison_tests import *
+import numpy as np
+from itertools import product
+import pytriqs.utility.mpi as mpi
+
+
+fops = [(s,o) for s,o in product(('up','dn'),range(3))]
+
+def make_hamiltonian(mu, U, J, b, t):
+    h = Operator()
+    orbs = range(3)
+    for o in orbs:
+        h += sum(-mu * (n("up", o) + n("dn", o)) for o in orbs)
+    for o in orbs:
+        h += b * (n("up", o) - n("dn", o))
+    for o in orbs:
+        h += U * n("up", o) * n("dn", o)
+    for o1, o2 in product(orbs,orbs):
+        if o1 == o2: continue
+        h += (U - 2 * J) * n("up", o1) * n("dn", o2)
+    for o1, o2 in product(orbs,orbs):
+        if o2 >= o1: continue
+        h += (U - 3 * J) * n("up", o1) * n("up", o2)
+        h += (U - 3 * J) * n("dn", o1) * n("dn", o2)
+    for o1, o2 in product(orbs,orbs):
+        if o1 == o2: continue
+        h += -J * c_dag("up", o1) * c_dag("dn", o1) * c("up", o2) * c("dn", o2)
+        h += -J * c_dag("up", o1) * c_dag("dn", o2) * c("up", o2) * c("dn", o1)
+
+    h += t * c_dag("up", 0) * c("up", 1) + dagger(t * c_dag("up", 0) * c("up", 1))
+    h += t * c_dag("dn", 0) * c("dn", 1) + dagger(t * c_dag("dn", 0) * c("dn", 1))
+
+    return h
+
+ad = AtomDiag(make_hamiltonian(0.4, 1.0, 0.3, 0.03, 0.2), fops)
+
+gf_struct = [['dn',[0,1,2]],['up',[0,1,2]]]
+beta = 10
+
+# create GF for comparison
+G_tau = atomic_g_tau(ad, beta, gf_struct, 400)
+G_iw = atomic_g_iw(ad, beta, gf_struct, 100)
+G_l = atomic_g_l(ad, beta, gf_struct, 20)
+G_w = atomic_g_w(ad, beta, gf_struct, (-2, 2), 400, 0.01)
+
+# HDF5
+if mpi.is_master_node():
+    with HDFArchive('atom_diag_bcast.h5', 'w') as ar:
+        ar['ad'] = ad
+
+
+ad_bcast = None
+if mpi.is_master_node():
+    with HDFArchive('atom_diag_bcast.h5', 'r') as ar:
+        ad_bcast = ar['ad']
+
+ad_bcast = mpi.bcast(ad_bcast)
+
+assert isinstance(ad_bcast, AtomDiagReal)
+
+# GF (real)
+G_tau_bcast = atomic_g_tau(ad_bcast, beta, gf_struct, 400)
+G_iw_bcast = atomic_g_iw(ad_bcast, beta, gf_struct, 100)
+G_l_bcast = atomic_g_l(ad_bcast, beta, gf_struct, 20)
+G_w_bcast = atomic_g_w(ad_bcast, beta, gf_struct, (-2, 2), 400, 0.01)
+
+assert_block_gfs_are_close(G_tau_bcast, G_tau)
+assert_block_gfs_are_close(G_iw_bcast, G_iw)
+assert_block_gfs_are_close(G_l_bcast, G_l)
+assert_block_gfs_are_close(G_w_bcast, G_w)
+

--- a/test/triqs/atom_diag/atom_diag_complex.cpp
+++ b/test/triqs/atom_diag/atom_diag_complex.cpp
@@ -5,12 +5,16 @@
 #include <triqs/atom_diag/gf.hpp>
 #include <triqs/arrays/blas_lapack/dot.hpp>
 #include <triqs/h5.hpp>
+#include <triqs/h5/serialization.hpp>
 
 #include "./hamiltonian.hpp"
 
 using namespace triqs::arrays;
 using namespace triqs::hilbert_space;
+using namespace triqs::h5;
 using namespace triqs::atom_diag;
+
+using atom_diag_cplx = triqs::atom_diag::atom_diag<true>;
 
 //#define GENERATE_REF_H5
 #ifdef GENERATE_REF_H5
@@ -28,7 +32,7 @@ TEST(atom_diag_complex, QuantumNumbers) {
   auto N    = N_up + N_dn;
 
   // Partition with total number of particles
-  auto ad1 = triqs::atom_diag::atom_diag<true>(h, fops, {N});
+  auto ad1 = atom_diag_cplx(h, fops, {N});
 
 #ifndef GENERATE_REF_H5
   vector<int> sp_dim_ref;
@@ -51,7 +55,7 @@ TEST(atom_diag_complex, QuantumNumbers) {
   }
 
   // Partition with N_up and N_dn
-  auto ad2 = triqs::atom_diag::atom_diag<true>(h, fops, {N_up, N_dn});
+  auto ad2 = atom_diag_cplx(h, fops, {N_up, N_dn});
 
 #ifndef GENERATE_REF_H5
   h5_read(ref_file, "/QuantumNumbers/N_up_N_dn/sp_dims", sp_dim_ref);
@@ -92,12 +96,27 @@ TEST(atom_diag_complex, Vacuum) {
   fundamental_operator_set fops;
   fops.insert("up");
   fops.insert("dn");
-  auto ad = triqs::atom_diag::atom_diag<true>(h, fops);
+  auto ad = atom_diag_cplx(h, fops);
 
   EXPECT_EQ(1, ad.get_vacuum_subspace_index());
   auto vac = ad.get_vacuum_state();
   EXPECT_COMPLEX_NEAR(1, dotc(vac, vac), 1e-14);
   for (auto s : {"up", "dn"}) EXPECT_COMPLEX_NEAR(0, dotc(vac, act(n(s), vac, ad)), 1e-14);
+}
+
+TEST(atom_diag_complex, Serialization) {
+  auto h = 2.0 * (n("up") - 0.5) * (n("dn") - 0.5);
+  h += 0.3 * (c_dag("up") * c("dn") + c_dag("dn") * c("up"));
+  h += 0.1_j * (c_dag("up") * c_dag("dn") + c("up") * c("dn"));
+
+  fundamental_operator_set fops;
+  fops.insert("up");
+  fops.insert("dn");
+  auto ad = atom_diag_cplx(h, fops);
+
+  auto ser = serialize(ad);
+  auto ser2 = serialize(deserialize<atom_diag_cplx>(ser));
+  EXPECT_EQ(ser, ser2);
 }
 
 TEST(atom_diag_complex, Autopartition) {
@@ -110,7 +129,7 @@ TEST(atom_diag_complex, Autopartition) {
   dcomplex t  = 0.2_j;
   auto h      = make_hamiltonian<many_body_operator_complex>(mu, U, J, b, t);
 
-  auto ad = triqs::atom_diag::atom_diag<true>(h, fops);
+  auto ad = atom_diag_cplx(h, fops);
 
   using triqs::hilbert_space::hilbert_space;
 #ifndef GENERATE_REF_H5
@@ -247,7 +266,7 @@ TEST(atom_diag_complex, Functions) {
 
   auto h = make_hamiltonian<many_body_operator_complex>(mu, U, J, b, t);
 
-  auto ad = triqs::atom_diag::atom_diag<true>(h, fops);
+  auto ad = atom_diag_cplx(h, fops);
 
   // Partition function
   double z = partition_function(ad, beta);


### PR DESCRIPTION
- brought back h5 serialization option
- make AtomDiag python object serializable via h5
- added tests for mpi bcast functionalities of AtomDiag object