### PR TITLE
Bug fix for the matplotlib interface not working

### DIFF
--- a/python/triqs/plot/mpl_interface.py
+++ b/python/triqs/plot/mpl_interface.py
@@ -110,4 +110,4 @@ def __oplot_impl(top, xlabel_fct, ylabel_fct, legend_fct, obj, xticks_fct,  titl
 
 def use_amsmath():
     rc('text', usetex=True)
-    rc('text.latex', preamble="\usepackage{amsmath}")
+    rc('text.latex', preamble=r"\usepackage{amsmath}")


### PR DESCRIPTION
The matplotlib interface in triqs unstable with python 3 is not working properly on import:
```
from triqs.plot.mpl_interface import oplot
```

giving the error:
```
File ".../triqs/3.x_unstable/lib/python3.7/site-packages/triqs/plot/mpl_interface.py", line 113
    rc('text.latex', preamble="\usepackage{amsmath}")
                             ^
SyntaxError: (unicode error) 'unicodeescape' codec can't decode bytes in position 0-1: truncated \uXXXX escape
```
This due to the changes in handling unicode character inputs: https://het.as.utexas.edu/HET/Software/Matplotlib/devel/portable_code.html

A simple `preamble=r"\usepackage{amsmath}` fixes this problem.