### PR TITLE
[gf.py] bugfix in order to access and set elements of rank1 Gfs

### DIFF
--- a/python/triqs/gf/gf.py
+++ b/python/triqs/gf/gf.py
@@ -305,8 +305,9 @@ class Gf(metaclass=AddMethod):
 
         # Only one argument. Must be a mesh point
         if not isinstance(key, tuple):
-            assert isinstance(key, (MeshPoint, Idx))
-            return self.data[key.linear_index if isinstance(key, MeshPoint) else self._mesh.index_to_linear(key.idx)]
+            if isinstance(key, (MeshPoint, Idx)):
+                return self.data[key.linear_index if isinstance(key, MeshPoint) else self._mesh.index_to_linear(key.idx)]
+            else: key = (key,)
 
         # If all arguments are MeshPoint, we are slicing the mesh or evaluating
         if all(isinstance(x, (MeshPoint, Idx)) for x in key):

--- a/python/triqs/gf/gf.py
+++ b/python/triqs/gf/gf.py
@@ -303,37 +303,10 @@ class Gf(metaclass=AddMethod):
         if key == self._full_slice:
             return self
 
+        # Only one argument. Must be a mesh point
         if not isinstance(key, tuple):
-            if isinstance(key, (MeshPoint, Idx)):
-                return self.data[key.linear_index if isinstance(key, MeshPoint) else self._mesh.index_to_linear(key.idx)]
-            else:
-                assert self.target_rank == 1, "wrong number of arguments. Expected %s, got %s"%(self.target_rank, 1)
-                # Assume empty indices (scalar_valued)
-                ind = GfIndices([])
-
-                # String access: transform the key into a list integers
-                if isinstance(key, str):
-                    assert self._indices, "Got string indices, but I have no indices to convert them !"
-                    key_tpl = tuple([self._indices.convert_index(key,1)]) # convert returns a slice of len 1
-
-                # Slicing with ranges -> Adjust indices
-                elif isinstance(key, slice): 
-                    key_tpl = tuple([key])
-                    ind = GfIndices([ v[k]  for k,v in zip(key_lst, self._indices.data)])
-
-                # Integer access
-                elif isinstance(key, int):
-                    key_tpl = tuple([key])
-
-                # Invalid Access
-                else:
-                    raise NotImplementedError("Partial slice of the target space not implemented")
-
-                dat = self._data[ self._rank * (slice(0,None),) + key_tpl ] 
-                r = Gf(mesh = self._mesh, data = dat, indices = ind)
-
-                r.__check_invariants()
-                return r
+            assert isinstance(key, (MeshPoint, Idx))
+            return self.data[key.linear_index if isinstance(key, MeshPoint) else self._mesh.index_to_linear(key.idx)]
 
         # If all arguments are MeshPoint, we are slicing the mesh or evaluating
         if all(isinstance(x, (MeshPoint, Idx)) for x in key):

--- a/python/triqs/gf/gf.py
+++ b/python/triqs/gf/gf.py
@@ -401,6 +401,7 @@ class Gf(metaclass=AddMethod):
             else:
                 assert self.target_rank == 1, "wrong number of arguments. Expected %s, got %s"%(self.target_rank, 1)
                 assert isinstance(key, int)
+                self[key] << val
 
         # If all arguments are MeshPoint, we are slicing the mesh or evaluating
         elif isinstance(key, tuple) and all(isinstance(x, (MeshPoint, Idx)) for x in key):

--- a/python/triqs/gf/gf.py
+++ b/python/triqs/gf/gf.py
@@ -327,7 +327,7 @@ class Gf(metaclass=AddMethod):
 
                 # Invalid Access
                 else:
-                    raise NotImplementedError, "Partial slice of the target space not implemented"
+                    raise NotImplementedError("Partial slice of the target space not implemented")
 
                 dat = self._data[ self._rank * [slice(0,None)] + key_lst ] 
                 r = Gf(mesh = self._mesh, data = dat, indices = ind)

--- a/python/triqs/gf/gf.py
+++ b/python/triqs/gf/gf.py
@@ -314,22 +314,22 @@ class Gf(metaclass=AddMethod):
                 # String access: transform the key into a list integers
                 if isinstance(key, str):
                     assert self._indices, "Got string indices, but I have no indices to convert them !"
-                    key_lst = [self._indices.convert_index(key,1)] # convert returns a slice of len 1
+                    key_tpl = tuple([self._indices.convert_index(key,1)]) # convert returns a slice of len 1
 
                 # Slicing with ranges -> Adjust indices
                 elif isinstance(key, slice): 
-                    key_lst = [key]
+                    key_tpl = tuple([key])
                     ind = GfIndices([ v[k]  for k,v in zip(key_lst, self._indices.data)])
 
                 # Integer access
                 elif isinstance(key, int):
-                    key_lst = [key]
+                    key_tpl = tuple([key])
 
                 # Invalid Access
                 else:
                     raise NotImplementedError("Partial slice of the target space not implemented")
 
-                dat = self._data[ self._rank * [slice(0,None)] + key_lst ] 
+                dat = self._data[ self._rank * (slice(0,None),) + key_tpl ] 
                 r = Gf(mesh = self._mesh, data = dat, indices = ind)
 
                 r.__check_invariants()

--- a/test/python/base/gf_init.py
+++ b/test/python/base/gf_init.py
@@ -71,5 +71,25 @@ class test_gf_init(unittest.TestCase):
         with self.assertRaises(AssertionError):
             g4 << g1
 
+    def test_gf_rank1(self):
+
+        beta, n_points = 50, 100
+        iw_mesh = MeshImFreq(beta, 'Fermion', n_points)
+        g1 = Gf(mesh = iw_mesh, target_shape = [2])
+        g1[0] << SemiCircular(half_bandwidth = 1)
+        g1[1] << SemiCircular(half_bandwidth = 2)
+
+        g2 = Gf(mesh = iw_mesh, target_shape = [2])
+        g2[:] = g1
+        assert_gfs_are_close(g1, g2)
+
+        g3 = Gf(mesh = iw_mesh, target_shape = [2])
+        g3 << g1
+        assert_gfs_are_close(g1, g3)
+
+        g3[1] << g3[0]
+        assert_gfs_are_close(g1[0], g3[1])
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
It is not possible to access and set single or multiple elements of a rank1 Gf in python (eq.: G[0] or G[:2]) .
Single arguments are assumed to be mesh points.
This commit should fix the issue.