### PR TITLE
Fix a serious bug in `imperative_operator` (#819) introduced by PR #686

### DIFF
--- a/c++/triqs/hilbert_space/imperative_operator.hpp
+++ b/c++/triqs/hilbert_space/imperative_operator.hpp
@@ -99,12 +99,38 @@ namespace triqs {
         hilbert_map = hmap;
         if ((hilbert_map.size() == 0) != !UseMap) TRIQS_RUNTIME_ERROR << "Internal error";
 
+        auto greater = [&fops](triqs::operators::canonical_ops_t const& op1,
+                               triqs::operators::canonical_ops_t const& op2) {
+          if(op1.dagger != op2.dagger) return op2.dagger;
+          return op1.dagger ? (fops[op1.indices] > fops[op2.indices]) :
+                              (fops[op1.indices] < fops[op2.indices]);
+        };
+
         // The goal here is to have a transcription of the many_body_operator in terms
         // of simple vectors (maybe the code below could be more elegant)
-        for (auto const &term : op) {
+        for (auto const& term : op) {
+          auto monomial = term.monomial;
+          auto coef = term.coef;
+
+          // Sort monomial according to the order established by fops
+          int n = monomial.size();
+          bool swapped;
+          do {
+            swapped = false;
+            for(int i = 1; i < n; ++i) {
+              if(greater(monomial[i - 1], monomial[i])) {
+                using std::swap;
+                swap(monomial[i - 1], monomial[i]);
+                swapped = true;
+                coef *= scalar_t(-1);
+              }
+            }
+            --n;
+          } while(swapped);
+
           std::vector<int> dag, ndag;
           uint64_t d_mask = 0, dag_mask = 0;
-          for (auto const &canonical_op : term.monomial) {
+          for (auto const &canonical_op : monomial) {
             (canonical_op.dagger ? dag : ndag).push_back(fops[canonical_op.indices]);
             (canonical_op.dagger ? dag_mask : d_mask) |= (uint64_t(1) << fops[canonical_op.indices]);
           }
@@ -120,7 +146,7 @@ namespace triqs {
             return mask;
           };
           uint64_t d_count_mask = compute_count_mask(ndag), dag_count_mask = compute_count_mask(dag);
-          all_terms.push_back(one_term_t{scalar_t(term.coef), d_mask, dag_mask, d_count_mask, dag_count_mask});
+          all_terms.push_back(one_term_t{scalar_t(coef), d_mask, dag_mask, d_count_mask, dag_count_mask});
         }
       }
 


### PR DESCRIPTION
PR #686 changed the order in which `fundamental_operator_set` stores index combinations. Before that PR, mutual order of two index combinations was dictated by the result of `operator<()`, which had been consistent with the way `many_body_operator` orders canonical operators within a monomial. Now the order of the index combinations and - consequently - of single particle bits forming a Fock state is arbitrary. When computing fermionic sign prefactor, the constructor of `imperative_operator` relied on ordering of the bits being consistent with the ordering of the monomial. PR #686 broke that assumption, which resulted in a dangerous and hard-to-find bug -- sign of some matrix elements can be erroneously flipped.

This PR fixes the issue by sorting monomials in `imperative_operator`'s constructor and revealing a possible sign change due to a permutation of canonical operators caused by `fops`.

With this fix, the Python script from #819 gives the following output.
```
[0. 0. 3.] [0. 0. 3.]
[0. 2.] [0. 2.]
[0. 2.] [0. 2.]
[0. 2.] [0. 2.]
[0. 2.] [0. 2.]
[0. 2.] [0. 0. 3.]
[0. 0. 3.] [0. 2.]
[0. 2.] [0. 2.]
[0. 2.] [0. 2.]
[0. 0. 3.] [0. 2.]
[0. 2.] [0. 0. 3.]
[0. 0. 3.] [0. 0. 3.]
[0. 2.] [0. 2.]
[0. 2.] [0. 2.]
[0. 2.] [0. 2.]
[0. 2.] [0. 2.]
[1.] [1.]
[1.] [1.]
[1.] [1.]
...
[1.] [1.]
```

Despite the fact the base branch is set to `3.0.x` here, I would greatly appreciate having the fix on `2.2.x` as well.