### PR TITLE
Extend conda installation instruction

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -73,8 +73,8 @@ and `triqs_tprf <https://github.com/conda-forge/triqs_tprf-feedstock/>`_.
 
 In case you encounter troubles resolving the dependencies, you can try using `mamba <https://github.com/mamba-org/mamba>`_ instead of `conda`::
 
-        conda install mamba -c conda-forge  # install mamba
-        mamba install -c conda-forge triqs  # use mamba instead of triqs for dependency resolution
+        conda install -c conda-forge mamba
+        mamba install -c conda-forge triqs
 
 .. _triqs_docker:
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -71,6 +71,11 @@ See also `github.com/conda-forge/triqs-feedstock <https://github.com/conda-forge
 We further provide packages for `triqs_cthyb <https://github.com/conda-forge/triqs_cthyb-feedstock/>`_, `triqs_dft_tools <https://github.com/conda-forge/triqs_dft_tools-feedstock/>`_
 and `triqs_tprf <https://github.com/conda-forge/triqs_tprf-feedstock/>`_.
 
+In case you encounter troubles resolving the dependencies, you can try using `mamba <https://github.com/mamba-org/mamba>`_ instead of `conda`::
+
+        conda install mamba -c conda-forge  # install mamba
+        mamba install -c conda-forge triqs  # use mamba instead of triqs for dependency resolution
+
 .. _triqs_docker:
 
 Docker


### PR DESCRIPTION
Refer to `mamba` for faster dependency resolution.

Depending on the state of the `conda` environment, dependency resolution can take forever.
`mamba` solves this issue.

Compare e.g. to the installation instructions of [sage-math](https://doc.sagemath.org/html/en/installation/conda.html).