### PR TITLE
create python api doc with autosummary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+doc/documentation/python_api
+doc/documentation/cpp_api

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -77,7 +77,7 @@ find_package(Sphinx)
 add_custom_target(docs_sphinx ALL)
 add_custom_command(
   TARGET docs_sphinx
-  COMMAND PYTHONPATH=${PROJECT_BINARY_DIR}/python:${CPP2PY_BINARY_DIR}:${h5_BINARY_DIR}/python:$ENV{PYTHONPATH} ${SPHINXBUILD_EXECUTABLE} -c . -j8 -b html ${CMAKE_CURRENT_SOURCE_DIR} html
+  COMMAND PYTHONPATH=${PROJECT_BINARY_DIR}/python:${CPP2PY_BINARY_DIR}:${h5_BINARY_DIR}/python:$ENV{PYTHONPATH} ${SPHINXBUILD_EXECUTABLE} -c . -j auto -b html ${CMAKE_CURRENT_SOURCE_DIR} html
 )
 
 option(Sphinx_Only "When building the documentation, skip the Python Modules and the generation of C++ Api and example outputs" OFF)

--- a/doc/_templates/autosummary_class_template.rst
+++ b/doc/_templates/autosummary_class_template.rst
@@ -1,0 +1,29 @@
+{{ fullname | escape | underline }}
+
+.. currentmodule:: {{ module }}
+
+.. autoclass:: {{ objname }}
+
+{% block methods %}
+{% if methods %}
+.. rubric:: {{ _('Methods') }}
+
+.. autosummary::
+    :toctree:                             
+    {% for item in methods %}
+      ~{{ name }}.{{ item }}
+    {%- endfor %}
+{% endif %}
+{% endblock %}
+
+{% block attributes %}
+{% if attributes %}
+.. rubric:: {{ _('Attributes') }}
+
+.. autosummary::
+    :toctree:                             
+    {% for item in attributes %}
+      ~{{ name }}.{{ item }}
+    {%- endfor %}
+{% endif %}
+{% endblock %}

--- a/doc/_templates/autosummary_module_template.rst
+++ b/doc/_templates/autosummary_module_template.rst
@@ -1,0 +1,68 @@
+{{ fullname | escape | underline}}
+
+.. automodule:: {{ fullname }}
+
+{% block functions %}
+{% if functions %}
+.. rubric:: Functions
+
+.. autosummary::
+    :toctree:                             
+    {% for item in functions %}
+    {{ item }}
+    {%- endfor %}
+{% endif %}
+{% endblock %}
+
+{% block attributes %}
+{% if attributes %}
+.. rubric:: Module Attributes
+
+.. autosummary::
+    :toctree:                             
+    {% for item in attributes %}
+    {{ item }}
+    {%- endfor %}
+{% endif %}
+{% endblock %}
+
+{% block classes %}
+{% if classes %}
+.. rubric:: {{ _('Classes') }}
+
+.. autosummary::
+    :toctree:                                         
+    :template: autosummary_class_template.rst
+    {% for item in classes %}
+    {{ item }}
+    {%- endfor %}
+{% endif %}
+{% endblock %}
+
+{% block exceptions %}
+{% if exceptions %}
+.. rubric:: {{ _('Exceptions') }}
+
+.. autosummary::
+    :toctree:                                       
+    {% for item in exceptions %}
+    {{ item }}
+    {%- endfor %}
+{% endif %}
+{% endblock %}
+
+{% block modules %}
+{% if modules %}
+.. rubric:: Modules
+
+.. autosummary::
+    :toctree:
+    :template: autosummary_module_template.rst 
+    :recursive:
+
+    {% for item in modules %}
+    {{ item }}
+    {%- endfor %}
+{% endif %}
+{% endblock %}
+

--- a/doc/conf.py.in
+++ b/doc/conf.py.in
@@ -53,6 +53,9 @@ myst_enable_extensions = [
 mathjax_path = "@MATHJAX_PATH@/MathJax.js?config=default"
 print("Mathjax: ",mathjax_path)
 
+# Turn on sphinx.ext.autosummary
+autosummary_generate = True
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['@TRIQS_SOURCE_DIR@/doc/_templates']
 
@@ -132,7 +135,7 @@ html_theme_options = {
     # Toc options
     'collapse_navigation': False,
     'sticky_navigation': True,
-    'navigation_depth': 4,
+    'navigation_depth': 5,
     'includehidden': True,
     'titles_only': False
 }

--- a/doc/documentation.rst
+++ b/doc/documentation.rst
@@ -22,7 +22,19 @@ C++ API
 Python API
 ----------
 
-.. toctree::
-   :maxdepth: 1
+.. autosummary::
+   :recursive:
+   :toctree: documentation/python_api
+   :template: autosummary_module_template.rst
 
-   documentation/python_api/contents
+   triqs.atom_diag
+   triqs.dos
+   triqs.fit
+   triqs.gf
+   triqs.lattice
+   triqs.operators
+   triqs.plot
+   triqs.random_generator
+   triqs.stat
+   triqs.sumk
+   triqs.utility

--- a/doc/documentation/manual/cpp2py/contents.rst
+++ b/doc/documentation/manual/cpp2py/contents.rst
@@ -1,6 +1,7 @@
 .. index:: wrapper
 
 .. module:: cpp2py.wrap_generator
+   :noindex:
 
 .. _wrapper:
 

--- a/doc/documentation/manual/triqs/gfs/py/contents.rst
+++ b/doc/documentation/manual/triqs/gfs/py/contents.rst
@@ -2,6 +2,7 @@
 .. index:: Green's functions
 
 .. module:: triqs.gf
+   :noindex:
 
 .. _green_py:
 

--- a/doc/documentation/manual/triqs/lattice_tools/contents.rst
+++ b/doc/documentation/manual/triqs/lattice_tools/contents.rst
@@ -1,6 +1,7 @@
 .. index:: lattices
 
 .. module:: triqs.lattice
+   :noindex:
 
 .. _lattice:
 

--- a/doc/documentation/manual/triqs/lattice_tools/dos.rst
+++ b/doc/documentation/manual/triqs/lattice_tools/dos.rst
@@ -1,6 +1,7 @@
 .. index:: lattices; dos
 
 .. module:: triqs.dos.dos
+   :noindex:
 
 .. _dos:
 

--- a/doc/documentation/manual/triqs/lattice_tools/hilbert.rst
+++ b/doc/documentation/manual/triqs/lattice_tools/hilbert.rst
@@ -1,6 +1,7 @@
 .. _hilbert_transform:
 
 .. module:: triqs.dos.hilbert_transform
+   :noindex:
 
 
 Hilbert Transform

--- a/doc/documentation/manual/triqs/operators/contents.rst
+++ b/doc/documentation/manual/triqs/operators/contents.rst
@@ -1,6 +1,7 @@
 .. index:: Second-quantization operators
 
 .. module:: triqs.operators
+   :noindex:
 
 .. _operators:
 

--- a/doc/documentation/manual/triqs/plotting_protocols/fit/fit.rst
+++ b/doc/documentation/manual/triqs/plotting_protocols/fit/fit.rst
@@ -1,5 +1,6 @@
 
 .. module:: triqs.fit.fit
+   :noindex:
 
 Fitting data
 ============

--- a/doc/documentation/manual/triqs/plotting_protocols/plotting/plotting.rst
+++ b/doc/documentation/manual/triqs/plotting_protocols/plotting/plotting.rst
@@ -2,6 +2,7 @@
 .. index:: matplotlib plotter
 
 .. module:: triqs.plot
+   :noindex:
 
 .. _plotting:
 

--- a/doc/documentation/manual/triqs/random_generator/contents.rst
+++ b/doc/documentation/manual/triqs/random_generator/contents.rst
@@ -1,6 +1,7 @@
 .. index:: Random number generator
 
 .. module:: triqs.random_generator
+   :noindex:
 
 .. _random_generator:
 

--- a/doc/documentation/python_api/contents.rst
+++ b/doc/documentation/python_api/contents.rst
@@ -1,8 +1,0 @@
-.. _pythonapi:
-
-.. toctree::
-   :maxdepth: 2
-
-   triqs
-   triqs/gf/Gf
-   triqs/utility/dichotomy

--- a/doc/documentation/python_api/pytriqs.rst
+++ b/doc/documentation/python_api/pytriqs.rst
@@ -1,7 +1,0 @@
-triqs
--------
-
-.. _triqs:
-
-.. automodule:: triqs
-   :members:

--- a/doc/documentation/python_api/triqs/gf/Gf.rst
+++ b/doc/documentation/python_api/triqs/gf/Gf.rst
@@ -1,7 +1,0 @@
-triqs.gf.Gf
--------------
-
-.. _triqs_gf_Gf:
-
-.. autoclass:: triqs.gf.Gf
-   :members:

--- a/doc/documentation/python_api/triqs/utility/dichotomy.rst
+++ b/doc/documentation/python_api/triqs/utility/dichotomy.rst
@@ -1,5 +1,0 @@
-triqs.utility.dichotomy
--------------------------
-
-.. automodule:: triqs.utility.dichotomy
-   :members:


### PR DESCRIPTION
* use autosummary to create python api reference manual
* remove old pythonapi rst files
* `noindex` manual entries with same name to not cross-reference away from the new python api manual
* add gitignore with automatically generated autosummary files