### PR TITLE
[doc] Replace remaining RI by mode

### DIFF
--- a/doc/documentation/manual/triqs/gfs/py/block.rst
+++ b/doc/documentation/manual/triqs/gfs/py/block.rst
@@ -173,7 +173,7 @@ Plot options
 There is one important option that you will find very useful when plotting Green's functions, which we 
 saw already in the previous section:
 
-* `RI` = 'R' or 'I' or 'S'
+* `mode` = 'R' or 'I' or 'S'
 
 It tells the plotter, what part of the Green's function you want to plot. 'R' for the real part, 'I'
 for the imaginary part, and 'S' for the spectral function, :math:`-1/\pi{\rm Im}G`. Of course, 

--- a/doc/documentation/manual/triqs/gfs/py/block/green_pade.py
+++ b/doc/documentation/manual/triqs/gfs/py/block/green_pade.py
@@ -36,5 +36,5 @@ g_pade.set_from_pade(gm, n_points = L, freq_offset = eta)
 
 # Comparison plot
 from triqs.plot.mpl_interface import oplot
-oplot(gr[0,0], '-o', RI = 'S', name = "Original DOS")
-oplot(g_pade[0,0], '-x', RI = 'S', name = "Pade-reconstructed DOS")
+oplot(gr[0,0], '-o', mode = 'S', name = "Original DOS")
+oplot(g_pade[0,0], '-x', mode = 'S', name = "Pade-reconstructed DOS")

--- a/doc/documentation/manual/triqs/gfs/py/block/green_refreq.py
+++ b/doc/documentation/manual/triqs/gfs/py/block/green_refreq.py
@@ -7,7 +7,7 @@ g['eg1','eg1'] = SemiCircular(half_bandwidth = 1)
 g['eg2','eg2'] = SemiCircular(half_bandwidth = 2)
 
 from triqs.plot.mpl_interface import oplot
-oplot(g['eg1','eg1'], '-o', RI = 'S')  # S : spectral function 
-oplot(g['eg2','eg2'], '-x', RI = 'S')
+oplot(g['eg1','eg1'], '-o', mode = 'S')  # S : spectral function 
+oplot(g['eg2','eg2'], '-x', mode = 'S')
 
 

--- a/doc/userguide/gfs/impinbath.py
+++ b/doc/userguide/gfs/impinbath.py
@@ -13,6 +13,6 @@ g.invert()
 
 # Plot it with matplotlib. 'S' means: spectral function ( -1/pi Imag (g) )
 from triqs.plot.mpl_interface import oplot, plt
-oplot( g['d','d'], '-o', RI = 'S', x_window  = (-1.8,1.8), name = "Impurity" )
-oplot( g['s','s'], '-x', RI = 'S', x_window  = (-1.8,1.8), name = "Bath" )
+oplot( g['d','d'], '-o', mode = 'S', x_window  = (-1.8,1.8), name = "Impurity" )
+oplot( g['s','s'], '-x', mode = 'S', x_window  = (-1.8,1.8), name = "Bath" )
 plt.show()

--- a/doc/userguide/python/ipt_full.py
+++ b/doc/userguide/python/ipt_full.py
@@ -57,7 +57,7 @@ for U in arange(Umin, Umax, 0.51):
     greal.set_from_pade(S.g, 201, 0.0)
 
     r=(U-Umin)/(Umax-Umin) #for color
-    oplot((-1/pi*greal).imag, lw=3,RI='S', color=(r,1.-r,1.-r), label = "U=%1.1f"%U)
+    oplot((-1/pi*greal).imag, lw=3,mode='S', color=(r,1.-r,1.-r), label = "U=%1.1f"%U)
 plt.xlim(-4,4)
 plt.ylim(0,0.7)
 plt.ylabel("$A(\omega)$");


### PR DESCRIPTION
The RI key for oplot was deprecated in 37e68715 and finally removed in 18fc34f3 but the documentation and examples were not updated in all places.