### PR TITLE
[cray-mpich] add support by EnvVar

### DIFF
--- a/python/triqs/utility/mpi.py.in
+++ b/python/triqs/utility/mpi.py.in
@@ -41,6 +41,8 @@ def check_for_mpi():
     # for MPICH and intel based MPI:
     elif os.environ.get('PMI_RANK'):
         is_mpi = True
+    elif os.environ.get('CRAY_MPICH_VERSION'):
+        is_mpi = True
     else:
         print('Warning: could not identify MPI environment!')
 


### PR DESCRIPTION
Add environment variable in python MPI detection to support `cray-mpich`.

The equivalent change in C++ is done in TRIQS/mpi, see https://github.com/TRIQS/mpi/pull/10