### PR TITLE
Micro optimize closest_mesh_pt

### DIFF
--- a/c++/triqs/mesh/bases/linear.hpp
+++ b/c++/triqs/mesh/bases/linear.hpp
@@ -66,7 +66,7 @@ namespace triqs::mesh {
 
     // -------------------- Constructors -------------------
 
-    explicit linear_mesh(domain_t dom, double a, double b, long n_pts) : _dom(std::move(dom)), L(n_pts), xmin(a), xmax(b), del(L == 1 ? 0. : (b - a) / (L - 1)) {
+    explicit linear_mesh(domain_t dom, double a, double b, long n_pts) : _dom(std::move(dom)), L(n_pts), xmin(a), xmax(b), del(L == 1 ? 0. : (b - a) / (L - 1)), del_inv{del == 0.0 ? std::numeric_limits<double>::infinity() : 1. / del} {
       EXPECTS(a<=b);
     }
 
@@ -82,6 +82,9 @@ namespace triqs::mesh {
 
     /// Step of the mesh
     double delta() const { return del; }
+
+    /// Inverse of the step of the mesh
+    double delta_inv() const { return del_inv; }
 
     /// Min of the mesh
     double x_min() const { return xmin; }
@@ -172,6 +175,7 @@ namespace triqs::mesh {
       ar &xmin;
       ar &xmax;
       ar &del;
+      ar &del_inv;
       ar &L;
     }
 
@@ -183,7 +187,7 @@ namespace triqs::mesh {
     private:
     domain_t _dom;
     long L;
-    double xmin, xmax, del;
+    double xmin, xmax, del, del_inv;
   };
 
   // ---------------------------------------------------------------------------

--- a/c++/triqs/mesh/details/closest_mesh_pt.hpp
+++ b/c++/triqs/mesh/details/closest_mesh_pt.hpp
@@ -29,11 +29,11 @@ namespace triqs::mesh {
   // ------------------------------------------------------
 
   template <typename Target> struct closest_point<imtime, Target> {
-    // index_t is int
     template <typename M, typename T> static int invoke(M const &mesh, closest_pt_wrap<T> const &p) {
-      double x = double(p.value) + 0.5 * mesh.delta();
-      int n    = std::floor(x / mesh.delta());
-      return n;
+      EXPECTS(mesh.x_min() < mesh.x_max());
+      EXPECTS(mesh.x_min() <= p.value);
+      EXPECTS(p.value <= mesh.x_max());
+      return static_cast<int>(p.value * mesh.delta_inv() + 0.5);
     }
   };
 
@@ -42,11 +42,11 @@ namespace triqs::mesh {
   // ------------------------------------------------------
 
   struct closest_point_linear_mesh {
-    // index_t is int
     template <typename M, typename T> static int invoke(M const &mesh, closest_pt_wrap<T> const &p) {
-      double x = double(p.value) - mesh.x_min() + 0.5 * mesh.delta();
-      int n    = std::floor(x / mesh.delta());
-      return n;
+      EXPECTS(mesh.x_min() < mesh.x_max());
+      EXPECTS(mesh.x_min() <= p.value);
+      EXPECTS(p.value <= mesh.x_max());
+      return static_cast<int>((p.value - mesh.x_min()) * mesh.delta_inv() + 0.5);
     }
   };
 


### PR DESCRIPTION
Benchmarking CT-INT revealed that this code is incredibly hot, so it is worthwhile to spend some time micro optimizing it.  We make use of the fact that this function only properly works for mesh points that are within the range of the mesh.  This allows to completely elide the call to std::floor since for positive values this is equivalent to truncation.  Futhermore division is replaced by multiplication with the precomputed inverse.

Co-authored-by: @Wentzell 