### PR TITLE
[mpi-python] python/triqs.utility.mpi.all_reduce

### DIFF
--- a/python/triqs/dos/hilbert_transform.py
+++ b/python/triqs/dos/hilbert_transform.py
@@ -151,7 +151,7 @@ class HilbertTransform:
             # sum the res GF of all nodes and returns the results on all nodes...
             # Cf Boost.mpi.python, collective communicator for documentation.
             # The point is that res is pickable, hence can be transmitted between nodes without further code...
-            res << mpi.all_reduce(mpi.world, res, lambda x, y: x+y)
+            res << mpi.all_reduce(res)
             mpi.barrier()
         # END of HT
 

--- a/python/triqs/sumk/sumk_discrete.py
+++ b/python/triqs/sumk/sumk_discrete.py
@@ -160,7 +160,7 @@ class SumkDiscrete:
             tmp2 *= w
             G += tmp2
 
-        G << mpi.all_reduce(mpi.world,G,lambda x,y: x+y)
+        G << mpi.all_reduce(G)
         mpi.barrier()
 
         return G

--- a/python/triqs/utility/mpi_mpi4py.py
+++ b/python/triqs/utility/mpi_mpi4py.py
@@ -64,10 +64,16 @@ def barrier(poll_msec=1):
         while not req.Test():
             time.sleep(poll_msec / 1000)
 
-# temporary patch
-# need to change the code for all all_reduce to use this layer....
-def all_reduce(WORLD, x, F) :
-    return world.allreduce(x)
+def all_reduce(x, comm=world, op=MPI.SUM):
+    try:
+        return comm.allreduce(x, op=op)
+    except (AttributeError, TypeError) as e:
+        if isinstance(x, MPI.Intracomm):
+            report(
+                "WARNING: the signature for all_reduce is now 'all_reduce(x, comm=world, op=MPI.SUM)'\n\tattempting compatibility with old signature"
+            )
+            return world.allreduce(comm)
+        raise e
 
 
 Verbosity_Level_Report_Max = 1

--- a/python/triqs/utility/mpi_nompi.py
+++ b/python/triqs/utility/mpi_nompi.py
@@ -52,7 +52,14 @@ def bcast(x, root = 0): return x
 
 def barrier(poll_msec=1) : return
 
-def all_reduce(WORLD, x, F) : return x
+# op doesn't do anything in serial so Ops like MINLOC or MAXLOC could fail
+def all_reduce(x, comm=world, op=lambda x, y: x + y):
+    if x is None:
+        report(
+            "WARNING: the signature for all_reduce is now 'all_reduce(x, comm=world, op=MPI.SUM)'\n\tattempting compatibility with old signature"
+        )
+        return comm
+    return x
 
 def send(val, dest):
     _sendval = val


### PR DESCRIPTION
Previous python all_reduce version did not use first or third argument at all. Now comm and op are optional arguments, actually work, and the signature better matches the c++ api.