### PR TITLE
Change behavior of make_real_in_tau and is_gf_real_in_tau for matrix_valued

### DIFF
--- a/python/triqs/gf/__init__.py
+++ b/python/triqs/gf/__init__.py
@@ -45,10 +45,7 @@ MeshCyclicLattice = MeshCycLat
 
 from .gf_fnt import fit_tail, fit_hermitian_tail, density, set_from_fourier, is_gf_real_in_tau, set_from_legendre, set_from_imfreq, set_from_imtime, is_gf_hermitian, fit_tail_on_window, fit_hermitian_tail_on_window, replace_by_tail, replace_by_tail_in_fit_window, rebinning_tau, enforce_discontinuity, GfIndices
 
-from .gf_factories import make_gf_from_fourier, make_hermitian
-
-# Create an alias for make_real_in_tau
-make_real_in_tau = make_hermitian
+from .gf_factories import make_gf_from_fourier, make_hermitian, make_real_in_tau
 
 import warnings
 

--- a/python/triqs/gf/gf_factories_desc.py
+++ b/python/triqs/gf/gf_factories_desc.py
@@ -35,6 +35,14 @@ for gf_type in ["gf", "block_gf", "block2_gf"]:
     m.add_function("%s<imtime, tensor_valued<4>> make_hermitian(%s<imtime, tensor_valued<4>> g)"%(gf_type, gf_view_type),
                 doc = "Symmetrize the Green function in imaginary time, to ensure its hermiticity (G_ijkl[tau] = G_klij[tau]*)")
 
+    # make_real_in_tau
+    m.add_function("%s<imfreq, scalar_valued> make_real_in_tau(%s<imfreq, scalar_valued> g)"%(gf_type, gf_view_type),
+                doc = "Symmetrize the Green function in freq, to ensure its real in tau (G[iw] = G[-iw]*)")
+    m.add_function("%s<imfreq, matrix_valued> make_real_in_tau(%s<imfreq, matrix_valued> g)"%(gf_type, gf_view_type),
+                doc = "Symmetrize the Green function in freq, to ensure its real in tau (G[iw](i,j) = G[-iw](i,j)*)")
+    m.add_function("%s<imfreq, tensor_valued<4>> make_real_in_tau(%s<imfreq, tensor_valued<4>> g)"%(gf_type, gf_view_type),
+                doc = "Symmetrize the Green function in freq, to ensure its real in tau (G[iw](i,j,k,l) = G[-iw](i,j,k,l)*)")
+
 # ---------------------- make_gf_from_fourier --------------------
 for Target in  ["scalar_valued", "matrix_valued", "tensor_valued<3>", "tensor_valued<4>"]:
 

--- a/test/c++/gfs/functions/hermiticity.cpp
+++ b/test/c++/gfs/functions/hermiticity.cpp
@@ -20,7 +20,7 @@
 #include <triqs/test_tools/gfs.hpp>
 
 using namespace triqs::gfs;
-using namespace triqs::arrays;
+using namespace nda;
 
 TEST(hermiticity, symmetrize_and_check) {
 
@@ -74,6 +74,33 @@ TEST(hermiticity, symmetrize_and_check) {
   auto Chi_tau = make_gf_from_fourier(Chi);
   EXPECT_TRUE(is_gf_hermitian(Chi_tau));
   EXPECT_GF_NEAR(Chi_tau, make_hermitian(Chi_tau), 1e-12);
+}
+
+TEST(real_in_tau, symmetrize_and_check) {
+
+  triqs::clef::placeholder<0> iw_;
+  triqs::clef::placeholder<1> i_;
+  triqs::clef::placeholder<2> j_;
+  double beta = 1;
+
+  // ============ Test with hermitian Gf
+  auto h = matrix<dcomplex>{{{1 + 0i, 0.1}, {0.1, 2 + 0i}}};
+  auto G = gf<imfreq>{{beta, Fermion}, {2, 2}};
+  for (auto &iw : G.mesh()) G[iw] = inverse(iw - h);
+
+  EXPECT_TRUE(is_gf_real_in_tau(G));
+
+  // Check that Gf remains the same
+  EXPECT_GF_NEAR(G, make_real_in_tau(G), 1e-15);
+
+  // ============  Now with cplx-valued Hamiltonian
+  h = matrix<dcomplex>{{{1 + 0i, 1i}, {-1i, 2 + 0i}}};
+  for (auto &iw : G.mesh()) G[iw] = inverse(iw - h);
+
+  EXPECT_FALSE(is_gf_real_in_tau(G));
+
+  // Restore hermiticity
+  EXPECT_TRUE(is_gf_real_in_tau(make_real_in_tau(G)));
 }
 
 MAKE_MAIN;

--- a/test/c++/gfs/functions/real_in_tau.cpp
+++ b/test/c++/gfs/functions/real_in_tau.cpp
@@ -1,6 +1,6 @@
 // Copyright (c) 2018 Commissariat à l'énergie atomique et aux énergies alternatives (CEA)
 // Copyright (c) 2018 Centre national de la recherche scientifique (CNRS)
-// Copyright (c) 2018-2019 Simons Foundation
+// Copyright (c) 2018-2020 Simons Foundation
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -17,12 +17,39 @@
 //
 // Authors: Nils Wentzell
 
-#include <triqs/gfs.hpp>
 #include <triqs/test_tools/gfs.hpp>
-using namespace triqs::gfs;
-using namespace std::complex_literals;
 
-TEST(Functions, RealGf) {
+using namespace triqs::gfs;
+using namespace nda;
+
+TEST(real_in_tau, symmetrize_and_check) {
+
+  triqs::clef::placeholder<0> iw_;
+  triqs::clef::placeholder<1> i_;
+  triqs::clef::placeholder<2> j_;
+  double beta = 1;
+
+  // ============ Test with hermitian Gf
+  auto h = matrix<dcomplex>{{{1 + 0i, 0.1}, {0.1, 2 + 0i}}};
+  auto G = gf<imfreq>{{beta, Fermion}, {2, 2}};
+  for (auto &iw : G.mesh()) G[iw] = inverse(iw - h);
+
+  EXPECT_TRUE(is_gf_real_in_tau(G));
+
+  // Check that Gf remains the same
+  EXPECT_GF_NEAR(G, make_real_in_tau(G), 1e-15);
+
+  // ============  Now with cplx-valued Hamiltonian
+  h = matrix<dcomplex>{{{1 + 0i, 1i}, {-1i, 2 + 0i}}};
+  for (auto &iw : G.mesh()) G[iw] = inverse(iw - h);
+
+  EXPECT_FALSE(is_gf_real_in_tau(G));
+
+  // Restore hermiticity
+  EXPECT_TRUE(is_gf_real_in_tau(make_real_in_tau(G)));
+}
+
+TEST(real_in_tau, real_gf) {
 
   double beta  = 1;
   int n_iw     = 100;


### PR DESCRIPTION
These functions  were previously identical to `make_hermitian` and `is_gf_hermitian`,
while they should really be based on the Green Function relation `G_(ij..)[iw] = G_(ij..)[-iw]*`
which is associated with a purely real-valued G_(ij..)(tau) (as opposed to `G_ij[iw] = G_ji[-iw]*` for hermiticity).
This PR implements these changes and extends the tests for the same functions.