### PR TITLE
extend discretize bath functionality

### DIFF
--- a/python/triqs/gf/tools.py
+++ b/python/triqs/gf/tools.py
@@ -367,9 +367,9 @@ def discretize_bath(delta_in, Nb, eps0= 3, V0 = 0.0, tol=1e-8, maxiter = 10000, 
         V_opt, eps_opt, delta_list = [], [], []
         for i, (block, delta) in zip(range(len(list(delta_in.indices))),delta_in):
             if isinstance(eps0, list) and isinstance(V0, list):
-                res = discretize_bath(delta, Nb, eps0[i], V0[i], tol, maxiter)
+                res = discretize_bath(delta, Nb, eps0[i], V0[i], tol, maxiter, cmplx)
             else:
-                res = discretize_bath(delta, Nb, eps0, V0, tol, maxiter)
+                res = discretize_bath(delta, Nb, eps0, V0, tol, maxiter, cmplx)
             V_opt.append(res[0])
             eps_opt.append(res[1])
             delta_list.append(res[2])

--- a/python/triqs/gf/tools.py
+++ b/python/triqs/gf/tools.py
@@ -21,7 +21,8 @@
 from . import lazy_expressions, descriptors, gf_fnt
 from .meshes import MeshImFreq, MeshReFreq, MeshImTime, MeshReTime, MeshLegendre
 from .block_gf import BlockGf
-from .gf import Gf, make_hermitian
+from .gf import Gf
+from .gf_factories import make_hermitian
 import numpy as np
 from itertools import product
 from .backwd_compat.gf_refreq import GfReFreq

--- a/python/triqs/gf/tools.py
+++ b/python/triqs/gf/tools.py
@@ -312,9 +312,9 @@ def make_delta(V, eps, mesh, block_names = None):
     mesh_values = np.array([w.value for w in mesh])
 
     if isinstance(mesh, MeshImFreq):
-        one_fermion = 1/mesh_values[:,None,None] - eps[None,None,:]
+        one_fermion = 1/(mesh_values[:,None,None] - eps[None,None,:])
     elif isinstance(mesh, MeshImTime):
-        one_fermion = -np.exp(-1*mesh_values[:,None,None] * eps[None,None,:]) / (1. + np.exp(-mesh.beta * eps[None,None,:]))
+        one_fermion = -np.exp(-mesh_values[:,None,None] * eps[None,None,:]) / (1. + np.exp(-mesh.beta * eps[None,None,:]))
     
     delta_res.data[:] = np.einsum('wij, wjk -> wik', V.conj().T[None,:,:] * one_fermion, V[None,:,:])
         

--- a/python/triqs/gf/tools.py
+++ b/python/triqs/gf/tools.py
@@ -307,7 +307,7 @@ def make_delta(V, eps, mesh, block_names = None):
     
     assert V.shape[0] == len(eps), 'number of bath sides in V and eps does not match'
     
-    delta_res = GfImFreq(mesh=mesh, target_shape=[V.shape[1],V.shape[1]])
+    delta_res = Gf(mesh=mesh, target_shape=[V.shape[1],V.shape[1]])
     
     mesh_values = np.array([w.value for w in mesh])
 

--- a/python/triqs/gf/tools.py
+++ b/python/triqs/gf/tools.py
@@ -366,10 +366,10 @@ def discretize_bath(delta_in, Nb, eps0= 3, V0 = 0.0, tol=1e-8, maxiter = 10000, 
     if isinstance(delta_in, BlockGf):
         V_opt, eps_opt, delta_list = [], [], []
         for i, (block, delta) in zip(range(len(list(delta_in.indices))),delta_in):
-            if isinstance(eps0, list) and isinstance(V0, list):
-                res = discretize_bath(delta, Nb, eps0[i], V0[i], tol, maxiter, cmplx)
-            else:
-                res = discretize_bath(delta, Nb, eps0, V0, tol, maxiter, cmplx)
+            res = discretize_bath(delta, Nb,
+                    eps0[i] if isinstance(eps0, list) else eps0,
+                    V0[i] if isinstance(V0, list) else V0,
+                    tol, maxiter, cmplx)
             V_opt.append(res[0])
             eps_opt.append(res[1])
             delta_list.append(res[2])

--- a/python/triqs/gf/tools.py
+++ b/python/triqs/gf/tools.py
@@ -412,12 +412,12 @@ def discretize_bath(delta_in, Nb, eps0=3, V0=None, tol=1e-15, maxiter=10000,
     def unflatten(x):
         # first half of parameters are hoppings, second half are bath energies
         if cmplx:
-            V = x[0:2*Nb*n_orb].view(complex).reshape(n_orb, Nb)
-            e = x[2*Nb*n_orb:]
+            V   = x[0:2*Nb*n_orb].view(complex).reshape(n_orb, Nb)
+            eps = x[2*Nb*n_orb:]
         else:
-            V = x[0:Nb*n_orb].reshape(n_orb, Nb)
-            e = x[Nb*n_orb:]
-        return V, e
+            V   = x[0:Nb*n_orb].reshape(n_orb, Nb)
+            eps = x[Nb*n_orb:]
+        return V, eps
 
     ####
     # define minimizer for scipy

--- a/python/triqs/gf/tools.py
+++ b/python/triqs/gf/tools.py
@@ -414,7 +414,7 @@ def discretize_bath(delta_in, Nb, eps0= 3, V0 = 0.0, tol=1e-8, maxiter = 10000, 
             one_fermion = 1/(mesh_values[:,None] - e[None,:])
         elif isinstance(delta_in.mesh, MeshImTime):
             one_fermion = -np.exp(-mesh_values[:,None] * e[None,:]) / (1. + np.exp(-delta_in.mesh.beta * e[None,:]))
-        delta = np.dot(V[None,:,:] * one_fermion[:,None,:], V.conj().T)
+        delta = np.einsum('wij, jk -> wik', V[None,:,:] * one_fermion[:,None,:], V.conj().T[:,:])
 
         # if Gf is scalar values we have to squeeze the add axis
         if len(delta_in.target_shape)==0:

--- a/test/python/base/discretize_bath.py
+++ b/test/python/base/discretize_bath.py
@@ -31,7 +31,7 @@ energies = np.array([0.0, 0.5])
 delta_iw = make_delta(V= hoppings, eps=energies, mesh=mesh)
 
 # run bath fitter on this input
-V_opt, e_opt, delta_disc_iw = discretize_bath(delta_in = delta_iw, Nb = 2, eps0=2.5, V_init=0.1, tol=1e-8)
+V_opt, e_opt, delta_disc_iw = discretize_bath(delta_in = delta_iw, Nb = 2, eps0=2.5, V0=0.1, tol=1e-8)
 
 # compare to given values
 assert max(abs(hoppings - V_opt)) < 1e-8, 'did not achieved requiered accuracy for bath fit '+str(V_opt)+' vs '+str(hoppings)
@@ -56,7 +56,7 @@ energies = np.array([-1.5437759000e+00, -4.0244628425e-01, -3.3678965769e-01, -3
 delta_tau = make_delta(V= hoppings, eps=energies, mesh=mesh)
 
 # run bath fitter on this input
-V_opt, e_opt, delta_disc_tau = discretize_bath(delta_in = delta_tau, Nb = 8, eps0= energies, V_init=hoppings, tol=1e-6, maxiter=100000)
+V_opt, e_opt, delta_disc_tau = discretize_bath(delta_in = delta_tau, Nb = 8, eps0= energies, V0=hoppings, tol=1e-6, maxiter=100000)
 
 # # compare to given values
 assert np.max(np.abs(hoppings - V_opt)) < 1e-6, 'did not achieved requiered accuracy for bath fit '+str(V_opt)+' vs '+str(hoppings)

--- a/test/python/base/discretize_bath.py
+++ b/test/python/base/discretize_bath.py
@@ -19,22 +19,48 @@
 
 import numpy as np
 from triqs.gf import *
-from triqs.gf.tools import discretize_bath
+from triqs.gf.tools import discretize_bath, make_delta
 from triqs.utility.comparison_tests import *
 
 # build delta from discretized values
-delta_iw = GfImFreq(target_shape=[], mesh=MeshImFreq(beta=40, S='Fermion', n_max=200))
+mesh=MeshImFreq(beta=40, S='Fermion', n_max=200)
 
 hoppings = np.array([0.2, 0.6])
 energies = np.array([0.0, 0.5])
 
-for w in delta_iw.mesh:
-    delta_iw[w] = np.sum(hoppings**2/( w.value - energies ) )
+delta_iw = make_delta(V= hoppings, eps=energies, mesh=mesh)
 
 # run bath fitter on this input
-t_opt, e_opt, delta_disc_iw = discretize_bath(delta_iw = delta_iw, Nb = 2, bandwidth=2.5, t_init=0.1, tol=1e-8)
+V_opt, e_opt, delta_disc_iw = discretize_bath(delta_in = delta_iw, Nb = 2, eps0=2.5, V_init=0.1, tol=1e-8)
 
 # compare to given values
-assert max(abs(hoppings - t_opt)) < 1e-8, 'did not achieved requiered accuracy for bath fit '+str(t_opt)+' vs '+str(hoppings)
+assert max(abs(hoppings - V_opt)) < 1e-8, 'did not achieved requiered accuracy for bath fit '+str(V_opt)+' vs '+str(hoppings)
 assert max(abs(energies - e_opt)) < 1e-8, 'did not achieved requiered accuracy for bath fit '+str(e_opt)+' vs '+str(energies)
 assert_gfs_are_close(delta_disc_iw, delta_iw)
+
+
+# second test with 2x2 delta input and init guess
+mesh=MeshImTime(beta=40, S='Fermion', n_max=1001)
+
+hoppings = np.array([[ 6.1916012067e-01,  1.4280122215e-08],
+                     [-1.9899876996e-07,  3.3503877422e-01],
+                     [ 3.4998359745e-01,  1.8024665743e-07],
+                     [-4.0523734143e-08,  1.8849071562e-01],
+                     [ 1.3545326772e-01,  4.9300282564e-08],
+                     [ 3.8188035741e-08, -2.2889123931e-01],
+                     [ 2.4378742241e-01,  3.3385121561e-08],
+                     [ 6.9810984451e-06, -4.7688592983e-02]])
+energies = np.array([-1.5437759000e+00, -4.0244628425e-01, -3.3678965769e-01, -3.8795127563e-02, 
+                     9.9602047476e-03,  1.6012620754e-01,  3.4692574848e-01,  2.0529795026e+03])
+
+delta_tau = make_delta(V= hoppings, eps=energies, mesh=mesh)
+
+# run bath fitter on this input
+V_opt, e_opt, delta_disc_tau = discretize_bath(delta_in = delta_tau, Nb = 8, eps0= energies, V_init=hoppings, tol=1e-6, maxiter=100000)
+
+# # compare to given values
+assert np.max(np.abs(hoppings - V_opt)) < 1e-6, 'did not achieved requiered accuracy for bath fit '+str(V_opt)+' vs '+str(hoppings)
+assert np.max(np.abs(energies - e_opt)) < 1e-6, 'did not achieved requiered accuracy for bath fit '+str(e_opt)+' vs '+str(energies)
+assert_gfs_are_close(delta_disc_tau, delta_tau)
+
+

--- a/test/python/base/discretize_bath.py
+++ b/test/python/base/discretize_bath.py
@@ -31,15 +31,15 @@ energies = np.array([0.0, 0.5])
 delta_iw = make_delta(V=hoppings, eps=energies, mesh=mesh)
 
 # run bath fitter on this input
-# V_opt, e_opt, delta_disc_iw = discretize_bath(delta_in=delta_iw, Nb=2, eps0=2.5, V0=None, tol=1e-10)
-# # compare to given values , resulting V can be correct up to a global sign
-# assert np.max(np.abs(hoppings) - np.abs(V_opt)) < 1e-6, 'did not achieved requiered accuracy for bath fit \n'+str(V_opt)+' vs \n'+str(hoppings)
-# assert np.max(np.abs(energies - e_opt)) < 1e-6, 'did not achieved requiered accuracy for bath fit \n'+str(e_opt)+' vs \n'+str(energies)
-# assert_gfs_are_close(delta_disc_iw, delta_iw)
+V_opt, e_opt, delta_disc_iw = discretize_bath(delta_in=delta_iw, Nb=2, eps0=2.5, V0=None, tol=1e-10)
+# compare to given values , resulting V can be correct up to a global sign
+assert np.max(np.abs(hoppings) - np.abs(V_opt)) < 1e-6, 'did not achieved requiered accuracy for bath fit \n'+str(V_opt)+' vs \n'+str(hoppings)
+assert np.max(np.abs(energies - e_opt)) < 1e-6, 'did not achieved requiered accuracy for bath fit \n'+str(e_opt)+' vs \n'+str(energies)
+assert_gfs_are_close(delta_disc_iw, delta_iw)
 
-# # try with Nb % n_orb != 0
-# V_opt, e_opt, delta_disc_iw = discretize_bath(delta_in=delta_iw, Nb=3, eps0=2.5, V0=None, tol=1e-10)
-# V_opt, e_opt, delta_disc_iw = discretize_bath(delta_in=delta_iw, Nb=1, eps0=2.5, V0=None, tol=1e-10)
+#try with Nb % n_orb != 0
+V_opt, e_opt, delta_disc_iw = discretize_bath(delta_in=delta_iw, Nb=3, eps0=2.5, V0=None, tol=1e-10)
+V_opt, e_opt, delta_disc_iw = discretize_bath(delta_in=delta_iw, Nb=1, eps0=2.5, V0=None, tol=1e-10)
 
 #################################################
 # second test with 2x2 delta input and init guess
@@ -53,46 +53,44 @@ energies = np.array([-1.5437759000e+00, -4.0244628425e-01, -3.3678965769e-01, -3
 
 delta_tau = make_delta(V=hoppings, eps=energies, mesh=mesh)
 
-V_opt, e_opt, delta_disc_tau = discretize_bath(delta_in=delta_tau, Nb=8, eps0=energies, V0=None, tol=1e-15, maxiter=1000000, method='BFGS', constr_tol=1e-8, penalty=10)
+V_opt, e_opt, delta_disc_tau = discretize_bath(delta_in=delta_tau, Nb=8, eps0=energies, V0=None, tol=1e-15, maxiter=10000000, method='BFGS')
 print('max hopping deviation', np.max(np.abs(hoppings) - np.abs(V_opt)))
-print(V_opt)
 
-# compare to given values
-assert np.max(np.abs(hoppings) - np.abs(V_opt)) < 1e-6, 'did not achieved requiered accuracy for bath fit \n'+str(V_opt)+' vs \n'+str(hoppings)
-assert np.max(np.abs(energies - e_opt)) < 1e-6, 'did not achieved requiered accuracy for bath fit \n'+str(e_opt)+' vs \n'+str(energies)
+# # compare to given values
+assert np.max(np.abs(hoppings) - np.abs(V_opt)) < 1e-5, 'did not achieved requiered accuracy for bath fit \n'+str(V_opt)+' vs \n'+str(hoppings)
+assert np.max(np.abs(energies - e_opt)) < 1e-5, 'did not achieved requiered accuracy for bath fit \n'+str(e_opt)+' vs \n'+str(energies)
 assert_gfs_are_close(delta_disc_tau, delta_tau)
 
 
-# #################################################
-# # test blockGf
-# mesh = MeshImTime(beta=40, S='Fermion', n_max=501)
+#################################################
+# test blockGf
+mesh = MeshImTime(beta=40, S='Fermion', n_max=501)
 
-# hoppings = [np.array([[0.2, 0.1, -0.5, 0.15]]),
-            # np.array([[0.2, -0.35, 0.7, 0.1]])]
+hoppings = [np.array([[0.2, 0.1, -0.5, 0.15]]),
+            np.array([[0.2, -0.35, 0.7, 0.1]])]
 
-# energies = [np.array([-2.2, -1.1, 0.0, 0.7]),
-            # np.array([-1.7, -0.3, -0.1, 0.2])]
+energies = [np.array([-2.2, -1.1, 0.0, 0.7]),
+            np.array([-1.7, -0.3, -0.1, 0.2])]
 
-# delta_tau = make_delta(V=hoppings, eps=energies, mesh=mesh)
+delta_tau = make_delta(V=hoppings, eps=energies, mesh=mesh)
 
-# # run bath fitter on hopping as input
-# V_opt, e_opt, delta_disc_tau = discretize_bath(delta_in=delta_tau, Nb=4, eps0=energies, V0=hoppings, tol=1e-12, maxiter=100000)
-# print('max hopping deviation', np.max(np.abs(hoppings) - np.abs(V_opt)))
+# run bath fitter on hopping as input
+V_opt, e_opt, delta_disc_tau = discretize_bath(delta_in=delta_tau, Nb=4, eps0=energies, V0=hoppings, tol=1e-15, maxiter=100000)
+print('max hopping deviation', np.max(np.abs(hoppings) - np.abs(V_opt)))
 
-# # compare to given values
-# for i, (block, delta_disc) in zip(range(len(list(delta_disc_tau.indices))), delta_disc_tau):
-    # assert np.max(np.abs(hoppings[i]) - np.abs(V_opt[i])) < 1e-8, 'did not achieved requiered accuracy for bath fit \n'+str(V_opt)+' vs \n'+str(hoppings)
-    # assert np.max(np.abs(energies[i] - e_opt[i])) < 1e-8, 'did not achieved requiered accuracy for bath fit \n'+str(e_opt)+' vs \n'+str(energies)
-    # assert_gfs_are_close(delta_disc, delta_tau[block])
+# compare to given values
+for i, (block, delta_disc) in zip(range(len(list(delta_disc_tau.indices))), delta_disc_tau):
+    assert np.max(np.abs(hoppings[i]) - np.abs(V_opt[i])) < 1e-8, 'did not achieved requiered accuracy for bath fit \n'+str(V_opt)+' vs \n'+str(hoppings)
+    assert np.max(np.abs(energies[i] - e_opt[i])) < 1e-8, 'did not achieved requiered accuracy for bath fit \n'+str(e_opt)+' vs \n'+str(energies)
+    assert_gfs_are_close(delta_disc, delta_tau[block])
 
 
-# #################################################
-# # and test without providing input parameters
-# V_opt, e_opt, delta_disc_tau = discretize_bath(delta_in=delta_tau, Nb=4, eps0=2, V0=None, tol=1e-15, maxiter=200, method='basinhopping')
-# print('max hopping deviation', np.max(np.abs(hoppings) - np.abs(V_opt)))
-
-# # compare to given values
-# for i, (block, delta_disc) in zip(range(len(list(delta_disc_tau.indices))), delta_disc_tau):
-    # assert np.max(np.abs(hoppings[i]) - np.abs(V_opt[i])) < 1e-3, 'did not achieved requiered accuracy for bath fit \n'+str(V_opt)+' vs \n'+str(hoppings)
-    # assert np.max(np.abs(energies[i] - e_opt[i])) < 1e-3, 'did not achieved requiered accuracy for bath fit \n'+str(e_opt)+' vs \n'+str(energies)
-    # assert_gfs_are_close(delta_disc, delta_tau[block], precision=1e-3)
+#################################################
+# and test without providing input parameters
+V_opt, e_opt, delta_disc_tau = discretize_bath(delta_in=delta_tau, Nb=4, eps0=2, V0=None, tol=1e-15, maxiter=200, method='basinhopping')
+print('max hopping deviation', np.max(np.abs(hoppings) - np.abs(V_opt)))
+# compare to given values
+for i, (block, delta_disc) in zip(range(len(list(delta_disc_tau.indices))), delta_disc_tau):
+    assert np.max(np.abs(hoppings[i]) - np.abs(V_opt[i])) < 1e-3, 'did not achieved requiered accuracy for bath fit \n'+str(V_opt)+' vs \n'+str(hoppings)
+    assert np.max(np.abs(energies[i] - e_opt[i])) < 1e-3, 'did not achieved requiered accuracy for bath fit \n'+str(e_opt)+' vs \n'+str(energies)
+    assert_gfs_are_close(delta_disc, delta_tau[block], precision=1e-3)

--- a/test/python/base/discretize_bath.py
+++ b/test/python/base/discretize_bath.py
@@ -42,6 +42,15 @@ V_opt, e_opt, delta_disc_iw = discretize_bath(delta_in=delta_iw, Nb=3, eps0=2.5,
 V_opt, e_opt, delta_disc_iw = discretize_bath(delta_in=delta_iw, Nb=1, eps0=2.5, V0=None, tol=1e-10)
 
 #################################################
+# test basin hopping
+V_opt, e_opt, delta_disc_iw = discretize_bath(delta_in=delta_iw, Nb=2, eps0=energies, V0=None, tol=1e-10, maxiter=100, method='basinhopping')
+print('max hopping deviation', np.max(np.abs(hoppings) - np.abs(V_opt)))
+# compare to given values
+assert np.max(np.abs(hoppings) - np.abs(V_opt)) < 1e-6, 'did not achieved requiered accuracy for bath fit \n'+str(V_opt)+' vs \n'+str(hoppings)
+assert np.max(np.abs(energies - e_opt)) < 1e-6, 'did not achieved requiered accuracy for bath fit \n'+str(e_opt)+' vs \n'+str(energies)
+assert_gfs_are_close(delta_disc_iw, delta_iw)
+
+#################################################
 # second test with 2x2 delta input and init guess
 mesh = MeshImTime(beta=40, S='Fermion', n_max=1001)
 
@@ -83,14 +92,3 @@ for i, (block, delta_disc) in zip(range(len(list(delta_disc_tau.indices))), delt
     assert np.max(np.abs(hoppings[i]) - np.abs(V_opt[i])) < 1e-8, 'did not achieved requiered accuracy for bath fit \n'+str(V_opt)+' vs \n'+str(hoppings)
     assert np.max(np.abs(energies[i] - e_opt[i])) < 1e-8, 'did not achieved requiered accuracy for bath fit \n'+str(e_opt)+' vs \n'+str(energies)
     assert_gfs_are_close(delta_disc, delta_tau[block])
-
-
-#################################################
-# and test without providing input parameters
-V_opt, e_opt, delta_disc_tau = discretize_bath(delta_in=delta_tau, Nb=4, eps0=2, V0=None, tol=1e-15, maxiter=200, method='basinhopping')
-print('max hopping deviation', np.max(np.abs(hoppings) - np.abs(V_opt)))
-# compare to given values
-for i, (block, delta_disc) in zip(range(len(list(delta_disc_tau.indices))), delta_disc_tau):
-    assert np.max(np.abs(hoppings[i]) - np.abs(V_opt[i])) < 1e-3, 'did not achieved requiered accuracy for bath fit \n'+str(V_opt)+' vs \n'+str(hoppings)
-    assert np.max(np.abs(energies[i] - e_opt[i])) < 1e-3, 'did not achieved requiered accuracy for bath fit \n'+str(e_opt)+' vs \n'+str(energies)
-    assert_gfs_are_close(delta_disc, delta_tau[block], precision=1e-3)

--- a/test/python/base/discretize_bath.py
+++ b/test/python/base/discretize_bath.py
@@ -31,15 +31,15 @@ energies = np.array([0.0, 0.5])
 delta_iw = make_delta(V=hoppings, eps=energies, mesh=mesh)
 
 # run bath fitter on this input
-V_opt, e_opt, delta_disc_iw = discretize_bath(delta_in=delta_iw, Nb=2, eps0=2.5, V0=None, tol=1e-10)
-# compare to given values , resulting V can be correct up to a global sign
-assert np.max(np.abs(hoppings) - np.abs(V_opt)) < 1e-6, 'did not achieved requiered accuracy for bath fit \n'+str(V_opt)+' vs \n'+str(hoppings)
-assert np.max(np.abs(energies - e_opt)) < 1e-6, 'did not achieved requiered accuracy for bath fit \n'+str(e_opt)+' vs \n'+str(energies)
-assert_gfs_are_close(delta_disc_iw, delta_iw)
+# V_opt, e_opt, delta_disc_iw = discretize_bath(delta_in=delta_iw, Nb=2, eps0=2.5, V0=None, tol=1e-10)
+# # compare to given values , resulting V can be correct up to a global sign
+# assert np.max(np.abs(hoppings) - np.abs(V_opt)) < 1e-6, 'did not achieved requiered accuracy for bath fit \n'+str(V_opt)+' vs \n'+str(hoppings)
+# assert np.max(np.abs(energies - e_opt)) < 1e-6, 'did not achieved requiered accuracy for bath fit \n'+str(e_opt)+' vs \n'+str(energies)
+# assert_gfs_are_close(delta_disc_iw, delta_iw)
 
-# try with Nb % n_orb != 0
-V_opt, e_opt, delta_disc_iw = discretize_bath(delta_in=delta_iw, Nb=3, eps0=2.5, V0=None, tol=1e-10)
-V_opt, e_opt, delta_disc_iw = discretize_bath(delta_in=delta_iw, Nb=1, eps0=2.5, V0=None, tol=1e-10)
+# # try with Nb % n_orb != 0
+# V_opt, e_opt, delta_disc_iw = discretize_bath(delta_in=delta_iw, Nb=3, eps0=2.5, V0=None, tol=1e-10)
+# V_opt, e_opt, delta_disc_iw = discretize_bath(delta_in=delta_iw, Nb=1, eps0=2.5, V0=None, tol=1e-10)
 
 #################################################
 # second test with 2x2 delta input and init guess
@@ -53,8 +53,9 @@ energies = np.array([-1.5437759000e+00, -4.0244628425e-01, -3.3678965769e-01, -3
 
 delta_tau = make_delta(V=hoppings, eps=energies, mesh=mesh)
 
-V_opt, e_opt, delta_disc_tau = discretize_bath(delta_in=delta_tau, Nb=8, eps0=energies, V0=None, tol=1e-12, maxiter=1000000)
+V_opt, e_opt, delta_disc_tau = discretize_bath(delta_in=delta_tau, Nb=8, eps0=energies, V0=None, tol=1e-15, maxiter=1000000, method='BFGS', constr_tol=1e-8, penalty=10)
 print('max hopping deviation', np.max(np.abs(hoppings) - np.abs(V_opt)))
+print(V_opt)
 
 # compare to given values
 assert np.max(np.abs(hoppings) - np.abs(V_opt)) < 1e-6, 'did not achieved requiered accuracy for bath fit \n'+str(V_opt)+' vs \n'+str(hoppings)
@@ -62,36 +63,36 @@ assert np.max(np.abs(energies - e_opt)) < 1e-6, 'did not achieved requiered accu
 assert_gfs_are_close(delta_disc_tau, delta_tau)
 
 
-#################################################
-# test blockGf
-mesh = MeshImTime(beta=40, S='Fermion', n_max=501)
+# #################################################
+# # test blockGf
+# mesh = MeshImTime(beta=40, S='Fermion', n_max=501)
 
-hoppings = [np.array([[0.2, 0.1, -0.5, 0.15]]),
-            np.array([[0.2, -0.35, 0.7, 0.1]])]
+# hoppings = [np.array([[0.2, 0.1, -0.5, 0.15]]),
+            # np.array([[0.2, -0.35, 0.7, 0.1]])]
 
-energies = [np.array([-2.2, -1.1, 0.0, 0.7]),
-            np.array([-1.7, -0.3, -0.1, 0.2])]
+# energies = [np.array([-2.2, -1.1, 0.0, 0.7]),
+            # np.array([-1.7, -0.3, -0.1, 0.2])]
 
-delta_tau = make_delta(V=hoppings, eps=energies, mesh=mesh)
+# delta_tau = make_delta(V=hoppings, eps=energies, mesh=mesh)
 
-# run bath fitter on hopping as input
-V_opt, e_opt, delta_disc_tau = discretize_bath(delta_in=delta_tau, Nb=4, eps0=energies, V0=hoppings, tol=1e-12, maxiter=100000)
-print('max hopping deviation', np.max(np.abs(hoppings) - np.abs(V_opt)))
+# # run bath fitter on hopping as input
+# V_opt, e_opt, delta_disc_tau = discretize_bath(delta_in=delta_tau, Nb=4, eps0=energies, V0=hoppings, tol=1e-12, maxiter=100000)
+# print('max hopping deviation', np.max(np.abs(hoppings) - np.abs(V_opt)))
 
-# compare to given values
-for i, (block, delta_disc) in zip(range(len(list(delta_disc_tau.indices))), delta_disc_tau):
-    assert np.max(np.abs(hoppings[i]) - np.abs(V_opt[i])) < 1e-8, 'did not achieved requiered accuracy for bath fit \n'+str(V_opt)+' vs \n'+str(hoppings)
-    assert np.max(np.abs(energies[i] - e_opt[i])) < 1e-8, 'did not achieved requiered accuracy for bath fit \n'+str(e_opt)+' vs \n'+str(energies)
-    assert_gfs_are_close(delta_disc, delta_tau[block])
+# # compare to given values
+# for i, (block, delta_disc) in zip(range(len(list(delta_disc_tau.indices))), delta_disc_tau):
+    # assert np.max(np.abs(hoppings[i]) - np.abs(V_opt[i])) < 1e-8, 'did not achieved requiered accuracy for bath fit \n'+str(V_opt)+' vs \n'+str(hoppings)
+    # assert np.max(np.abs(energies[i] - e_opt[i])) < 1e-8, 'did not achieved requiered accuracy for bath fit \n'+str(e_opt)+' vs \n'+str(energies)
+    # assert_gfs_are_close(delta_disc, delta_tau[block])
 
 
-#################################################
-# and test without providing input parameters
-V_opt, e_opt, delta_disc_tau = discretize_bath(delta_in=delta_tau, Nb=4, eps0=2, V0=None, tol=1e-15, maxiter=200, method='basinhopping')
-print('max hopping deviation', np.max(np.abs(hoppings) - np.abs(V_opt)))
+# #################################################
+# # and test without providing input parameters
+# V_opt, e_opt, delta_disc_tau = discretize_bath(delta_in=delta_tau, Nb=4, eps0=2, V0=None, tol=1e-15, maxiter=200, method='basinhopping')
+# print('max hopping deviation', np.max(np.abs(hoppings) - np.abs(V_opt)))
 
-# compare to given values
-for i, (block, delta_disc) in zip(range(len(list(delta_disc_tau.indices))), delta_disc_tau):
-    assert np.max(np.abs(hoppings[i]) - np.abs(V_opt[i])) < 1e-3, 'did not achieved requiered accuracy for bath fit \n'+str(V_opt)+' vs \n'+str(hoppings)
-    assert np.max(np.abs(energies[i] - e_opt[i])) < 1e-3, 'did not achieved requiered accuracy for bath fit \n'+str(e_opt)+' vs \n'+str(energies)
-    assert_gfs_are_close(delta_disc, delta_tau[block], precision=1e-3)
+# # compare to given values
+# for i, (block, delta_disc) in zip(range(len(list(delta_disc_tau.indices))), delta_disc_tau):
+    # assert np.max(np.abs(hoppings[i]) - np.abs(V_opt[i])) < 1e-3, 'did not achieved requiered accuracy for bath fit \n'+str(V_opt)+' vs \n'+str(hoppings)
+    # assert np.max(np.abs(energies[i] - e_opt[i])) < 1e-3, 'did not achieved requiered accuracy for bath fit \n'+str(e_opt)+' vs \n'+str(energies)
+    # assert_gfs_are_close(delta_disc, delta_tau[block], precision=1e-3)

--- a/test/python/base/discretize_bath.py
+++ b/test/python/base/discretize_bath.py
@@ -31,11 +31,11 @@ energies = np.array([0.0, 0.5])
 delta_iw = make_delta(V= hoppings, eps=energies, mesh=mesh)
 
 # run bath fitter on this input
-V_opt, e_opt, delta_disc_iw = discretize_bath(delta_in = delta_iw, Nb = 2, eps0=2.5, V0=0.1, tol=1e-8)
+V_opt, e_opt, delta_disc_iw = discretize_bath(delta_in = delta_iw, Nb = 2, eps0=2.5, V0=0.1, tol=1e-10)
 
 # compare to given values , resulting V can be correct up to a global sign
-assert np.max(np.abs(hoppings) - np.abs(V_opt)) < 1e-8, 'did not achieved requiered accuracy for bath fit \n'+str(V_opt)+' vs \n'+str(hoppings)
-assert np.max(np.abs(energies - e_opt)) < 1e-8, 'did not achieved requiered accuracy for bath fit \n'+str(e_opt)+' vs \n'+str(energies)
+assert np.max(np.abs(hoppings) - np.abs(V_opt)) < 1e-6, 'did not achieved requiered accuracy for bath fit \n'+str(V_opt)+' vs \n'+str(hoppings)
+assert np.max(np.abs(energies - e_opt)) < 1e-6, 'did not achieved requiered accuracy for bath fit \n'+str(e_opt)+' vs \n'+str(energies)
 assert_gfs_are_close(delta_disc_iw, delta_iw)
 
 
@@ -55,8 +55,8 @@ delta_tau = make_delta(V= hoppings, eps=energies, mesh=mesh)
 V_opt, e_opt, delta_disc_tau = discretize_bath(delta_in = delta_tau, Nb = 8, eps0= energies, V0=hoppings, tol=1e-10, maxiter=100000)
 
 # # compare to given values
-assert np.max(np.abs(hoppings) - np.abs(V_opt)) < 1e-8, 'did not achieved requiered accuracy for bath fit \n'+str(V_opt)+' vs \n'+str(hoppings)
-assert np.max(np.abs(energies - e_opt)) < 1e-8, 'did not achieved requiered accuracy for bath fit \n'+str(e_opt)+' vs \n'+str(energies)
+assert np.max(np.abs(hoppings) - np.abs(V_opt)) < 1e-6, 'did not achieved requiered accuracy for bath fit \n'+str(V_opt)+' vs \n'+str(hoppings)
+assert np.max(np.abs(energies - e_opt)) < 1e-6, 'did not achieved requiered accuracy for bath fit \n'+str(e_opt)+' vs \n'+str(energies)
 assert_gfs_are_close(delta_disc_tau, delta_tau)
 
 
@@ -84,7 +84,7 @@ for i, (block, delta_disc) in zip(range(len(list(delta_disc_tau.indices))), delt
 
 #################################################
 # and test without providing input parameters
-V_opt, e_opt, delta_disc_tau = discretize_bath(delta_in = delta_tau, Nb = 4, eps0= 1.5, V0=0.2, tol=1e-10, maxiter=1000000)
+V_opt, e_opt, delta_disc_tau = discretize_bath(delta_in = delta_tau, Nb = 4, eps0= 3, V0=0.4, tol=1e-12, maxiter=1000000)
 
 # # compare to given values
 for i, (block, delta_disc) in zip(range(len(list(delta_disc_tau.indices))), delta_disc_tau):

--- a/test/python/base/discretize_bath.py
+++ b/test/python/base/discretize_bath.py
@@ -25,7 +25,7 @@ from triqs.utility.comparison_tests import *
 # build delta from discretized values
 mesh=MeshImFreq(beta=40, S='Fermion', n_max=200)
 
-hoppings = np.array([0.2, 0.6])
+hoppings = np.array([[0.2, 0.6]])
 energies = np.array([0.0, 0.5])
 
 delta_iw = make_delta(V= hoppings, eps=energies, mesh=mesh)
@@ -33,34 +33,61 @@ delta_iw = make_delta(V= hoppings, eps=energies, mesh=mesh)
 # run bath fitter on this input
 V_opt, e_opt, delta_disc_iw = discretize_bath(delta_in = delta_iw, Nb = 2, eps0=2.5, V0=0.1, tol=1e-8)
 
-# compare to given values
-assert max(abs(hoppings - V_opt)) < 1e-8, 'did not achieved requiered accuracy for bath fit '+str(V_opt)+' vs '+str(hoppings)
-assert max(abs(energies - e_opt)) < 1e-8, 'did not achieved requiered accuracy for bath fit '+str(e_opt)+' vs '+str(energies)
+# compare to given values , resulting V can be correct up to a global sign
+assert np.max(np.abs(hoppings) - np.abs(V_opt)) < 1e-8, 'did not achieved requiered accuracy for bath fit \n'+str(V_opt)+' vs \n'+str(hoppings)
+assert np.max(np.abs(energies - e_opt)) < 1e-8, 'did not achieved requiered accuracy for bath fit \n'+str(e_opt)+' vs \n'+str(energies)
 assert_gfs_are_close(delta_disc_iw, delta_iw)
 
 
+#################################################
 # second test with 2x2 delta input and init guess
 mesh=MeshImTime(beta=40, S='Fermion', n_max=1001)
 
-hoppings = np.array([[ 6.1916012067e-01,  1.4280122215e-08],
-                     [-1.9899876996e-07,  3.3503877422e-01],
-                     [ 3.4998359745e-01,  1.8024665743e-07],
-                     [-4.0523734143e-08,  1.8849071562e-01],
-                     [ 1.3545326772e-01,  4.9300282564e-08],
-                     [ 3.8188035741e-08, -2.2889123931e-01],
-                     [ 2.4378742241e-01,  3.3385121561e-08],
-                     [ 6.9810984451e-06, -4.7688592983e-02]])
-energies = np.array([-1.5437759000e+00, -4.0244628425e-01, -3.3678965769e-01, -3.8795127563e-02, 
+hoppings = np.array([[ 6.1916012067e-01, 0.0, 3.4998359745e-01, 0.0, 1.3545326772e-01, 0.0, 2.4378742241e-01, 0.0],
+                     [ 0.0, 3.3503877422e-01, 0.0, 1.8849071562e-01, 0.0, -2.2889123931e-01, 0.0, -4.7688592983e-02]])
+
+energies = np.array([-1.5437759000e+00, -4.0244628425e-01, -3.3678965769e-01, -3.8795127563e-02,
                      9.9602047476e-03,  1.6012620754e-01,  3.4692574848e-01,  2.0529795026e+03])
 
 delta_tau = make_delta(V= hoppings, eps=energies, mesh=mesh)
 
 # run bath fitter on this input
-V_opt, e_opt, delta_disc_tau = discretize_bath(delta_in = delta_tau, Nb = 8, eps0= energies, V0=hoppings, tol=1e-6, maxiter=100000)
+V_opt, e_opt, delta_disc_tau = discretize_bath(delta_in = delta_tau, Nb = 8, eps0= energies, V0=hoppings, tol=1e-10, maxiter=100000)
 
 # # compare to given values
-assert np.max(np.abs(hoppings - V_opt)) < 1e-6, 'did not achieved requiered accuracy for bath fit '+str(V_opt)+' vs '+str(hoppings)
-assert np.max(np.abs(energies - e_opt)) < 1e-6, 'did not achieved requiered accuracy for bath fit '+str(e_opt)+' vs '+str(energies)
+assert np.max(np.abs(hoppings) - np.abs(V_opt)) < 1e-8, 'did not achieved requiered accuracy for bath fit \n'+str(V_opt)+' vs \n'+str(hoppings)
+assert np.max(np.abs(energies - e_opt)) < 1e-8, 'did not achieved requiered accuracy for bath fit \n'+str(e_opt)+' vs \n'+str(energies)
 assert_gfs_are_close(delta_disc_tau, delta_tau)
 
 
+#################################################
+# test blockGf
+mesh=MeshImTime(beta=40, S='Fermion', n_max=1001)
+
+hoppings = [np.array([[6.1916012067e-01, 3.4998359745e-01, 1.3545326772e-01, 2.4378742241e-01]]),
+            np.array([[3.3503877422e-01, 1.8849071562e-01, -2.2889123931e-01, -4.7688592983e-02]])]
+
+energies = [np.array([-1.5437759000e+00, -4.0244628425e-01, -3.3678965769e-01, -3.8795127563e-02]),
+            np.array([9.9602047476e-03, 1.6012620754e-01, 3.4692574848e-01, 6.89823085e+02])]
+
+delta_tau = make_delta(V= hoppings, eps=energies, mesh=mesh)
+
+# run bath fitter on this input
+V_opt, e_opt, delta_disc_tau = discretize_bath(delta_in = delta_tau, Nb = 4, eps0= energies, V0=hoppings, tol=1e-10, maxiter=100000)
+
+# # compare to given values
+for i, (block, delta_disc) in zip(range(len(list(delta_disc_tau.indices))), delta_disc_tau):
+    assert np.max(np.abs(hoppings[i]) - np.abs(V_opt[i])) < 1e-8, 'did not achieved requiered accuracy for bath fit \n'+str(V_opt)+' vs \n'+str(hoppings)
+    assert np.max(np.abs(energies[i] - e_opt[i])) < 1e-8, 'did not achieved requiered accuracy for bath fit \n'+str(e_opt)+' vs \n'+str(energies)
+    assert_gfs_are_close(delta_disc, delta_tau[block])
+
+
+#################################################
+# and test without providing input parameters
+V_opt, e_opt, delta_disc_tau = discretize_bath(delta_in = delta_tau, Nb = 4, eps0= 1.5, V0=0.2, tol=1e-10, maxiter=1000000)
+
+# # compare to given values
+for i, (block, delta_disc) in zip(range(len(list(delta_disc_tau.indices))), delta_disc_tau):
+    assert np.max(np.abs(hoppings[i]) - np.abs(V_opt[i])) < 1e-5, 'did not achieved requiered accuracy for bath fit \n'+str(V_opt)+' vs \n'+str(hoppings)
+    assert np.max(np.abs(energies[i] - e_opt[i])) < 1e-5, 'did not achieved requiered accuracy for bath fit \n'+str(e_opt)+' vs \n'+str(energies)
+    assert_gfs_are_close(delta_disc, delta_tau[block])

--- a/test/python/base/discretize_bath.py
+++ b/test/python/base/discretize_bath.py
@@ -54,28 +54,28 @@ delta_tau = make_delta(V= hoppings, eps=energies, mesh=mesh)
 # run bath fitter on this input
 V_opt, e_opt, delta_disc_tau = discretize_bath(delta_in = delta_tau, Nb = 8, eps0= energies, V0=hoppings, tol=1e-10, maxiter=100000)
 
-# # compare to given values
+# compare to given values
 assert np.max(np.abs(hoppings) - np.abs(V_opt)) < 1e-6, 'did not achieved requiered accuracy for bath fit \n'+str(V_opt)+' vs \n'+str(hoppings)
 assert np.max(np.abs(energies - e_opt)) < 1e-6, 'did not achieved requiered accuracy for bath fit \n'+str(e_opt)+' vs \n'+str(energies)
 assert_gfs_are_close(delta_disc_tau, delta_tau)
 
 
-#################################################
+# #################################################
 # test blockGf
 mesh=MeshImTime(beta=40, S='Fermion', n_max=1001)
 
-hoppings = [np.array([[6.1916012067e-01, 3.4998359745e-01, 1.3545326772e-01, 2.4378742241e-01]]),
-            np.array([[3.3503877422e-01, 1.8849071562e-01, -2.2889123931e-01, -4.7688592983e-02]])]
+hoppings = [np.array([[0.2, 0.1, -0.5, 0.15]]),
+            np.array([[0.2, -0.35, 0.7, 0.1]])]
 
-energies = [np.array([-1.5437759000e+00, -4.0244628425e-01, -3.3678965769e-01, -3.8795127563e-02]),
-            np.array([9.9602047476e-03, 1.6012620754e-01, 3.4692574848e-01, 6.89823085e+02])]
+energies = [np.array([-2.2, -1.1, 0.0, 0.7]),
+            np.array([-1.7, -0.3, -0.1, 0.2])]
 
 delta_tau = make_delta(V= hoppings, eps=energies, mesh=mesh)
 
 # run bath fitter on this input
 V_opt, e_opt, delta_disc_tau = discretize_bath(delta_in = delta_tau, Nb = 4, eps0= energies, V0=hoppings, tol=1e-10, maxiter=100000)
 
-# # compare to given values
+# compare to given values
 for i, (block, delta_disc) in zip(range(len(list(delta_disc_tau.indices))), delta_disc_tau):
     assert np.max(np.abs(hoppings[i]) - np.abs(V_opt[i])) < 1e-8, 'did not achieved requiered accuracy for bath fit \n'+str(V_opt)+' vs \n'+str(hoppings)
     assert np.max(np.abs(energies[i] - e_opt[i])) < 1e-8, 'did not achieved requiered accuracy for bath fit \n'+str(e_opt)+' vs \n'+str(energies)
@@ -84,10 +84,10 @@ for i, (block, delta_disc) in zip(range(len(list(delta_disc_tau.indices))), delt
 
 #################################################
 # and test without providing input parameters
-V_opt, e_opt, delta_disc_tau = discretize_bath(delta_in = delta_tau, Nb = 4, eps0= 3, V0=0.4, tol=1e-12, maxiter=1000000)
+V_opt, e_opt, delta_disc_tau = discretize_bath(delta_in = delta_tau, Nb = 4, eps0= 2, V0=0.4, tol=1e-15, maxiter=200, method='basinhopping')
 
-# # compare to given values
+# compare to given values
 for i, (block, delta_disc) in zip(range(len(list(delta_disc_tau.indices))), delta_disc_tau):
-    assert np.max(np.abs(hoppings[i]) - np.abs(V_opt[i])) < 1e-5, 'did not achieved requiered accuracy for bath fit \n'+str(V_opt)+' vs \n'+str(hoppings)
-    assert np.max(np.abs(energies[i] - e_opt[i])) < 1e-5, 'did not achieved requiered accuracy for bath fit \n'+str(e_opt)+' vs \n'+str(energies)
-    assert_gfs_are_close(delta_disc, delta_tau[block])
+    assert np.max(np.abs(hoppings[i]) - np.abs(V_opt[i])) < 1e-3, 'did not achieved requiered accuracy for bath fit \n'+str(V_opt)+' vs \n'+str(hoppings)
+    assert np.max(np.abs(energies[i] - e_opt[i])) < 1e-3, 'did not achieved requiered accuracy for bath fit \n'+str(e_opt)+' vs \n'+str(energies)
+    assert_gfs_are_close(delta_disc, delta_tau[block], precision=1e-3)

--- a/test/python/base/discretize_bath.py
+++ b/test/python/base/discretize_bath.py
@@ -18,20 +18,20 @@
 # Authors: Alexander Hampel, Nils Wentzell
 
 import numpy as np
-from triqs.gf import *
+from triqs.gf import MeshImFreq, MeshImTime
 from triqs.gf.tools import discretize_bath, make_delta
-from triqs.utility.comparison_tests import *
+from triqs.utility.comparison_tests import assert_gfs_are_close
 
 # build delta from discretized values
-mesh=MeshImFreq(beta=40, S='Fermion', n_max=200)
+mesh = MeshImFreq(beta=40, S='Fermion', n_max=200)
 
 hoppings = np.array([[0.2, 0.6]])
 energies = np.array([0.0, 0.5])
 
-delta_iw = make_delta(V= hoppings, eps=energies, mesh=mesh)
+delta_iw = make_delta(V=hoppings, eps=energies, mesh=mesh)
 
 # run bath fitter on this input
-V_opt, e_opt, delta_disc_iw = discretize_bath(delta_in = delta_iw, Nb = 2, eps0=2.5, V0=0.1, tol=1e-10)
+V_opt, e_opt, delta_disc_iw = discretize_bath(delta_in=delta_iw, Nb=2, eps0=2.5, V0=0.1, tol=1e-10)
 
 # compare to given values , resulting V can be correct up to a global sign
 assert np.max(np.abs(hoppings) - np.abs(V_opt)) < 1e-6, 'did not achieved requiered accuracy for bath fit \n'+str(V_opt)+' vs \n'+str(hoppings)
@@ -41,18 +41,18 @@ assert_gfs_are_close(delta_disc_iw, delta_iw)
 
 #################################################
 # second test with 2x2 delta input and init guess
-mesh=MeshImTime(beta=40, S='Fermion', n_max=1001)
+mesh = MeshImTime(beta=40, S='Fermion', n_max=1001)
 
-hoppings = np.array([[ 6.1916012067e-01, 0.0, 3.4998359745e-01, 0.0, 1.3545326772e-01, 0.0, 2.4378742241e-01, 0.0],
-                     [ 0.0, 3.3503877422e-01, 0.0, 1.8849071562e-01, 0.0, -2.2889123931e-01, 0.0, -4.7688592983e-02]])
+hoppings = np.array([[6.1916012067e-01, 0.0, 3.4998359745e-01, 0.0, 1.3545326772e-01, 0.0, 2.4378742241e-01, 0.0],
+                     [0.0, 3.3503877422e-01, 0.0, 1.8849071562e-01, 0.0, -2.2889123931e-01, 0.0, -4.7688592983e-02]])
 
 energies = np.array([-1.5437759000e+00, -4.0244628425e-01, -3.3678965769e-01, -3.8795127563e-02,
                      9.9602047476e-03,  1.6012620754e-01,  3.4692574848e-01,  2.0529795026e+03])
 
-delta_tau = make_delta(V= hoppings, eps=energies, mesh=mesh)
+delta_tau = make_delta(V=hoppings, eps=energies, mesh=mesh)
 
 # run bath fitter on this input
-V_opt, e_opt, delta_disc_tau = discretize_bath(delta_in = delta_tau, Nb = 8, eps0= energies, V0=hoppings, tol=1e-10, maxiter=100000)
+V_opt, e_opt, delta_disc_tau = discretize_bath(delta_in=delta_tau, Nb=8, eps0=energies, V0=hoppings, tol=1e-10, maxiter=100000)
 
 # compare to given values
 assert np.max(np.abs(hoppings) - np.abs(V_opt)) < 1e-6, 'did not achieved requiered accuracy for bath fit \n'+str(V_opt)+' vs \n'+str(hoppings)
@@ -62,7 +62,7 @@ assert_gfs_are_close(delta_disc_tau, delta_tau)
 
 # #################################################
 # test blockGf
-mesh=MeshImTime(beta=40, S='Fermion', n_max=1001)
+mesh = MeshImTime(beta=40, S='Fermion', n_max=1001)
 
 hoppings = [np.array([[0.2, 0.1, -0.5, 0.15]]),
             np.array([[0.2, -0.35, 0.7, 0.1]])]
@@ -70,10 +70,10 @@ hoppings = [np.array([[0.2, 0.1, -0.5, 0.15]]),
 energies = [np.array([-2.2, -1.1, 0.0, 0.7]),
             np.array([-1.7, -0.3, -0.1, 0.2])]
 
-delta_tau = make_delta(V= hoppings, eps=energies, mesh=mesh)
+delta_tau = make_delta(V=hoppings, eps=energies, mesh=mesh)
 
 # run bath fitter on this input
-V_opt, e_opt, delta_disc_tau = discretize_bath(delta_in = delta_tau, Nb = 4, eps0= energies, V0=hoppings, tol=1e-10, maxiter=100000)
+V_opt, e_opt, delta_disc_tau = discretize_bath(delta_in=delta_tau, Nb=4, eps0=energies, V0=hoppings, tol=1e-10, maxiter=100000)
 
 # compare to given values
 for i, (block, delta_disc) in zip(range(len(list(delta_disc_tau.indices))), delta_disc_tau):
@@ -84,7 +84,7 @@ for i, (block, delta_disc) in zip(range(len(list(delta_disc_tau.indices))), delt
 
 #################################################
 # and test without providing input parameters
-V_opt, e_opt, delta_disc_tau = discretize_bath(delta_in = delta_tau, Nb = 4, eps0= 2, V0=0.4, tol=1e-15, maxiter=200, method='basinhopping')
+V_opt, e_opt, delta_disc_tau = discretize_bath(delta_in=delta_tau, Nb=4, eps0=2, V0=0.4, tol=1e-15, maxiter=200, method='basinhopping')
 
 # compare to given values
 for i, (block, delta_disc) in zip(range(len(list(delta_disc_tau.indices))), delta_disc_tau):

--- a/test/python/base/discretize_bath.py
+++ b/test/python/base/discretize_bath.py
@@ -31,13 +31,15 @@ energies = np.array([0.0, 0.5])
 delta_iw = make_delta(V=hoppings, eps=energies, mesh=mesh)
 
 # run bath fitter on this input
-V_opt, e_opt, delta_disc_iw = discretize_bath(delta_in=delta_iw, Nb=2, eps0=2.5, V0=0.1, tol=1e-10)
-
+V_opt, e_opt, delta_disc_iw = discretize_bath(delta_in=delta_iw, Nb=2, eps0=2.5, V0=None, tol=1e-10)
 # compare to given values , resulting V can be correct up to a global sign
 assert np.max(np.abs(hoppings) - np.abs(V_opt)) < 1e-6, 'did not achieved requiered accuracy for bath fit \n'+str(V_opt)+' vs \n'+str(hoppings)
 assert np.max(np.abs(energies - e_opt)) < 1e-6, 'did not achieved requiered accuracy for bath fit \n'+str(e_opt)+' vs \n'+str(energies)
 assert_gfs_are_close(delta_disc_iw, delta_iw)
 
+# try with Nb % n_orb != 0
+V_opt, e_opt, delta_disc_iw = discretize_bath(delta_in=delta_iw, Nb=3, eps0=2.5, V0=None, tol=1e-10)
+V_opt, e_opt, delta_disc_iw = discretize_bath(delta_in=delta_iw, Nb=1, eps0=2.5, V0=None, tol=1e-10)
 
 #################################################
 # second test with 2x2 delta input and init guess
@@ -51,8 +53,8 @@ energies = np.array([-1.5437759000e+00, -4.0244628425e-01, -3.3678965769e-01, -3
 
 delta_tau = make_delta(V=hoppings, eps=energies, mesh=mesh)
 
-# run bath fitter on this input
-V_opt, e_opt, delta_disc_tau = discretize_bath(delta_in=delta_tau, Nb=8, eps0=energies, V0=hoppings, tol=1e-10, maxiter=100000)
+V_opt, e_opt, delta_disc_tau = discretize_bath(delta_in=delta_tau, Nb=8, eps0=energies, V0=None, tol=1e-12, maxiter=1000000)
+print('max hopping deviation', np.max(np.abs(hoppings) - np.abs(V_opt)))
 
 # compare to given values
 assert np.max(np.abs(hoppings) - np.abs(V_opt)) < 1e-6, 'did not achieved requiered accuracy for bath fit \n'+str(V_opt)+' vs \n'+str(hoppings)
@@ -60,9 +62,9 @@ assert np.max(np.abs(energies - e_opt)) < 1e-6, 'did not achieved requiered accu
 assert_gfs_are_close(delta_disc_tau, delta_tau)
 
 
-# #################################################
+#################################################
 # test blockGf
-mesh = MeshImTime(beta=40, S='Fermion', n_max=1001)
+mesh = MeshImTime(beta=40, S='Fermion', n_max=501)
 
 hoppings = [np.array([[0.2, 0.1, -0.5, 0.15]]),
             np.array([[0.2, -0.35, 0.7, 0.1]])]
@@ -72,8 +74,9 @@ energies = [np.array([-2.2, -1.1, 0.0, 0.7]),
 
 delta_tau = make_delta(V=hoppings, eps=energies, mesh=mesh)
 
-# run bath fitter on this input
-V_opt, e_opt, delta_disc_tau = discretize_bath(delta_in=delta_tau, Nb=4, eps0=energies, V0=hoppings, tol=1e-10, maxiter=100000)
+# run bath fitter on hopping as input
+V_opt, e_opt, delta_disc_tau = discretize_bath(delta_in=delta_tau, Nb=4, eps0=energies, V0=hoppings, tol=1e-12, maxiter=100000)
+print('max hopping deviation', np.max(np.abs(hoppings) - np.abs(V_opt)))
 
 # compare to given values
 for i, (block, delta_disc) in zip(range(len(list(delta_disc_tau.indices))), delta_disc_tau):
@@ -84,7 +87,8 @@ for i, (block, delta_disc) in zip(range(len(list(delta_disc_tau.indices))), delt
 
 #################################################
 # and test without providing input parameters
-V_opt, e_opt, delta_disc_tau = discretize_bath(delta_in=delta_tau, Nb=4, eps0=2, V0=0.4, tol=1e-15, maxiter=200, method='basinhopping')
+V_opt, e_opt, delta_disc_tau = discretize_bath(delta_in=delta_tau, Nb=4, eps0=2, V0=None, tol=1e-15, maxiter=200, method='basinhopping')
+print('max hopping deviation', np.max(np.abs(hoppings) - np.abs(V_opt)))
 
 # compare to given values
 for i, (block, delta_disc) in zip(range(len(list(delta_disc_tau.indices))), delta_disc_tau):


### PR DESCRIPTION
This PR adds a more advanced bath discretization function for triqs:
- add function make_delta to construct a hybridization function on the imaginary axis for given hoppings and bath energies
- changes to discretize_bath: 
    - allow to fit BlockGf objects, with blocks of arbitrary size
    - allow for complex hybridization
    - fit is directly performed on iw or tau
    - add gradient based minimizer BFGS and add basin hopping
    - allow to pass either a complete guess for the hoppings and energies, or a single value for all hoppings