### PR TITLE
[doc] fix link of logo to index.html

### DIFF
--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -8,7 +8,7 @@
 {# Not strictly valid HTML, but it's the only way to display/scale
    it properly, without weird scripting or heaps of work
 #}
-<a href="index.html">
+<a href={{ pathto('index') }}>
   <img src="{{ pathto('_static/' + logo, 1) }}" class="logo" alt="{{ _('Logo') }}"/>
 </a>
 


### PR DESCRIPTION
The link behind the logo of the triqs doc was broken pointing to the wrong index.html on subpages of the autodoc generated pages. See for example https://triqs.github.io/triqs/latest/documentation/python_api/triqs.gf.html . Clicking on the logo leads to https://triqs.github.io/triqs/latest/documentation/python_api/index.html which does not exist. This fixes this by using sphinx macros to resolve the path to index.html

Should also be merged into 3.1.x.

Thanks O. Gingras for reporting!