### PR TITLE
fix indents in triqs sumk

### DIFF
--- a/python/triqs/sumk/sumk_discrete_from_lattice.py
+++ b/python/triqs/sumk/sumk_discrete_from_lattice.py
@@ -86,7 +86,7 @@ class SumkDiscreteFromLattice (SumkDiscrete):
         # compute the points where to evaluate the function in the BZ and with the weights
         def pts1d(N):
             for n in range(N):
-		yield (n - N/2 +1.0) / N
+                yield (n - N/2 +1.0) / N
 
         if method=="Riemann":
             bz_weights=1.0/nk
@@ -103,7 +103,7 @@ class SumkDiscreteFromLattice (SumkDiscrete):
             for wa,ptsa in NR.Gauleg(-pi,pi,n_bz_A):
                 for wb,ptsb in NR.Gauleg(-pi,pi,n_bz_B):
                     for wc,ptsc in NR.Gauleg(-pi,pi,n_bz_C):
-			self.bz_points[k_index,:] = (ptsa,ptsb,ptsc)[0:self.dim] /(2*pi)
+                        self.bz_points[k_index,:] = (ptsa,ptsb,ptsc)[0:self.dim] /(2*pi)
                         self.bz_weights[k_index] = wa * wb * wc
                         k_index +=1
         else:
@@ -160,7 +160,7 @@ class SumkDiscreteFromLattice (SumkDiscrete):
                 rv = a+s*(b-a)+t*(c-a)+(k+1)*g
                 if k == 0 or j < n_bz-i-1:
                   self.bz_points[k_index]  = rv
-	          self.bz_weights[k_index] = w/(n_bz*n_bz)
+                  self.bz_weights[k_index] = w/(n_bz*n_bz)
                   total_weight += self.bz_weights[k_index]
                   k_index = k_index+1
 


### PR DESCRIPTION
Small fix for triqs sumk lattice tools. Idention levels were not correct. Before a simple 
```
from triqs.sumk import *
``` 
did not work. Fixed now.