### PR TITLE
fix error in TBSuperLattice __repr__function

### DIFF
--- a/python/triqs/lattice/super_lattice.py
+++ b/python/triqs/lattice/super_lattice.py
@@ -175,4 +175,4 @@ class TBSuperLattice(TBLattice):
    Base TBLattice: %s
    SuperLattice Units: %s
    Remove internal Hoppings: %s
-   Cluster site positions: %s"""%(self.__BaseLattice, f(self.__super_lattice_units), self.__cluster_sites, self.__remove_internal_hoppings)
+   Cluster site positions: %s"""%(self.__BaseLattice, f(self.__super_lattice_units), self.__remove_internal_hoppings, self.__cluster_sites)


### PR DESCRIPTION
The __repr__ function of TBSuperLattice currently mixes up "Remove internal Hoppings" and "Cluster site positions" when printing the information about the superlattice. 

I changed the order to fix it