### PR TITLE
U_matrix supports wannier90 basis

### DIFF
--- a/python/triqs/operators/util/U_matrix.py
+++ b/python/triqs/operators/util/U_matrix.py
@@ -306,6 +306,8 @@ def spherical_to_cubic(l, convention='triqs'):
         T[2,1] = 1.0
     elif l == 2:
         if convention == 'wien2k':
+            # projectors created in Wien2k are defined in the complex spherical
+            # basis (see dmftproj manual Sec. 1.3.3).
             cubic_names = ("z^2","x^2-y^2","xy","yz","xz")
             T[0,2] = 1.0
             T[1,0] = 1.0/sqrt(2);   T[1,4] = 1.0/sqrt(2)

--- a/python/triqs/operators/util/U_matrix.py
+++ b/python/triqs/operators/util/U_matrix.py
@@ -168,7 +168,7 @@ def U_matrix_kanamori(n_orb, U_int, J_hund):
     return U, Uprime
 
 # Get t2g or eg components
-def t2g_submatrix(U, convention=''):
+def t2g_submatrix(U, convention='triqs'):
     r"""
     Extract the t2g submatrix of the full d-manifold two- or four-index U matrix.
 
@@ -180,9 +180,11 @@ def t2g_submatrix(U, convention=''):
                  The basis convention.
                  Takes the values
 
-                 - '': basis ordered as ("xy","yz","z^2","xz","x^2-y^2"),
+                 - 'triqs': basis ordered as ("xy","yz","z^2","xz","x^2-y^2"),
+                 - 'vasp': same as 'triqs',
                  - 'wien2k': basis ordered as ("z^2","x^2-y^2","xy","yz","xz"),
-                 - 'wannier90': basis order as ("z^2", "xz", "yz", "x^2-y^2", "xy"). 
+                 - 'wannier90': basis order as ("z^2", "xz", "yz", "x^2-y^2", "xy"),
+                 - 'qe': same as 'wannier90'.
 
 
     Returns
@@ -193,14 +195,14 @@ def t2g_submatrix(U, convention=''):
     """
     if convention == 'wien2k':
         return subarray(U, len(U.shape)*[(2,3,4)])
-    elif convention == 'wannier90':
+    elif convention == 'wannier90' or convention == 'qe':
         return subarray(U, len(U.shape)*[(1,2,4)])
-    elif convention== '':
+    elif convention == 'triqs' or convention=='vasp':
         return subarray(U, len(U.shape)*[(0,1,3)])
     else:
         raise ValueError("Unknown convention: "+str(convention))
 
-def eg_submatrix(U, convention=''):
+def eg_submatrix(U, convention='triqs'):
     r"""
     Extract the eg submatrix of the full d-manifold two- or four-index U matrix.
 
@@ -212,9 +214,11 @@ def eg_submatrix(U, convention=''):
                  The basis convention.
                  Takes the values
 
-                 - '': basis ordered as ("xy","yz","z^2","xz","x^2-y^2"),
+                 - 'triqs': basis ordered as ("xy","yz","z^2","xz","x^2-y^2"),
+                 - 'vasp': same as 'triqs',
                  - 'wien2k': basis ordered as ("z^2","x^2-y^2","xy","yz","xz"),
-                 - 'wannier90': basis order as ("z^2", "xz", "yz", "x^2-y^2", "xy"). 
+                 - 'wannier90': basis order as ("z^2", "xz", "yz", "x^2-y^2", "xy"),
+                 - 'qe': same as 'wannier90'.
 
 
     Returns
@@ -225,10 +229,9 @@ def eg_submatrix(U, convention=''):
     """
     if convention == 'wien2k':
         return subarray(U, len(U.shape)*[(0,1)])
-    elif convention == 'wannier90':
-        return subarray(U, len(U.shape)*[(0,3)])
-    elif convention == '':
-        return subarray(U, len(U.shape)*[(2,4)])
+    elif convention == 'wannier90' or convention == 'qe':
+        return subarray(U, len(U.shape)*[(1,2,4)])
+    elif convention == 'triqs' or convention=='vasp':
     else:
         raise ValueError("Unknown convention: "+str(convention))
 
@@ -260,7 +263,7 @@ def transform_U_matrix(U_matrix, T):
 
 # Rotation matrices: complex harmonics to cubic harmonics
 # Complex harmonics basis: ..., Y_{-2}, Y_{-1}, Y_{0}, Y_{1}, Y_{2}, ...
-def spherical_to_cubic(l, convention=''):
+def spherical_to_cubic(l, convention='triqs'):
     r"""
     Get the spherical harmonics to cubic harmonics transformation matrix.
 
@@ -272,9 +275,11 @@ def spherical_to_cubic(l, convention=''):
                  The basis convention.
                  Takes the values
 
-                 - '': basis ordered as ("xy","yz","z^2","xz","x^2-y^2"),
-                 - 'wien2k': basis ordered as ("z^2","x^2-y^2","xy","yz","xz").
-                 - 'wannier90': basis order as ("z^2", "xz", "yz", "x^2-y^2", "xy"). 
+                 - 'triqs': basis ordered as ("xy","yz","z^2","xz","x^2-y^2"),
+                 - 'vasp': same as 'triqs',
+                 - 'wien2k': basis ordered as ("z^2","x^2-y^2","xy","yz","xz"),
+                 - 'wannier90': basis order as ("z^2", "xz", "yz", "x^2-y^2", "xy"),
+                 - 'qe': same as 'wannier90'.
 
     Returns
     -------
@@ -283,13 +288,13 @@ def spherical_to_cubic(l, convention=''):
 
     """
 
-    if not convention in ('wien2k','wannier90', ''):
+    if not convention in ('wien2k','wannier90', 'triqs', 'vasp', 'qe'):
         raise ValueError("Unknown convention: "+str(convention))
 
     size = 2*l+1
     T = np.zeros((size,size),dtype=complex)
-    if convention == 'wien2k' and l != 2:
-        raise ValueError("spherical_to_cubic: wien2k convention implemented only for l=2")
+    if convention in ['wien2k', 'wannier90', 'qe'] and l != 2:
+        raise ValueError("spherical_to_cubic: [wien2k, wannier90, qe] convention implemented only for l=2")
     if l == 0:
         cubic_names = ("s")
     elif l == 1:
@@ -305,14 +310,14 @@ def spherical_to_cubic(l, convention=''):
             T[2,0] =-1.0/sqrt(2);   T[2,4] = 1.0/sqrt(2)
             T[3,1] = 1.0/sqrt(2);   T[3,3] =-1.0/sqrt(2)
             T[4,1] = 1.0/sqrt(2);   T[4,3] = 1.0/sqrt(2)
-        elif convention == 'wannier90':
+        elif convention == 'wannier90' or convention == 'qe':
             cubic_names = ("z^2", "xz", "yz", "x^2-y^2", "xy")
             T[0,2] = 1.0;           T[1,1] = 1.0/sqrt(2);
             T[1,3] =-1.0/sqrt(2);   T[2,1] = 1j/sqrt(2);
             T[2,3] = 1j/sqrt(2);    T[3,0] = 1.0/sqrt(2);
             T[3,4] = 1.0/sqrt(2);   T[4,0] = 1j/sqrt(2);    
             T[4,4] = -1j/sqrt(2);
-        else:
+        elif convention == 'triqs' or convention == 'vasp':
             cubic_names = ("xy","yz","z^2","xz","x^2-y^2")
             T[0,0] = 1j/sqrt(2);    T[0,4] = -1j/sqrt(2)
             T[1,1] = 1j/sqrt(2);    T[1,3] = 1j/sqrt(2)

--- a/python/triqs/operators/util/U_matrix.py
+++ b/python/triqs/operators/util/U_matrix.py
@@ -307,9 +307,11 @@ def spherical_to_cubic(l, convention=''):
             T[4,1] = 1.0/sqrt(2);   T[4,3] = 1.0/sqrt(2)
         elif convention == 'wannier90':
             cubic_names = ("z^2", "xz", "yz", "x^2-y^2", "xy")
-            T[0,4] = 1.0; T[1,2] = 1.0;
-            T[2,0] = 1.0; T[3,1] = 1.0;
-            T[4,3] = 1.0;
+            T[0,2] = 1.0;           T[1,1] = 1.0/sqrt(2);
+            T[1,3] =-1.0/sqrt(2);   T[2,1] = 1j/sqrt(2);
+            T[2,3] = 1j/sqrt(2);    T[3,0] = 1.0/sqrt(2);
+            T[3,4] = 1.0/sqrt(2);   T[4,0] = 1j/sqrt(2);    
+            T[4,4] = -1j/sqrt(2);
         else:
             cubic_names = ("xy","yz","z^2","xz","x^2-y^2")
             T[0,0] = 1j/sqrt(2);    T[0,4] = -1j/sqrt(2)

--- a/python/triqs/operators/util/U_matrix.py
+++ b/python/triqs/operators/util/U_matrix.py
@@ -181,7 +181,9 @@ def t2g_submatrix(U, convention=''):
                  Takes the values
 
                  - '': basis ordered as ("xy","yz","z^2","xz","x^2-y^2"),
-                 - 'wien2k': basis ordered as ("z^2","x^2-y^2","xy","yz","xz").
+                 - 'wien2k': basis ordered as ("z^2","x^2-y^2","xy","yz","xz"),
+                 - 'wannier90': basis order as ("z^2", "xz", "yz", "x^2-y^2", "xy"). 
+
 
     Returns
     -------
@@ -191,6 +193,8 @@ def t2g_submatrix(U, convention=''):
     """
     if convention == 'wien2k':
         return subarray(U, len(U.shape)*[(2,3,4)])
+    elif convention == 'wannier90':
+        return subarray(U, len(U.shape)*[(1,2,4)])
     elif convention== '':
         return subarray(U, len(U.shape)*[(0,1,3)])
     else:
@@ -209,7 +213,8 @@ def eg_submatrix(U, convention=''):
                  Takes the values
 
                  - '': basis ordered as ("xy","yz","z^2","xz","x^2-y^2"),
-                 - 'wien2k': basis ordered as ("z^2","x^2-y^2","xy","yz","xz").
+                 - 'wien2k': basis ordered as ("z^2","x^2-y^2","xy","yz","xz"),
+                 - 'wannier90': basis order as ("z^2", "xz", "yz", "x^2-y^2", "xy"). 
 
 
     Returns
@@ -220,6 +225,8 @@ def eg_submatrix(U, convention=''):
     """
     if convention == 'wien2k':
         return subarray(U, len(U.shape)*[(0,1)])
+    elif convention == 'wannier90':
+        return subarray(U, len(U.shape)*[(0,3)])
     elif convention == '':
         return subarray(U, len(U.shape)*[(2,4)])
     else:
@@ -267,6 +274,7 @@ def spherical_to_cubic(l, convention=''):
 
                  - '': basis ordered as ("xy","yz","z^2","xz","x^2-y^2"),
                  - 'wien2k': basis ordered as ("z^2","x^2-y^2","xy","yz","xz").
+                 - 'wannier90': basis order as ("z^2", "xz", "yz", "x^2-y^2", "xy"). 
 
     Returns
     -------
@@ -275,7 +283,7 @@ def spherical_to_cubic(l, convention=''):
 
     """
 
-    if not convention in ('wien2k',''):
+    if not convention in ('wien2k','wannier90', ''):
         raise ValueError("Unknown convention: "+str(convention))
 
     size = 2*l+1
@@ -297,6 +305,11 @@ def spherical_to_cubic(l, convention=''):
             T[2,0] =-1.0/sqrt(2);   T[2,4] = 1.0/sqrt(2)
             T[3,1] = 1.0/sqrt(2);   T[3,3] =-1.0/sqrt(2)
             T[4,1] = 1.0/sqrt(2);   T[4,3] = 1.0/sqrt(2)
+        elif convention == 'wannier90':
+            cubic_names = ("z^2", "xz", "yz", "x^2-y^2", "xy")
+            T[0,4] = 1.0; T[1,2] = 1.0;
+            T[2,0] = 1.0; T[3,1] = 1.0;
+            T[4,3] = 1.0;
         else:
             cubic_names = ("xy","yz","z^2","xz","x^2-y^2")
             T[0,0] = 1j/sqrt(2);    T[0,4] = -1j/sqrt(2)

--- a/python/triqs/operators/util/U_matrix.py
+++ b/python/triqs/operators/util/U_matrix.py
@@ -230,8 +230,10 @@ def eg_submatrix(U, convention='triqs'):
     if convention == 'wien2k':
         return subarray(U, len(U.shape)*[(0,1)])
     elif convention == 'wannier90' or convention == 'qe':
-        return subarray(U, len(U.shape)*[(1,2,4)])
+        return subarray(U, len(U.shape)*[(0,3)])
     elif convention == 'triqs' or convention=='vasp':
+        return subarray(U, len(U.shape)*[(2,4)])
+
     else:
         raise ValueError("Unknown convention: "+str(convention))
 


### PR DESCRIPTION
The functions that transform the Umatrix: ``spherical_to_cubic``, ``t2g_submatrix``, and ``eg_submatrix`` now support ``convention = "wannier90"``, where the d-shell is ordered as ("z^2", "xz", "yz", "x^2-y^2", "xy").