### PR TITLE
fix density function for GfReFreq resulting in non hermitian density matrix

### DIFF
--- a/c++/triqs/gfs/functions/density.cpp
+++ b/c++/triqs/gfs/functions/density.cpp
@@ -143,7 +143,6 @@ namespace triqs::gfs {
     double dw0 = -wmin - (N0 - 1) * dw; // last interval width to w=0
 
     nda::matrix<dcomplex> res(g.target_shape());
-    nda::matrix<dcomplex> den(g.target_shape());
 
     // Trapetzoidal integration, with partial right interval
     res = 0.5 * g[0];
@@ -172,7 +171,6 @@ namespace triqs::gfs {
     assert(beta > 0.);
 
     nda::matrix<dcomplex> res(g.target_shape());
-    nda::matrix<dcomplex> den(g.target_shape());
     res() = 0;
 
     for (auto const &w : g.mesh()) res += g[w] / (1. + exp(beta * w));

--- a/c++/triqs/gfs/functions/density.cpp
+++ b/c++/triqs/gfs/functions/density.cpp
@@ -160,9 +160,10 @@ namespace triqs::gfs {
     for (int idx : range(0, res.shape()[0])) res(idx, idx) = dcomplex(0., imag(res(idx, idx)));
 
     res *= dcomplex(0., 1.) * dw / M_PI; // scale to density
-    den = 0.5 * (res + dagger(res));     // A = i( g - g^+ )
-
-    return den;
+    
+    // writing back into res is problematic due to lazy expressionsreturn
+    // return directly instead
+    return 0.5 * (res + dagger(res));     // A = i( g - g^+ )
   }
 
   /// Finite temperature density from integration on the real frequency axis
@@ -182,9 +183,10 @@ namespace triqs::gfs {
     for (int idx : range(0, res.shape()[0])) res(idx, idx) = dcomplex(0., imag(res(idx, idx)));
 
     res *= dcomplex(0., 1.) * g.mesh().delta() / M_PI; // scale to density
-    den = 0.5 * (res + dagger(res));                   // A = i( g - g^+ )
 
-    return den;
+    // writing back into res is problematic due to lazy expressionsreturn
+    // return directly instead
+    return 0.5 * (res + dagger(res));     // A = i( g - g^+ )
   }
 
   //-------------------------------------------------------

--- a/c++/triqs/gfs/functions/density.cpp
+++ b/c++/triqs/gfs/functions/density.cpp
@@ -143,6 +143,7 @@ namespace triqs::gfs {
     double dw0 = -wmin - (N0 - 1) * dw; // last interval width to w=0
 
     nda::matrix<dcomplex> res(g.target_shape());
+    nda::matrix<dcomplex> den(g.target_shape());
 
     // Trapetzoidal integration, with partial right interval
     res = 0.5 * g[0];
@@ -159,9 +160,9 @@ namespace triqs::gfs {
     for (int idx : range(0, res.shape()[0])) res(idx, idx) = dcomplex(0., imag(res(idx, idx)));
 
     res *= dcomplex(0., 1.) * dw / M_PI; // scale to density
-    res = 0.5 * (res + dagger(res));     // A = i( g - g^+ )
+    den = 0.5 * (res + dagger(res));     // A = i( g - g^+ )
 
-    return res;
+    return den;
   }
 
   /// Finite temperature density from integration on the real frequency axis
@@ -170,6 +171,7 @@ namespace triqs::gfs {
     assert(beta > 0.);
 
     nda::matrix<dcomplex> res(g.target_shape());
+    nda::matrix<dcomplex> den(g.target_shape());
     res() = 0;
 
     for (auto const &w : g.mesh()) res += g[w] / (1. + exp(beta * w));
@@ -180,9 +182,9 @@ namespace triqs::gfs {
     for (int idx : range(0, res.shape()[0])) res(idx, idx) = dcomplex(0., imag(res(idx, idx)));
 
     res *= dcomplex(0., 1.) * g.mesh().delta() / M_PI; // scale to density
-    res = 0.5 * (res + dagger(res));                   // A = i( g - g^+ )
+    den = 0.5 * (res + dagger(res));                   // A = i( g - g^+ )
 
-    return res;
+    return den;
   }
 
   //-------------------------------------------------------

--- a/test/c++/gfs/gf_density.cpp
+++ b/test/c++/gfs/gf_density.cpp
@@ -72,4 +72,20 @@ TEST(Gf, Density_with_not_all_moments) {
   EXPECT_THROW(triqs::gfs::density(G), triqs::runtime_error);
 }
 
+TEST(Gf, DensityFermionReFreq) {
+
+  double wmax = 10;
+  int N       = 1000;
+  auto h      = matrix<dcomplex>{{{1 + 0i, 1i}, {-1i, 2 + 0i}}};
+  auto G      = gf<refreq>{{-wmax, wmax, N}, {2, 2}};
+  nda::matrix<dcomplex> n_dag(G.target_shape());
+
+  //G(iw_) << inverse(w_ - h + eta); // FIXME
+  for (auto &w : G.mesh()) G[w] = inverse(w - h + 0.1i);
+
+  auto n = triqs::gfs::density(G);
+  n_dag  = dagger(n);
+  EXPECT_ARRAY_EQ(n, n_dag);
+}
+
 MAKE_MAIN;

--- a/test/c++/gfs/gf_density.cpp
+++ b/test/c++/gfs/gf_density.cpp
@@ -81,7 +81,7 @@ TEST(Gf, DensityFermionReFreq) {
   nda::matrix<dcomplex> n_dag(G.target_shape());
 
   //G(iw_) << inverse(w_ - h + eta); // FIXME
-  for (auto &w : G.mesh()) G[w] = inverse(w - h + 0.1i);
+  for (auto &w : G.mesh()) G[w] = inverse(w - h + 1e-8i);
 
   auto n = triqs::gfs::density(G);
   n_dag  = dagger(n);


### PR DESCRIPTION
The density function for ReFreq Green functions has a serious bug, which leads to non-hermitian density matrices that are numerically wrong. I am not quite sure why it fails. But this line: 
```
res = 0.5 * (res + dagger(res));     // A = i( g - g^+ )
```
in c++/triqs/gfs/functions/density.cpp line 163 should make sure that the resulting density is always hermitian. No matter how res is structured. 

The problem seems, that `dagger()` is not performed in-place / in the right order, i.e. before adding the result to `res`. dagger only gives back some mapping object / view on it. Changing the line to: 
```
den = 0.5 * (res + dagger(res));     // A = i( g - g^+ )
``` 
fixes the problem. Maybe this can even be fixed in the dagger function? 

This PR fixes the problem in a very simple way, but I also added a test in the PR that makes sure that the resulting density matrix is a hermitian matrix. 

This should be merged before tagging 3.1. 

Thanks to @phibeck for reporting the issue.