### PR TITLE
Be sure to properly treat both rvalues and lvalues in c2py functions.

### DIFF
--- a/cpp2py/include/cpp2py/converters/optional.hpp
+++ b/cpp2py/include/cpp2py/converters/optional.hpp
@@ -1,14 +1,17 @@
 #pragma once
+#include "../traits.hpp"
+
 namespace cpp2py {
 
  template <typename T> struct py_converter<std::optional<T>> {
 
-  using conv = py_converter<T>;
+   using conv = py_converter<std::decay_t<T>>;
 
-  static PyObject *c2py(std::optional<T> &op) {
-   if (!bool(op)) Py_RETURN_NONE;
-   return conv::c2py(*op);
-  }
+   template <typename O> static PyObject *c2py(O &&op) {
+     static_assert(is_instantiation_of_v<std::optional, std::decay_t<O>>, "Logic Error");
+     if (!bool(op)) Py_RETURN_NONE;
+     return conv::c2py(*(std::forward<O>(op)));
+   }
 
   static bool is_convertible(PyObject *ob, bool raise_exception) {
    return ((ob == Py_None) or conv::is_convertible(ob, raise_exception));

--- a/cpp2py/include/cpp2py/converters/pair.hpp
+++ b/cpp2py/include/cpp2py/converters/pair.hpp
@@ -1,13 +1,15 @@
 #pragma once
-//#include <utility>
+#include "../traits.hpp"
 
 namespace cpp2py {
 
   template <typename T1, typename T2> struct py_converter<std::pair<T1, T2>> {
 
-    static PyObject *c2py(std::pair<T1, T2> const &p) {
-      pyref x1 = py_converter<T1>::c2py(std::get<0>(p));
-      pyref x2 = py_converter<T2>::c2py(std::get<1>(p));
+    template <typename P> static PyObject *c2py(P &&p) {
+      static_assert(is_instantiation_of_v<std::pair, std::decay_t<P>>, "Logic error");
+      pyref x1 = convert_to_python(std::get<0>(std::forward<P>(p)));
+      pyref x2 = convert_to_python(std::get<1>(std::forward<P>(p)));
+
       if (x1.is_null() or x2.is_null()) return NULL;
       return PyTuple_Pack(2, (PyObject *)x1, (PyObject *)x2);
     }

--- a/cpp2py/include/cpp2py/converters/tuple.hpp
+++ b/cpp2py/include/cpp2py/converters/tuple.hpp
@@ -20,13 +20,18 @@ namespace cpp2py {
       return PyTuple_Pack(sizeof...(Types), (PyObject *)(objs[Is])...);
     }
 
+    // Helper function needed due to clang v6 parameter pack issue
+    static auto py_seq_fast_get_item(PyObject *seq, Py_ssize_t i) {
+      return PySequence_Fast_GET_ITEM(seq, i);
+    }
+
     // is_convertible implementation
     template <auto... Is> static bool is_convertible_impl(PyObject *seq, bool raise_exception, std::index_sequence<Is...>) {
-      return (py_converter<std::decay_t<Types>>::is_convertible(PySequence_Fast_GET_ITEM(seq, Is), raise_exception) and ...);
+      return (py_converter<std::decay_t<Types>>::is_convertible(py_seq_fast_get_item(seq, Is), raise_exception) and ...);
     }
 
     template <auto... Is> static auto py2c_impl(PyObject *seq, std::index_sequence<Is...>) {
-      return std::make_tuple(py_converter<std::decay_t<Types>>::py2c(PySequence_Fast_GET_ITEM(seq, Is))...);
+      return std::make_tuple(py_converter<std::decay_t<Types>>::py2c(py_seq_fast_get_item(seq, Is))...);
     }
 
     public:

--- a/cpp2py/include/cpp2py/converters/vector.hpp
+++ b/cpp2py/include/cpp2py/converters/vector.hpp
@@ -2,16 +2,26 @@
 //#include <vector>
 //#include <numeric>
 
+#include "../traits.hpp"
+
 namespace cpp2py {
 
   template <typename T> struct py_converter<std::vector<T>> {
- 
+
    // --------------------------------------
 
-   static PyObject *c2py(std::vector<T> const &v) {
+   template <typename V> static PyObject *c2py(V &&v) {
+      static_assert(is_instantiation_of_v<std::vector, std::decay_t<V>>, "Logic error");
+      using value_type = typename std::remove_reference_t<V>::value_type;
+
       PyObject *list = PyList_New(0);
-      for (auto const &x : v) {
-        pyref y = py_converter<T>::c2py(x);
+      for (auto &x : v) {
+        pyref y;
+        if constexpr(std::is_reference_v<V>){
+          y = py_converter<value_type>::c2py(x);
+        } else { // Vector passed as rvalue
+          y = py_converter<value_type>::c2py(std::move(x));
+        }
         if (y.is_null() or (PyList_Append(list, y) == -1)) {
           Py_DECREF(list);
           return NULL;
@@ -37,12 +47,12 @@ namespace cpp2py {
     }
 
    // --------------------------------------
-   
+
    static std::vector<T> py2c(PyObject *ob) {
       pyref seq = PySequence_Fast(ob, "expected a sequence");
       std::vector<T> res;
       int len = PySequence_Size(ob);
-      for (int i = 0; i < len; i++) res.push_back(py_converter<T>::py2c(PySequence_Fast_GET_ITEM((PyObject *)seq, i))); //borrowed ref
+      for (int i = 0; i < len; i++) res.push_back(py_converter<std::decay_t<T>>::py2c(PySequence_Fast_GET_ITEM((PyObject *)seq, i))); //borrowed ref
       return res;
     }
   };

--- a/cpp2py/include/cpp2py/py_converter.hpp
+++ b/cpp2py/include/cpp2py/py_converter.hpp
@@ -106,6 +106,8 @@ namespace cpp2py {
 
     using is_wrapped_type = void; // to recognize
 
+    static_assert(not std::is_reference_v<T>, "Not implemented");
+
     template <typename U> static PyObject *c2py(U &&x) {
       PyTypeObject *p = get_type_ptr(typeid(T));
       if (p == nullptr) return NULL;

--- a/cpp2py/include/cpp2py/pyref.hpp
+++ b/cpp2py/include/cpp2py/pyref.hpp
@@ -109,6 +109,7 @@ namespace cpp2py {
       return i;
     }
   };
+  static_assert(sizeof(pyref) == sizeof(PyObject *), "pyref must contain only a PyObject *");
 
   // FIXME : put static or the other functions inline ?
   

--- a/cpp2py/include/cpp2py/traits.hpp
+++ b/cpp2py/include/cpp2py/traits.hpp
@@ -1,0 +1,11 @@
+#pragma once
+#include <type_traits>
+
+namespace cpp2py {
+
+  template <template <typename...> class TMPLT, typename T> struct is_instantiation_of : std::false_type {};
+  template <template <typename...> class TMPLT, typename... U> struct is_instantiation_of<TMPLT, TMPLT<U...>> : std::true_type {};
+  template <template <typename...> class gf, typename T>
+  inline constexpr bool is_instantiation_of_v = is_instantiation_of<gf, std::decay_t<T>>::value;
+
+} // namespace cpp2py


### PR DESCRIPTION
This is a trivial backport of TRIQS/cpp2py@3e4667a to the 2.2.x branch of TRIQS (fixes #768). 