### PR TITLE
use poll barrier in python to reduce CPU load per default as done in the C++ mpi layer

### DIFF
--- a/python/triqs/utility/mpi_mpi4py.py
+++ b/python/triqs/utility/mpi_mpi4py.py
@@ -51,7 +51,7 @@ def recv(source = 0):
 def barrier(poll_msec=1):
     """
     Use asynchronous synchronization, otherwise mpi.barrier uses up all the CPU time during
-    the run of subprocess. if poll_interval is 0.0 or None the default mpi barrier of mpi4py
+    the run of subprocess. if poll_msec is 0.0 or None the default mpi barrier of mpi4py
     is used.
     Parameters
     ----------

--- a/python/triqs/utility/mpi_mpi4py.py
+++ b/python/triqs/utility/mpi_mpi4py.py
@@ -55,7 +55,7 @@ def barrier(poll_msec=1):
     is used.
     Parameters
     ----------
-    poll_interval: float, time step for pinging the status of the sleeping ranks in msec
+    poll_msec: float, time step for pinging the status of the sleeping ranks in msec
     """
     if not poll_msec:
         world.barrier()

--- a/python/triqs/utility/mpi_nompi.py
+++ b/python/triqs/utility/mpi_nompi.py
@@ -50,7 +50,7 @@ def is_master_node(): return True
 
 def bcast(x, root = 0): return x
 
-def barrier() : return
+def barrier(poll_msec=1) : return
 
 def all_reduce(WORLD, x, F) : return x
 

--- a/test/python/atom_diag/atom_diag_bcast.py
+++ b/test/python/atom_diag/atom_diag_bcast.py
@@ -69,6 +69,10 @@ if mpi.is_master_node():
 else:
     ad = None
 
+# test custom mpi barrier in python
+mpi.barrier(None)
+mpi.barrier(10)
+
 ad_bcast = mpi.bcast(ad_bcast)
 
 assert isinstance(ad_bcast, AtomDiagReal)


### PR DESCRIPTION
same poll barrier implementation as in the C++ layer in triqs. Reduces CPU load on waiting MPI ranks drastically. Default wait time is 1 msec as in the C++ implementation. passing 0.0 or `None` to the barrier function call will use the default mpi.barier() call of mpi4py. I added a very brief test in one of the few mpi enabled python tests to check the function and cleaned up a few white spaces.