### PR TITLE
 [atom_diag] Another go at fixing #825

### DIFF
--- a/c++/triqs/atom_diag/atom_diag.hpp
+++ b/c++/triqs/atom_diag/atom_diag.hpp
@@ -139,9 +139,9 @@ namespace triqs {
        * @note See :ref:`space_partition` for more details on the auto-partition scheme.
        */
       atom_diag(many_body_op_t const &h, fundamental_operator_set const &fops);
-      
+
       atom_diag(many_body_op_t const &h, many_body_op_t const &hyb, fundamental_operator_set const &fops);
-      
+
       atom_diag(many_body_op_t const &h, fundamental_operator_set const &fops, int n_min, int n_max);
 
       /// Reduce a given Hamiltonian to a block-diagonal form and diagonalize it
@@ -287,6 +287,15 @@ namespace triqs {
        */
       matrix_t const &cdag_matrix(int op_linear_index, int sp_index) const { return cdag_matrices[op_linear_index][sp_index]; }
 
+      /// Get matrix representation for a monomial operator
+      /**
+       * @param op_vec A product of canonical operators operators (a monomial)
+       * @param B Initial subspace B
+       * @return Index of the subspace connected from by :ref:`op_vec` from :ref:`B` and the corresponding matrix (not necessarily square)
+       *
+       */
+      std::pair<int, matrix_t> get_matrix_element_of_monomial(operators::monomial_t const &op_vec, int B) const;
+
       /// Get block matrix representation for general operator
       /**
        * @param op Many body operator
@@ -321,7 +330,6 @@ namespace triqs {
       std::vector<int> first_eigenstate_of_subspace; // Index of the first eigenstate of each subspace
       void fill_first_eigenstate_of_subspace();
       void compute_vacuum();
-      std::pair<int, matrix_t> get_matrix_element_of_monomial(operators::monomial_t const &op_vec, int B) const;
 
       /* Friend declarations of a template class are a bit ugly */
       friend std::ostream &operator<<<Complex>(std::ostream &os, atom_diag const &ss);

--- a/c++/triqs/atom_diag/impl/atom_diag.cpp
+++ b/c++/triqs/atom_diag/impl/atom_diag.cpp
@@ -113,7 +113,6 @@ namespace triqs {
 
       matrix_t m;
       int Bp = -1;
-      bool found_nonzero_element = false;
 
       for(auto [i_index, i]: itertools::enumerate(get_fock_states(B))) {
         state<class hilbert_space, scalar_t, true> initial_st(full_hs, i);
@@ -128,9 +127,8 @@ namespace triqs {
             if(sp.has_state(j)) {
               Bp = sp.get_index();
 
-              if(not found_nonzero_element) {
+              if(m.empty()) {
                 m = matrix_t::zeros({get_subspace_dim(Bp), get_subspace_dim(B)});
-                found_nonzero_element = true;
               }
 
               m(sp.get_state_index(j), i_index) = x;

--- a/c++/triqs/hilbert_space/state.hpp
+++ b/c++/triqs/hilbert_space/state.hpp
@@ -96,6 +96,15 @@ namespace triqs {
   */
       state(HilbertSpace const &hs) : hs_p(&hs) {}
 
+      /// Construct a new state object and set the st-th amplitude to 1.
+      /**
+       * @param hs Hilbert space the new state belongs to
+       * @param st Basis state with the unity amplitude
+       */
+      state(HilbertSpace const &hs, fock_state_t st) : hs_p(&hs) {
+        ampli[st] = value_type(1.0);
+      }
+
       /// Return the dimension of the associated Hilbert space
       /**
    @return Dimension of the associated Hilbert space
@@ -241,6 +250,15 @@ namespace triqs {
    @param hs Hilbert space the new state belongs to
   */
       state(HilbertSpace const &hs) : hs_p(&hs), ampli(nda::zeros<ScalarType>(hs.size())) {}
+
+      /// Construct a new state object and set the st-th amplitude to 1.
+      /**
+       * @param hs Hilbert space the new state belongs to
+       * @param st Basis state with the unity amplitude
+       */
+      state(HilbertSpace const &hs, fock_state_t st) : hs_p(&hs), ampli(nda::zeros<ScalarType>(hs.size())) {
+        ampli[st] = value_type(1.0);
+      }
 
       /// Return the dimension of the associated Hilbert space
       /**

--- a/c++/triqs/hilbert_space/state.hpp
+++ b/c++/triqs/hilbert_space/state.hpp
@@ -76,7 +76,7 @@ namespace triqs {
                                                   boost::multiplicative<state<HilbertSpace, ScalarType, true>, ScalarType> {
       // derivations implement the vector space operations over ScalarType from the compounds operators +=, *=, ....
       const HilbertSpace *hs_p;
-      using amplitude_t = std::unordered_map<std::size_t, ScalarType>;
+      using amplitude_t = std::unordered_map<fock_state_t, ScalarType>;
       amplitude_t ampli;
 
       public:
@@ -107,13 +107,13 @@ namespace triqs {
    @param i index of the requested amplitude
    @return Reference to the requested amplitude
   */
-      value_type &operator()(int i) { return ampli[i]; }
+      value_type &operator()(fock_state_t i) { return ampli[i]; }
       /// Access to individual amplitudes
       /**
    @param i index of the requested amplitude
    @return Constant reference to the requested amplitude
   */
-      value_type const &operator()(int i) const { return ampli[i]; }
+      value_type const &operator()(fock_state_t i) const { return ampli[i]; }
 
       /// In-place addition of another state
       /**

--- a/c++/triqs/operators/many_body_operator.hpp
+++ b/c++/triqs/operators/many_body_operator.hpp
@@ -24,6 +24,7 @@
 #include <ostream>
 #include <cmath>
 #include <algorithm>
+#include <utility>
 #include <boost/operators.hpp>
 #include <triqs/utility/real_or_complex.hpp>
 #include <triqs/utility/numeric_ops.hpp>
@@ -129,6 +130,11 @@ namespace triqs {
       explicit many_body_operator_generic(scalar_t const &x) {
         using triqs::utility::is_zero;
         if (!is_zero(x)) monomials.insert({{}, x});
+      }
+
+      many_body_operator_generic(scalar_t const &x, monomial_t monomial) {
+        using triqs::utility::is_zero;
+        if (!is_zero(x)) monomials.emplace(std::move(monomial), x);
       }
 
       struct _cdress;


### PR DESCRIPTION
This solution is based on a conceptionally different implementation of `atom_diag::get_matrix_element_of_monomial()`. It is proposed by @Wentzell in https://github.com/TRIQS/triqs/issues/825#issuecomment-1036647227.

I have also made `atom_diag::get_matrix_element_of_monomial()` public and removed the free function `matrix_element_of_monomial()` from `atom_diag/impl/functions.cpp` as it was doing the very same thing.