### PR TITLE
fix SumkDiscreteFromLattice after TBL changes

### DIFF
--- a/python/triqs/sumk/sumk_discrete.py
+++ b/python/triqs/sumk/sumk_discrete.py
@@ -70,7 +70,7 @@ class SumkDiscrete:
 
     #-------------------------------------------------------------
 
-    def __call__ (self, Sigma, mu=0, eta=0, field=None, epsilon_hat=None, result=None, selected_blocks=()):
+    def __call__ (self, Sigma, mu=0, field=None, epsilon_hat=None, result=None, selected_blocks=()):
         """
         - Computes:
            result <- \[ \sum_k (\omega + \mu - field - t(k) - Sigma(k,\omega)) \]
@@ -123,6 +123,7 @@ class SumkDiscrete:
 
         G = result if result else model.copy()
         assert isinstance(G,BlockGf), "G must be a BlockGf"
+        assert isinstance(G.mesh, MeshImFreq), "G.mesh must be MeshImFreq but is {}".format(type(G.mesh))
 
         # check input
         assert self.orthogonal_basis, "Local_G: must be orthogonal. non ortho cases not checked."

--- a/python/triqs/sumk/sumk_discrete_from_lattice.py
+++ b/python/triqs/sumk/sumk_discrete_from_lattice.py
@@ -19,6 +19,7 @@
 
 
 from .sumk_discrete import SumkDiscrete
+import numpy as np
 from triqs.lattice.tight_binding import TBLattice
 
 class SumkDiscreteFromLattice (SumkDiscrete):
@@ -46,7 +47,7 @@ class SumkDiscreteFromLattice (SumkDiscrete):
         self.SL = lattice
         self.patch,self.method = patch,method
         # init the array
-        SumkDiscrete.__init__ (self, dim = self.SL.dim, gf_struct = lattice.OrbitalNames)
+        SumkDiscrete.__init__ (self, dim = self.SL.bl.ndim, gf_struct = lattice.OrbitalNames)
         self.Recompute_Grid(n_points,  method)
 
      #-------------------------------------------------------------
@@ -112,7 +113,7 @@ class SumkDiscreteFromLattice (SumkDiscrete):
         # A shift
         if Q:
             try:
-                Q = numpy.array(Q)
+                Q = np.array(Q)
                 assert len(Q.shape) ==1
             except:
                 raise RuntimeError("Q is not of correct type")
@@ -120,16 +121,16 @@ class SumkDiscreteFromLattice (SumkDiscrete):
                 self.bz_points[k_index,:] +=Q
 
         # Compute the discretized hoppings from the Superlattice
-        self.hopping[:,:,:] = self.SL.hopping(self.bz_points.transpose().copy()).transpose(2,0,1)
+        self.hopping[:,:,:] = self.SL.fourier(self.bz_points)
 
         if self.orthogonal_basis:
-            self.mu_pattern[:,:] = numpy.identity(self.SL.n_orbitals)
+            self.mu_pattern[:,:] = np.identity(self.SL.n_orbitals)
         else:
             assert 0 , "not checked"
             self.overlap[:,:,:] = self.SL.Overlap(bz_points.transpose().copy())
-            mupat = numpy.identity(self.SL.n_orbitals)
+            mupat = np.identity(self.SL.n_orbitals)
             for k_index in range(self.N_kpts()):
-                self.mu_pattern[:,:,k_index] = Num.dot( mupat ,self.Overlap[:,:,k_index])
+                self.mu_pattern[:,:,k_index] = np.dot( mupat ,self.Overlap[:,:,k_index])
 
     #-------------------------------------------------------------
 
@@ -139,7 +140,7 @@ class SumkDiscreteFromLattice (SumkDiscrete):
         Internal
         """
 
-        tritemp = numpy.array(patch._triangles)
+        tritemp = np.array(patch._triangles)
         ntri = len(tritemp)/3
         nk = n_bz*n_bz*ntri
         self.resize_arrays(nk)
@@ -168,7 +169,7 @@ class SumkDiscreteFromLattice (SumkDiscrete):
         self.bz_weights /= total_weight
 
         # Compute the discretized hoppings from the Superlattice
-        self.hopping[:,:,:] = self.SL.hopping(self.bz_points.transpose().copy()).transpose(2,0,1)
+        self.hopping[:,:,:] = self.SL.fourier(self.bz_points)
 
         if self.orthogonal_basis:
             self.mu_pattern[:,:] =  self.SL.MuPattern[:,:]

--- a/python/triqs/sumk/sumk_discrete_from_lattice.py
+++ b/python/triqs/sumk/sumk_discrete_from_lattice.py
@@ -47,7 +47,7 @@ class SumkDiscreteFromLattice (SumkDiscrete):
         self.SL = lattice
         self.patch,self.method = patch,method
         # init the array
-        SumkDiscrete.__init__ (self, dim = self.SL.ndim, gf_struct = lattice.OrbitalNames)
+        SumkDiscrete.__init__ (self, dim = self.SL.ndim, gf_struct = lattice.orbital_names)
         self.Recompute_Grid(n_points,  method)
 
      #-------------------------------------------------------------

--- a/python/triqs/sumk/sumk_discrete_from_lattice.py
+++ b/python/triqs/sumk/sumk_discrete_from_lattice.py
@@ -47,7 +47,7 @@ class SumkDiscreteFromLattice (SumkDiscrete):
         self.SL = lattice
         self.patch,self.method = patch,method
         # init the array
-        SumkDiscrete.__init__ (self, dim = self.SL.bl.ndim, gf_struct = lattice.OrbitalNames)
+        SumkDiscrete.__init__ (self, dim = self.SL.ndim, gf_struct = lattice.OrbitalNames)
         self.Recompute_Grid(n_points,  method)
 
      #-------------------------------------------------------------


### PR DESCRIPTION
after recent changes in triqs lattice utils Sumk_discrete_from_lattice.py has not been updated. 

* add numpy and fix usage
* exchange `hopping` -> `fourier`
* `SL.dim` is not working anymore, TBL has no property dim anymore, instead use correctly `SL.bl.ndim`