### PR TITLE
[mc_generic] Properly catch exception and stop

### DIFF
--- a/c++/triqs/mc_tools/mc_generic.hpp
+++ b/c++/triqs/mc_tools/mc_generic.hpp
@@ -287,8 +287,8 @@ namespace triqs::mc_tools {
       }
 
       // final reporting
-      if (status == 1) std::cerr << "rank " << c.rank() << ": mc_generic stops because of stop_callback" << std::endl;
-      if (status == 2) std::cerr << "rank " << c.rank() << ": mc_generic stops because of a signal" << std::endl;
+      if (status == 1) report << "mc_generic stops because of stop_callback" << std::endl;
+      if (status == 2) report << "mc_generic stops because of a signal" << std::endl;
 
       report(3) << "\n" << std::endl;
 

--- a/c++/triqs/mc_tools/mc_generic.hpp
+++ b/c++/triqs/mc_tools/mc_generic.hpp
@@ -54,17 +54,19 @@ namespace triqs::mc_tools {
     /**
     * Constructor
     *
-    * @param random_name     Name of the random generator (cf doc).
-    * @param random_seed     Seed for the random generator
-    * @param verbosity       Verbosity level. 0 : None, ... TBA
+    * @param random_name           Name of the random generator (cf doc).
+    * @param random_seed           Seed for the random generator
+    * @param verbosity             Verbosity level. 0 : None, ... TBA
+    * @param rethrow_exception     Whether to throw an exception on each node when an exception occurs on one of them.
+    *                              When set to false use MPI_Abort instead
     */
-    mc_generic(std::string random_name, int random_seed, int verbosity, bool recover_from_exception = false)
+    mc_generic(std::string random_name, int random_seed, int verbosity, bool rethrow_exception = true)
        : RandomGenerator(random_name, random_seed),
          AllMoves(RandomGenerator),
          AllMeasures(),
          AllMeasuresAux(),
          report(&std::cout, verbosity),
-         recover_from_exception(recover_from_exception) {}
+         rethrow_exception(rethrow_exception) {}
 
     /**
    * Register a move
@@ -216,7 +218,7 @@ namespace triqs::mc_tools {
       double next_info_time = 0.1;
 
       std::unique_ptr<mpi::monitor> node_monitor;
-      if (recover_from_exception) node_monitor = std::make_unique<mpi::monitor>(c);
+      if (rethrow_exception) node_monitor = std::make_unique<mpi::monitor>(c);
 
       for (; !stop_it; ++NC) { // do NOT reinit NC to 0
         try {
@@ -246,7 +248,7 @@ namespace triqs::mc_tools {
         } catch (std::exception const &err) {
           // log the error and node number
           std::cerr << "mc_generic: Exception occurs on node " << c.rank() << "\n" << err.what() << std::endl;
-          if (recover_from_exception)
+          if (rethrow_exception)
             node_monitor->request_emergency_stop();
           else
             c.abort(2);
@@ -396,9 +398,9 @@ namespace triqs::mc_tools {
     uint64_t nmeasures, current_cycle_number = 0;
     utility::timer timer_accumulation, timer_warmup;
     std::function<void()> after_cycle_duty;
-    MCSignType sign             = 1;
-    uint64_t done_percent       = 0;
-    uint64_t config_id          = 0;
-    bool recover_from_exception = false;
+    MCSignType sign        = 1;
+    uint64_t done_percent  = 0;
+    uint64_t config_id     = 0;
+    bool rethrow_exception = true;
   };
 } // namespace triqs::mc_tools

--- a/c++/triqs/mc_tools/mc_generic.hpp
+++ b/c++/triqs/mc_tools/mc_generic.hpp
@@ -256,8 +256,9 @@ namespace triqs::mc_tools {
         stop_it |= node_monitor.should_stop(); // if one node has requested a stop, the monitor checks, bcast the info
       }                                        // end main NC loop
 
-      int status = (finished ? 0 : (triqs::signal_handler::received() ? 2 : 1));
-      if (not node_monitor.success()) status = 3;
+      int status   = (finished ? 0 : (triqs::signal_handler::received() ? 2 : 1));
+      bool success = node_monitor.finalize();
+      if (not success) status = 3;
 
       triqs::signal_handler::stop();
       current_cycle_number += NC;

--- a/c++/triqs/utility/exceptions.hpp
+++ b/c++/triqs/utility/exceptions.hpp
@@ -27,7 +27,7 @@
 #include <sstream>
 #include <stdlib.h>
 
-#define TRIQS_ERROR(CLASS, NAME) throw CLASS() << ".. Triqs " << NAME << " at " << __FILE__ << " : " << __LINE__ << "\n\n"
+#define TRIQS_ERROR(CLASS, NAME) throw CLASS() << "Triqs " << NAME << "\n    at " << __FILE__ << " : " << __LINE__ << "\n\n"
 #define TRIQS_RUNTIME_ERROR TRIQS_ERROR(triqs::runtime_error, "runtime error")
 #define TRIQS_KEYBOARD_INTERRUPT TRIQS_ERROR(triqs::keyboard_interrupt, "Ctrl-C")
 #define TRIQS_ASSERT(X)                                                                                                                              \
@@ -56,7 +56,7 @@ namespace triqs {
     } // to limit code size
     virtual const char *what() const throw() {
       std::stringstream out;
-      out << acc.str() << "\n.. Error occurred on node ";
+      out << acc.str() << "\nException was thrown on node ";
       if (mpi::is_initialized()) out << mpi::communicator().rank() << "\n";
       if (getenv("TRIQS_SHOW_EXCEPTION_TRACE")) out << ".. C++ trace is : " << trace() << "\n";
       _what = out.str();

--- a/c++/triqs/utility/signal_handler.hpp
+++ b/c++/triqs/utility/signal_handler.hpp
@@ -21,6 +21,8 @@
 namespace triqs {
   namespace signal_handler {
 
+    class exception {};
+
     /// Start the signal handler
     void start();
 

--- a/test/c++/mc_tools/CMakeLists.txt
+++ b/test/c++/mc_tools/CMakeLists.txt
@@ -1,1 +1,8 @@
 all_tests()
+
+set(TEST_MPI_NUMPROC 2)
+add_cpp_test(different_moves_mc)
+set(TEST_MPI_NUMPROC 3)
+add_cpp_test(different_moves_mc)
+set(TEST_MPI_NUMPROC 4)
+add_cpp_test(different_moves_mc)


### PR DESCRIPTION
- When an exception occurs on a node, properly stop all nodes
  at the end of the MC sweep, by reporting and throwing an exception on
  each node in C++.
- Update test to actually test in mpi mode, as Google Test.