### PR TITLE
Test for issue when multiplying Gfs with different dimensions

### DIFF
--- a/python/triqs/gf/block2_gf.py
+++ b/python/triqs/gf/block2_gf.py
@@ -289,8 +289,16 @@ class Block2Gf:
         return self
 
     def __mul__(self,y):
-        c = self.copy()
-        c *= y
+        if isinstance(y, self.__class__):
+            block_list = []
+            for i1, name1 in enumerate(self.__indices1):
+                block_list.append([])
+                for i2, name2 in enumerate(self.__indices2):
+                    block_list[i1].append(self[(name1, name2)] * y[(name1, name2)])
+            c = Block2Gf(name_list1=self.__indices1, name_list2=self.__indices2, block_list=block_list)
+        else:
+            c = self.copy()
+            c *= y
         return c
 
     def __rmul__(self,x): return self.__mul__(x)

--- a/python/triqs/gf/block_gf.py
+++ b/python/triqs/gf/block_gf.py
@@ -361,8 +361,16 @@ class BlockGf:
         return self
 
     def __mul__(self,y):
-        c = self.copy()
-        c *= y
+        if isinstance(y, BlockGf):
+            name_list = []
+            block_list = []
+            for (n,g) in self:
+                name_list.append(n)
+                block_list.append(self[n] * y[n])
+            c = BlockGf(name_list=name_list, block_list=block_list)
+        else:
+            c = self.copy()
+            c *= y
         return c
 
     def __rmul__(self,x): return self.__mul__(x)

--- a/test/python/base/CMakeLists.txt
+++ b/test/python/base/CMakeLists.txt
@@ -43,6 +43,9 @@ add_python_test(bug_bcast_mesh)
 # Issues with the high frequency moments
 add_python_test(tail_issues)
 
+# issue with mult of Gf with different dim
+add_python_test(issue_gf_mult_dim)
+
 # Add evaluator for g
 add_python_test(gf_eval)
 

--- a/test/python/base/gf_base_op.py
+++ b/test/python/base/gf_base_op.py
@@ -181,5 +181,23 @@ class test_Gf_Base_Op(unittest.TestCase):
         assert_gfs_are_close(G, G_exact)
         assert_gfs_are_close(Mat * G * linalg.inv(Mat), G_exact)
 
+    def test_different_rank_prod(self):
+        mesh = MeshImFreq(beta=self.beta, S="Fermion", n_max=10)
+        G1 = Gf(mesh=mesh, target_shape=[2,2])
+        G1 << inverse(iOmega_n + 2)
+        G2 = Gf(mesh=mesh, target_shape=[])
+        G2 << inverse(iOmega_n - 2)
+
+        G_loop = G1.copy()
+        for i in range(len(G1.mesh)):
+            G_loop.data[i] = G1.data[i] * G2.data[i]
+
+        G3 = G1.copy()
+        G3 *= G2
+
+        assert_gfs_are_close(G1*G2, G_loop)
+        assert_gfs_are_close(G2*G1, G_loop)
+        assert_gfs_are_close(G3, G_loop)
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/python/base/gf_block.py
+++ b/test/python/base/gf_block.py
@@ -88,5 +88,45 @@ class test_Gf_Block(unittest.TestCase):
 
         assert_block2_gfs_are_close(-B1.imag, B2.imag)
 
+    def test_mult(self):
+
+        G1 = Gf(mesh=self.iw_mesh, target_shape=(1,1))
+        G2 = G1.copy()
+        G3 = Gf(mesh=self.iw_mesh, target_shape=(1,2))
+        G4 = Gf(mesh=self.iw_mesh, target_shape=(1,3))
+
+        G1 << inverse(2 + iOmega_n)
+        G2 << inverse(2 - iOmega_n)
+        for i in range(2):
+            G3[0,i] << inverse(iOmega_n + 2 + i)
+        for i in range(3):
+            G4[0,i] << inverse(iOmega_n + 2 + i)
+
+        B1 = BlockGf(name_list=['0', '1'], block_list=[G1, G2])
+        B2 = BlockGf(name_list=['0', '1'], block_list=[G3, G4])
+        B3 = B1 * B2
+        B4 = BlockGf(name_list=['0', '1'], block_list=[G1*G3, G2*G4])
+
+        assert_block_gfs_are_close(B3, B4)
+
+    def test_block2_mult(self):
+
+        G1 = Gf(mesh=self.iw_mesh, target_shape=(2,2))
+        G2 = G1.copy()
+        G3 = G1.copy()
+        G4 = G1.copy()
+
+        G1 << inverse(2 + iOmega_n)
+        G2 << inverse(2 - iOmega_n)
+        G1 << inverse(3 + iOmega_n)
+        G2 << inverse(3 - iOmega_n)
+
+        B1 = Block2Gf(name_list1=['0', '1'], name_list2=['0', '1'], block_list=[[G1, G2], [G2, G1]])
+        B2 = Block2Gf(name_list1=['0', '1'], name_list2=['0', '1'], block_list=[[G3, G4], [G3, G4]])
+        B3 = B1 * B2
+        B4 = Block2Gf(name_list1=['0', '1'], name_list2=['0', '1'], block_list=[[G1*G3, G2*G4], [G2*G3, G1*G4]])
+
+        assert_block2_gfs_are_close(B3, B4)
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/python/base/issue_gf_mult_dim.py
+++ b/test/python/base/issue_gf_mult_dim.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2017 Commissariat à l'énergie atomique et aux énergies alternatives (CEA)
+# Copyright (c) 2017 Centre national de la recherche scientifique (CNRS)
+# Copyright (c) 2020 Simons Foundation
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You may obtain a copy of the License at
+#     https:#www.gnu.org/licenses/gpl-3.0.txt
+#
+# Authors: Olivier Parcollet, Nils Wentzellm, Alexander Hampel
+
+from triqs.gf import *
+from triqs.utility.comparison_tests import *
+import numpy as np
+
+iw_mesh = MeshImFreq(beta=40, S='Fermion', n_max=1025)
+
+# create upfolded Gf with 5x5 dim
+G_upf = Gf(mesh=iw_mesh, target_shape=[5, 5])
+# create downfolded target Gf with 3x3 dim
+G_dnf = Gf(mesh=iw_mesh, target_shape=[3, 3])
+
+# downfolding projector from the 5 to 3 orb
+downfolding = Gf(mesh=iw_mesh, target_shape=[3,5])
+
+# the downfolding / projection from 5 to 3 orbitals fails
+# because atm triqs expects in each of those multiplications that
+# dim a = dim b
+# but this should work since we are doing [3,5]x[5,5]x[5,3]
+G_dnf  << downfolding*(G_upf*downfolding.transpose().conjugate())
+


### PR DESCRIPTION
When multiplying two Green functions with different shape, for example for downfolding / upfolding purposes, triqs gives an error, that the dimensions do not match. A simple example would be: 
```
from triqs.gf import *

iw_mesh = MeshImFreq(beta=40, S='Fermion', n_max=1025)
# create upfolded Gf with 5x5 dim
G_upf = Gf(mesh=iw_mesh, target_shape=[5, 5])
# create downfolded target Gf with 3x3 dim
G_dnf = Gf(mesh=iw_mesh, target_shape=[3, 3])

# downfolding projector from the 5 to 3 orb
downfolding = Gf(mesh=iw_mesh, target_shape=[3,5])

# the downfolding / projection from 5 to 3 orbitals fails
# this should work since we are doing [3,5]x[5,5]x[5,3]
G_dnf  << downfolding*(G_upf*downfolding.transpose().conjugate())
```
This should work as the multiplication of matrices of these dimensions makes sense and is often used for downfolding. The code gives the error:
```
Traceback (most recent call last):
File "/mnt/home/ahampel/Dropbox/git/triqs3/triqs.src/test/python/base/issue_gf_mult_dim.py", line 36, in <module>
G_dnf  << downfolding*(G_upf*downfolding.transpose().conjugate())
File "/mnt/home/ahampel/git/triqs-3.x_unstable/triqs_fix_gf_mult.build/python/triqs/gf/gf.py", line 537, in __mul__
     c.__imul__impl(y)
File "/mnt/home/ahampel/git/triqs-3.x_unstable/triqs_fix_gf_mult.build/python/triqs/gf/gf.py", line 494, in __imul__impl
     d_self[n] = np.dot(d_self[n], d_args[n]) # put to C if too slow.
ValueError: could not broadcast input array from shape (5,3) into shape (5,5)
```
Triqs expect the outcoming Gf to have the same shape as the first input Gf.

This PR adds a simple test that fails at the moment and should be fixed.

Thanks.