### PR TITLE
Weighted Tailfit

### DIFF
--- a/c++/triqs/gfs/meshes/tail_fitter.hpp
+++ b/c++/triqs/gfs/meshes/tail_fitter.hpp
@@ -80,10 +80,10 @@ namespace triqs::gfs {
     std::vector<long> _fit_idx_lst;
 
     public:
-    tail_fitter(double tail_fraction, int n_tail_max, std::optional<int> expansion_order = {}, int error_order = 0)
+    tail_fitter(double tail_fraction, int n_tail_max, std::optional<int> expansion_order = {}, std::optional<int> error_order = {})
        : _tail_fraction(tail_fraction),
          _n_tail_max(n_tail_max),
-         _error_order(error_order),
+         _error_order(error_order.has_value() ? *error_order : 0),
          _adjust_order(not expansion_order.has_value()),
          _expansion_order(_adjust_order ? max_order : *expansion_order) {}
     //----------------------------------------------------------------------------------------------
@@ -96,8 +96,6 @@ namespace triqs::gfs {
 
     // The default upper limit for the number of frequencies to consider in the tail fit
     static constexpr int default_n_tail_max = 30;
-    
-    static constexpr int default_error_order = 0;
 
     //----------------------------------------------------------------------------------------------
 
@@ -310,19 +308,19 @@ namespace triqs::gfs {
 
     // Adjust the parameters for the tail-fitting
     void set_tail_fit_parameters(double tail_fraction, int n_tail_max = tail_fitter::default_n_tail_max,
-                                 std::optional<int> expansion_order = {}, int error_order = tail_fitter::default_error_order) const {
+                                 std::optional<int> expansion_order = {}, std::optional<int> error_order = {}) const {
       _tail_fitter = std::make_shared<tail_fitter>(tail_fitter{tail_fraction, n_tail_max, expansion_order, error_order});
     }
 
     // The tail fitter is mutable, even if the mesh is immutable to cache some data
     tail_fitter &get_tail_fitter() const {
-      if (!_tail_fitter) _tail_fitter = std::make_shared<tail_fitter>(tail_fitter::default_tail_fraction, tail_fitter::default_n_tail_max, std::nullopt, tail_fitter::default_error_order);
+      if (!_tail_fitter) _tail_fitter = std::make_shared<tail_fitter>(tail_fitter::default_tail_fraction, tail_fitter::default_n_tail_max);
       return *_tail_fitter;
     }
 
     // Adjust the parameters for the tail-fitting and return the fitter
     tail_fitter &get_tail_fitter(double tail_fraction, int n_tail_max = tail_fitter::default_n_tail_max,
-                                 std::optional<int> expansion_order = {}, int error_order = tail_fitter::default_error_order) const {
+                                 std::optional<int> expansion_order = {}, std::optional<int> error_order = {}) const {
       set_tail_fit_parameters(tail_fraction, n_tail_max, expansion_order, error_order);
       return *_tail_fitter;
     }

--- a/doc/documentation/manual/triqs/gfs/c++/tail.rst
+++ b/doc/documentation/manual/triqs/gfs/c++/tail.rst
@@ -63,7 +63,7 @@ The experienced user can adjust the parameters of the fitting procedure directly
 
 .. code-block:: c
    
-   G.mesh().set_tail_fit_parameters(tail_fraction, n_tail_max, expansion_order)
+   G.mesh().set_tail_fit_parameters(tail_fraction, n_tail_max, expansion_order, error_order)
 
 The fitting parameters are
 
@@ -79,7 +79,7 @@ The fitting parameters are
   This parameter will fix the largest order to be considered for the fit.
   
 * :code:`error_order` (integer, optional, default = 0)
-  Assume an omega-dependent error for the fit. :math:`\Delta G(i\omega_n) \sim |\omega_n|^\eta`
+  Assume an omega-dependent error of the Green's function for the fit. Error_order :math:`\eta` is defined such that :math:`\Delta G(i\omega_n) \sim |\omega_n|^\eta`
 
 Adjusting the fit window (Advanced)
 -----------------------------------

--- a/doc/documentation/manual/triqs/gfs/c++/tail.rst
+++ b/doc/documentation/manual/triqs/gfs/c++/tail.rst
@@ -77,6 +77,9 @@ The fitting parameters are
 
 * :code:`expansion_order` (integer, optional)
   This parameter will fix the largest order to be considered for the fit.
+  
+* :code:`error_order` (integer, optional, default = 0)
+  Assume an omega-dependent error for the fit. :math:`\Delta G(i\omega_n) \sim |\omega_n|^\eta`
 
 Adjusting the fit window (Advanced)
 -----------------------------------

--- a/python/triqs/gf/meshes_desc.py
+++ b/python/triqs/gf/meshes_desc.py
@@ -78,7 +78,7 @@ m.add_constructor(signature = "(double beta, statistic_enum S, int n_max=1025)")
 m.add_method("""int last_index()""")
 m.add_method("""int first_index()""")
 m.add_method("""bool positive_only()""")
-m.add_method("""void set_tail_fit_parameters(double tail_fraction, int n_tail_max = 30, std::optional<int> expansion_order = {})""")
+m.add_method("""void set_tail_fit_parameters(double tail_fraction, int n_tail_max = 30, std::optional<int> expansion_order = {}, int error_order = 0)""")
 m.add_property(name = "beta",
                getter = cfunction(calling_pattern="double result = self_c.domain().beta",
                signature = "double()",

--- a/python/triqs/gf/meshes_desc.py
+++ b/python/triqs/gf/meshes_desc.py
@@ -78,7 +78,7 @@ m.add_constructor(signature = "(double beta, statistic_enum S, int n_max=1025)")
 m.add_method("""int last_index()""")
 m.add_method("""int first_index()""")
 m.add_method("""bool positive_only()""")
-m.add_method("""void set_tail_fit_parameters(double tail_fraction, int n_tail_max = 30, std::optional<int> expansion_order = {}, int error_order = 0)""")
+m.add_method("""void set_tail_fit_parameters(double tail_fraction, int n_tail_max = 30, std::optional<int> expansion_order = {}, std::optional<int> error_order = {})""")
 m.add_property(name = "beta",
                getter = cfunction(calling_pattern="double result = self_c.domain().beta",
                signature = "double()",


### PR DESCRIPTION
Dear all

This PR implements the weighted tailfit originally proposed by @gkraberger (PR #482), that got lost during the rework of the tails in 2.x (see also #719).

Please review whether you want to add it in this way - or if I'm messing with something I should not mess with here.
The default behaviour of the tailfit does not change, the order of the error can be set by `set_tail_fit_parameters`. 