### PR TITLE
fix warning suppression in newer gcc / clang compilers for comma subscript

### DIFF
--- a/c++/triqs/CMakeLists.txt
+++ b/c++/triqs/CMakeLists.txt
@@ -36,7 +36,7 @@ else()
 endif()
 
 # Disable warnings about comma expression in array subscript
-target_compile_options(triqs PUBLIC -Wno-deprecated-comma-subscript)
+target_compile_options(triqs PUBLIC -Wno-deprecated-comma-subscript -Wno-unknown-warning-option)
 
 # Compile Definitions
 option(CHECK_MEMORY "Turn on memory check" OFF)


### PR DESCRIPTION
With clang 9.0.1 this cmake list change fixes the warning: 
```
warning: unknown warning option '-Wno-deprecated-comma-subscript'; did you mean '-Wno-deprecated-writable-strings'? [-Wunknown-warning-option]
```
which occurs for almost all C++ files.