### PR TITLE
Run triqs without MPI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,16 +106,12 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 cmake_policy(SET CMP0069 NEW)
 include(CheckIPOSupported)
-check_ipo_supported(RESULT ipo_supported OUTPUT output)
+check_ipo_supported(RESULT ipo_supported)
 if(NOT ipo_supported)
   message(STATUS "Linktime optimizations could not be enabled!")
-  #message(STATUS "LTO Example failed to compile with error:\n${output}")
 else()
   message(STATUS "Linktime optimizations enabled!")
   set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
-  if(CMAKE_SYSTEM_NAME EQUAL "Linux")
-    add_link_options($<$<CXX_COMPILER_ID:Clang>:-fuse-ld=gold>)
-  endif()
 endif()
 
 #---------------------------------------------------------------------

--- a/c++/triqs/gfs/block/block_gf.hpp
+++ b/c++/triqs/gfs/block/block_gf.hpp
@@ -178,7 +178,7 @@ namespace triqs::gfs {
 
     /// Construct from the mpi lazy class of the implementation class, cf mpi section
     // NB : type must be the same, e.g. g2(reduce(g1)) will work only if mesh, Target, Singularity are the same...
-    template <typename Tag> block_gf(mpi_lazy<Tag, block_gf_const_view<Mesh, Target>> x) : block_gf() { operator=(x); }
+    template <typename Tag> block_gf(mpi::lazy<Tag, block_gf_const_view<Mesh, Target>> x) : block_gf() { operator=(x); }
 
     /// Construct from a vector of gf
     block_gf(data_t V) REQUIRES(Arity == 1) : _block_names(details::_make_block_names1(V.size())), _glist(std::move(V)) {}
@@ -237,11 +237,11 @@ namespace triqs::gfs {
     block_gf &operator=(block_gf &&rhs) = default;
 
     /**
-     * Assignment operator overload specific for mpi_lazy objects (keep before general assignment)
+     * Assignment operator overload specific for mpi::lazy objects (keep before general assignment)
      *
      * @param l The lazy object returned by reduce
      */
-    block_gf &operator=(mpi_lazy<mpi::tag::reduce, block_gf::const_view_type> l) {
+    block_gf &operator=(mpi::lazy<mpi::tag::reduce, block_gf::const_view_type> l) {
       
       _block_names = l.rhs.block_names();
       _glist       = mpi::reduce(l.rhs.data(), l.c, l.root, l.all, l.op);

--- a/c++/triqs/gfs/block/block_gf_view.hpp
+++ b/c++/triqs/gfs/block/block_gf_view.hpp
@@ -135,10 +135,10 @@ namespace triqs::gfs {
     }
 
     /**
-    * Assignment operator overload specific for mpi_lazy objects (keep before general assignment)
+    * Assignment operator overload specific for mpi::lazy objects (keep before general assignment)
     * @param l The lazy object returned by reduce
     */
-    block_gf_view &operator=(mpi_lazy<mpi::tag::reduce, const_view_type> l) REQUIRES(not IsConst) {
+    block_gf_view &operator=(mpi::lazy<mpi::tag::reduce, const_view_type> l) REQUIRES(not IsConst) {
       if (l.rhs.size() != this->size())
         TRIQS_RUNTIME_ERROR << "mpi reduction of block_gf : size of RHS is incompatible with the size of the view to be assigned to";
       _block_names = l.rhs.block_names();

--- a/c++/triqs/gfs/block/mpi.hpp
+++ b/c++/triqs/gfs/block/mpi.hpp
@@ -74,7 +74,7 @@ namespace triqs::gfs {
   template <typename V, typename T, int Arity, bool IsConst>
   mpi::lazy<mpi::tag::reduce, block_gf_const_view<V, T, Arity>> mpi_reduce(block_gf_view<V, T, Arity, IsConst> const &a, mpi::communicator c = {},
                                                                     int root = 0, bool all = false, MPI_Op op = MPI_SUM) {
-    return {block_gf_view<V, T, Arity>{a}, c, root, all, op};
+    return {a, c, root, all, op};
   }
 
 } // namespace triqs::gfs

--- a/c++/triqs/gfs/block/mpi.hpp
+++ b/c++/triqs/gfs/block/mpi.hpp
@@ -54,7 +54,7 @@ namespace triqs::gfs {
     * @return Returns a lazy object describing the object and the MPI operation to be performed.
     */
   template <typename V, typename T, int Arity>
-  mpi_lazy<mpi::tag::reduce, block_gf_const_view<V, T, Arity>> mpi_reduce(block_gf<V, T, Arity> const &a, mpi::communicator c = {}, int root = 0,
+  mpi::lazy<mpi::tag::reduce, block_gf_const_view<V, T, Arity>> mpi_reduce(block_gf<V, T, Arity> const &a, mpi::communicator c = {}, int root = 0,
                                                                    bool all = false, MPI_Op op = MPI_SUM) {
     return {a(), c, root, all, op};
   }
@@ -72,7 +72,7 @@ namespace triqs::gfs {
     * @return Returns a lazy object describing the object and the MPI operation to be performed.
     */
   template <typename V, typename T, int Arity, bool IsConst>
-  mpi_lazy<mpi::tag::reduce, block_gf_const_view<V, T, Arity>> mpi_reduce(block_gf_view<V, T, Arity, IsConst> const &a, mpi::communicator c = {},
+  mpi::lazy<mpi::tag::reduce, block_gf_const_view<V, T, Arity>> mpi_reduce(block_gf_view<V, T, Arity, IsConst> const &a, mpi::communicator c = {},
                                                                     int root = 0, bool all = false, MPI_Op op = MPI_SUM) {
     return {block_gf_view<V, T, Arity>{a}, c, root, all, op};
   }

--- a/c++/triqs/gfs/gf/_gf_view_common.hpp
+++ b/c++/triqs/gfs/gf/_gf_view_common.hpp
@@ -250,17 +250,17 @@ friend void mpi_broadcast(this_t &g, mpi::communicator c = {}, int root = 0) {
 }
 
 // mako ${mpidoc("Reduce")}
-friend mpi_lazy<mpi::tag::reduce, const_view_type> mpi_reduce(this_t const &a, mpi::communicator c = {}, int root = 0, bool all = false,
+friend mpi::lazy<mpi::tag::reduce, const_view_type> mpi_reduce(this_t const &a, mpi::communicator c = {}, int root = 0, bool all = false,
                                                               MPI_Op op = MPI_SUM) {
   return {a(), c, root, all, op};
 }
 
 // mako ${mpidoc("Scatter")}
-friend mpi_lazy<mpi::tag::scatter, const_view_type> mpi_scatter(this_t const &a, mpi::communicator c = {}, int root = 0) {
+friend mpi::lazy<mpi::tag::scatter, const_view_type> mpi_scatter(this_t const &a, mpi::communicator c = {}, int root = 0) {
   return {a(), c, root, true};
 }
 
 // mako ${mpidoc("Gather")}
-friend mpi_lazy<mpi::tag::gather, const_view_type> mpi_gather(this_t const &a, mpi::communicator c = {}, int root = 0, bool all = false) {
+friend mpi::lazy<mpi::tag::gather, const_view_type> mpi_gather(this_t const &a, mpi::communicator c = {}, int root = 0, bool all = false) {
   return {a(), c, root, all};
 }

--- a/c++/triqs/gfs/gf/defs.hpp
+++ b/c++/triqs/gfs/gf/defs.hpp
@@ -67,23 +67,4 @@ namespace triqs::gfs {
 
   template <typename Mesh, typename Target> struct gf_h5_rw;
 
-  /*------------------------------------------------------------------------------------------------------
-   *                                  For mpi lazy
-   *-----------------------------------------------------------------------------------------------------*/
-
-  // A small lazy tagged class
-  template <typename Tag, typename T> struct mpi_lazy {
-    T rhs;
-    mpi::communicator c;
-    int root;
-    bool all;
-  };
-
-  template <typename T> struct mpi_lazy<mpi::tag::reduce, T> {
-    T rhs;
-    mpi::communicator c;
-    int root;
-    bool all;
-    MPI_Op op;
-  };
 } // namespace triqs::gfs

--- a/c++/triqs/gfs/gf/gf.hpp
+++ b/c++/triqs/gfs/gf/gf.hpp
@@ -288,7 +288,7 @@ namespace triqs::gfs {
      *  
      *  NB : type must be the same, e.g. g2(reduce(g1)) will work only if mesh, Target, Singularity are the same...
      */
-    template <typename Tag> gf(mpi_lazy<Tag, gf_const_view<Mesh, Target>> l) : gf() { operator=(l); }
+    template <typename Tag> gf(mpi::lazy<Tag, gf_const_view<Mesh, Target>> l) : gf() { operator=(l); }
 
     /// ---------------  swap --------------------
 
@@ -364,7 +364,7 @@ namespace triqs::gfs {
      * Performs MPI reduce
      * @param l The lazy object returned by mpi::reduce
      */
-    void operator=(mpi_lazy<mpi::tag::reduce, gf_const_view<Mesh, Target>> l) {
+    void operator=(mpi::lazy<mpi::tag::reduce, gf_const_view<Mesh, Target>> l) {
       _mesh    = l.rhs.mesh();
       _data    = mpi::reduce(l.rhs.data(), l.c, l.root, l.all, l.op); // arrays:: necessary on gcc 5. why ??
       _indices = l.rhs.indices();
@@ -374,7 +374,7 @@ namespace triqs::gfs {
      * Performs MPI scatter
      * @param l The lazy object returned by mpi::scatter
      */
-    void operator=(mpi_lazy<mpi::tag::scatter, gf_const_view<Mesh, Target>> l) {
+    void operator=(mpi::lazy<mpi::tag::scatter, gf_const_view<Mesh, Target>> l) {
       _mesh    = mpi::scatter(l.rhs.mesh(), l.c, l.root);
       _data    = mpi::scatter(l.rhs.data(), l.c, l.root, true);
       _indices = mpi::scatter(l.rhs.indices(), l.c, l.root);
@@ -384,7 +384,7 @@ namespace triqs::gfs {
      * Performs MPI gather
      * @param l The lazy object returned by mpi::gather
      */
-    void operator=(mpi_lazy<mpi::tag::gather, gf_const_view<Mesh, Target>> l) {
+    void operator=(mpi::lazy<mpi::tag::gather, gf_const_view<Mesh, Target>> l) {
       _mesh    = mpi::gather(l.rhs.mesh(), l.c, l.root);
       _data    = mpi::gather(l.rhs.data(), l.c, l.root, l.all);
       _indices = mpi::gather(l.rhs.indices(), l.c, l.root);

--- a/c++/triqs/gfs/gf/gf_view.hpp
+++ b/c++/triqs/gfs/gf/gf_view.hpp
@@ -275,7 +275,7 @@ namespace triqs::gfs {
     * Performs MPI reduce
     * @param l The lazy object returned by mpi::reduce
     */
-    void operator=(mpi_lazy<mpi::tag::reduce, gf_const_view<Mesh, Target>> l) {
+    void operator=(mpi::lazy<mpi::tag::reduce, gf_const_view<Mesh, Target>> l) {
       _mesh = l.rhs.mesh();
       _data = mpi::reduce(l.rhs.data(), l.c, l.root, l.all, l.op); // arrays:: necessary on gcc 5. why ??
     }
@@ -284,7 +284,7 @@ namespace triqs::gfs {
      * Performs MPI scatter
      * @param l The lazy object returned by reduce
      */
-    void operator=(mpi_lazy<mpi::tag::scatter, gf_const_view<Mesh, Target>> l) {
+    void operator=(mpi::lazy<mpi::tag::scatter, gf_const_view<Mesh, Target>> l) {
       _mesh = mpi::scatter(l.rhs.mesh(), l.c, l.root);
       _data = mpi::scatter(l.rhs.data(), l.c, l.root, true);
     }
@@ -293,7 +293,7 @@ namespace triqs::gfs {
      * Performs MPI gather
      * @param l The lazy object returned by mpi::reduce
      */
-    void operator=(mpi_lazy<mpi::tag::gather, gf_const_view<Mesh, Target>> l) {
+    void operator=(mpi::lazy<mpi::tag::gather, gf_const_view<Mesh, Target>> l) {
       _mesh = mpi::gather(l.rhs.mesh(), l.c, l.root);
       _data = mpi::gather(l.rhs.data(), l.c, l.root, l.all);
     }

--- a/c++/triqs/mc_tools/mc_generic.hpp
+++ b/c++/triqs/mc_tools/mc_generic.hpp
@@ -230,7 +230,7 @@ namespace triqs::mc_tools {
       double next_info_time = 0.1;
 
       std::unique_ptr<mpi::monitor> node_monitor;
-      if (rethrow_exception) node_monitor = std::make_unique<mpi::monitor>(c);
+      if (rethrow_exception and mpi::has_env) node_monitor = std::make_unique<mpi::monitor>(c);
 
       for (; !stop_it; ++NC) { // do NOT reinit NC to 0
         try {

--- a/c++/triqs/test_tools/arrays.hpp
+++ b/c++/triqs/test_tools/arrays.hpp
@@ -57,9 +57,13 @@ using triqs::clef::placeholder;
 
 #define MAKE_MAIN                                                                                                                                    \
   int main(int argc, char **argv) {                                                                                                                  \
-    ::mpi::environment env(argc, argv);                                                                                                              \
     ::testing::InitGoogleTest(&argc, argv);                                                                                                          \
-    return RUN_ALL_TESTS();                                                                                                                          \
+    if (mpi::has_env) {                                                                                                                              \
+      mpi::environment env(argc, argv);                                                                                                              \
+      std::cout << "MPI environment detected\n";                                                                                                     \
+      return RUN_ALL_TESTS();                                                                                                                        \
+    } else                                                                                                                                           \
+      return RUN_ALL_TESTS();                                                                                                                        \
   }
 
 // Arrays are equal

--- a/python/triqs/utility/CMakeLists.txt
+++ b/python/triqs/utility/CMakeLists.txt
@@ -7,6 +7,7 @@ SET(PYTHON_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/h5diff.py
   ${CMAKE_CURRENT_BINARY_DIR}/mpi.py
   ${CMAKE_CURRENT_BINARY_DIR}/mpi_mpi4py.py
+  ${CMAKE_CURRENT_BINARY_DIR}/mpi_nompi.py
   ${CMAKE_CURRENT_BINARY_DIR}/mpi_boost.py
   ${CMAKE_CURRENT_SOURCE_DIR}/redirect.py
   ${CMAKE_CURRENT_SOURCE_DIR}/capture_stdout.py

--- a/python/triqs/utility/mpi.py.in
+++ b/python/triqs/utility/mpi.py.in
@@ -19,4 +19,35 @@
 #
 ################################################################################
 
-from .mpi_mpi4py import *
+import os
+
+
+def check_for_mpi():
+    '''
+    Simple function checking if triqs has been called with 
+    mpirun or without, by checking for typical MPI environment
+    variables
+
+    Returns: 
+    -------
+    is_mpi: bool
+            True if triqs called with mpirun
+    '''
+    is_mpi = False
+
+    # for OpenMPI:
+    if os.environ.get('OMPI_COMM_WORLD_RANK'):
+        is_mpi = True
+    # for MPICH and intel based MPI:
+    elif os.environ.get('PMI_RANK'):
+        is_mpi = True
+    else:
+        print('Warning: could not identify MPI environment!')
+
+    return is_mpi
+
+
+if check_for_mpi():
+    from .mpi_mpi4py import *
+else:
+    from .mpi_nompi import *

--- a/python/triqs/utility/mpi_nompi.py
+++ b/python/triqs/utility/mpi_nompi.py
@@ -29,6 +29,11 @@ world = None
 rank = 0
 size = 1
 
+All_Nodes_report = False
+
+# variable for send and receive
+_sendval = None
+
 myprint_err ("Starting serial run at: %s"%(str(datetime.datetime.now())))
 
 
@@ -37,7 +42,7 @@ myprint_err ("Starting serial run at: %s"%(str(datetime.datetime.now())))
 def report(*x,**opt):
         myprint,myflush = (myprint_err,sys.stderr.flush)  if 'stderr' in opt and opt['stderr'] else (myprint_out,sys.stdout.flush)
         for y in x:
-          myprint( y)  # open('report','a').write(str(y) + '\n') #             print y
+          myprint(y)  # open('report','a').write(str(y) + '\n') #             print y
           myflush() # be sure to flush the buffer!
 
 
@@ -45,25 +50,24 @@ def is_master_node(): return True
 
 def bcast(x): return x
 
-def barrier() : return True
+def barrier() : return
 
 def all_reduce(WORLD, x, F) : return x
 
-def send(val, dest): return True
+def send(val, dest):
+    _sendval = val
+    return
 
-# this one I am not sure how to implement
-def recv(source = 0): return True
-
-def slice_inf(imin,imax) :
-  return imin
-
-def slice_sup(imin,imax) :
-  return imax
+def recv(source = 0):
+    if _sendval is None:
+        raise Exception('send val not set')
+    recval = _sendval
+    _sendval = None
+    return recval
 
 def slice_array(A) :
     """Given an array A, it returns a VIEW of a slice over the first dim on the node"""
-    imax = A.shape[0]-1
-    return A[slice_inf(0,imax):slice_sup(0,imax)+1] # +1 due to the slice convention
+    return A
 
 HostNames = {}
 def master_gets_host_names():

--- a/python/triqs/utility/mpi_nompi.py
+++ b/python/triqs/utility/mpi_nompi.py
@@ -1,0 +1,74 @@
+# Copyright (c) 2013 Commissariat à l'énergie atomique et aux énergies alternatives (CEA)
+# Copyright (c) 2013 Centre national de la recherche scientifique (CNRS)
+# Copyright (c) 2019-2020 Simons Foundation
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You may obtain a copy of the License at
+#     https:#www.gnu.org/licenses/gpl-3.0.txt
+#
+# Authors: Olivier Parcollet, Nils Wentzell, Alexander Hampel
+
+
+# this module provides a simple dummy class for MPI in case no MPI env
+# is loaded and triqs is executed in serial
+
+import os,sys,datetime
+myprint_err = lambda x : sys.stderr.write("%s\n"%x)
+myprint_out = lambda x : sys.stdout.write("%s\n"%x)
+
+world = None
+rank = 0
+size = 1
+
+myprint_err ("Starting serial run at: %s"%(str(datetime.datetime.now())))
+
+
+# next are simplified implementations of all mpi functions triqs provides
+
+def report(*x,**opt):
+        myprint,myflush = (myprint_err,sys.stderr.flush)  if 'stderr' in opt and opt['stderr'] else (myprint_out,sys.stdout.flush)
+        for y in x:
+          myprint( y)  # open('report','a').write(str(y) + '\n') #             print y
+          myflush() # be sure to flush the buffer!
+
+
+def is_master_node(): return True
+
+def bcast(x): return x
+
+def barrier() : return True
+
+def all_reduce(WORLD, x, F) : return x
+
+def send(val, dest): return True
+
+# this one I am not sure how to implement
+def recv(source = 0): return True
+
+def slice_inf(imin,imax) :
+  return imin
+
+def slice_sup(imin,imax) :
+  return imax
+
+def slice_array(A) :
+    """Given an array A, it returns a VIEW of a slice over the first dim on the node"""
+    imax = A.shape[0]-1
+    return A[slice_inf(0,imax):slice_sup(0,imax)+1] # +1 due to the slice convention
+
+HostNames = {}
+def master_gets_host_names():
+    """ find the host name of all the nodes """
+    from socket import gethostname
+    print("Hostnames : ")
+    print("Node 0  on machine %s"%(gethostname()))
+

--- a/test/c++/gfs/CMakeLists.txt
+++ b/test/c++/gfs/CMakeLists.txt
@@ -3,6 +3,7 @@ add_subdirectory(multivar)
 add_subdirectory(functions)
 add_subdirectory(meshes)
 
+add_cpp_test(mpi_gf)
 set(TEST_MPI_NUMPROC 2)
 add_cpp_test(mpi_gf)
 set(TEST_MPI_NUMPROC 3)

--- a/test/python/base/CMakeLists.txt
+++ b/test/python/base/CMakeLists.txt
@@ -7,7 +7,6 @@ set(testenv PYTHONPATH=${CMAKE_BINARY_DIR}/python:${CPP2PY_MODULE_DIR}:${CPP2PY_
 add_test(NAME py_check_mpi_env COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 1 ${MPIEXEC_PREFLAGS} ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_mpi_env.py)
 set_property(TEST py_check_mpi_env PROPERTY ENVIRONMENT ${testenv})
 
-#add_python_test(is_mpi_true MPI_NUMPROC 1)
 
 # Greens functions
 add_python_test(gf_imfreq)

--- a/test/python/base/CMakeLists.txt
+++ b/test/python/base/CMakeLists.txt
@@ -52,3 +52,6 @@ add_python_test(gf_tensor_valued)
 add_python_test(histograms)
 add_python_test(histogram_bcast)
 add_python_test(brillouin_zone)
+
+# discretize bath
+add_python_test(discretize_bath)

--- a/test/python/base/CMakeLists.txt
+++ b/test/python/base/CMakeLists.txt
@@ -2,6 +2,13 @@
 FILE(GLOB all_h5_files RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.h5)
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/${all_h5_files} DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
+# test if MPI detection works on system
+set(testenv PYTHONPATH=${CMAKE_BINARY_DIR}/python:${CPP2PY_MODULE_DIR}:${CPP2PY_BINARY_DIR}:${h5_MODULE_DIR}:${h5_BINARY_DIR}/python:./:$ENV{PYTHONPATH})
+add_test(NAME py_check_mpi_env COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 1 ${MPIEXEC_PREFLAGS} ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_mpi_env.py)
+set_property(TEST py_check_mpi_env PROPERTY ENVIRONMENT ${testenv})
+
+#add_python_test(is_mpi_true MPI_NUMPROC 1)
+
 # Greens functions
 add_python_test(gf_imfreq)
 add_python_test(gf_block)

--- a/test/python/base/check_mpi_env.py
+++ b/test/python/base/check_mpi_env.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2013-2014 Commissariat à l'énergie atomique et aux énergies alternatives (CEA)
+# Copyright (c) 2013-2014 Centre national de la recherche scientifique (CNRS)
+# Copyright (c) 2019-2020 Simons Foundation
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You may obtain a copy of the License at
+#     https:#www.gnu.org/licenses/gpl-3.0.txt
+#
+# Authors: Olivier Parcollet, Nils Wentzell
+
+import os
+import sys
+
+
+from triqs.utility.mpi import check_for_mpi
+
+
+is_mpi = check_for_mpi()
+
+assert is_mpi  == True, 'MPI environment could not be properly deterimend, check your MPI env'
+
+
+
+
+

--- a/test/python/base/discretize_bath.py
+++ b/test/python/base/discretize_bath.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2018 Commissariat à l'énergie atomique et aux énergies alternatives (CEA)
+# Copyright (c) 2018 Centre national de la recherche scientifique (CNRS)
+# Copyright (c) 2018-2020 Simons Foundation
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You may obtain a copy of the License at
+#     https:#www.gnu.org/licenses/gpl-3.0.txt
+#
+# Authors: Alexander Hampel, Nils Wentzell
+
+import numpy as np
+from triqs.gf import *
+from triqs.gf.tools import discretize_bath
+from triqs.utility.comparison_tests import *
+
+# build delta from discretized values
+delta_iw = GfImFreq(target_shape=[], mesh=MeshImFreq(beta=40, S='Fermion', n_max=200))
+
+hoppings = np.array([0.2, 0.6])
+energies = np.array([0.0, 0.5])
+
+for w in delta_iw.mesh:
+    delta_iw[w] = np.sum(hoppings**2/( w.value - energies ) )
+
+# run bath fitter on this input
+t_opt, e_opt, delta_disc_iw = discretize_bath(delta_iw = delta_iw, Nb = 2, bandwidth=2.5, t_init=0.1, tol=1e-8)
+
+# compare to given values
+assert max(abs(hoppings - t_opt)) < 1e-8, 'did not achieved requiered accuracy for bath fit '+str(t_opt)+' vs '+str(hoppings)
+assert max(abs(energies - e_opt)) < 1e-8, 'did not achieved requiered accuracy for bath fit '+str(e_opt)+' vs '+str(energies)
+assert_gfs_are_close(delta_disc_iw, delta_iw)


### PR DESCRIPTION
Adding the functionality to all triqs parts to be run without calling any parts of MPI. Even not an init. This allows to run the c++ and python part to be run without having access to MPI at runtime for testing, or quick analysis. Can be useful on HPC systems with no MPI access on login nodes. This needs also an updated version of triqs_mpi and NDA (PR seperately).

- added a second mpi layer which is imported instead of mpi4py if triqs is run without mpirun
- added a test to check if the mpi environment can be detected correctly
- added tests for running w/o MPI
- changed parts of c++ code to be in line with triqs_mpi
