### PR TITLE
plot: fix histogram plotting via oplot

### DIFF
--- a/python/triqs/plot/protocol.py
+++ b/python/triqs/plot/protocol.py
@@ -20,6 +20,10 @@
 
 import numpy
 
+# dict for plotting functions for specific C++ wrapped types
+# expect entries of type : plot_function
+# see example in stat.__init__.py for histograms
+plot_function_table = {}
 
 def clip_array(x_array, x_min, x_max):
     """
@@ -52,8 +56,12 @@ def plot_protocol_apply(ob, opt_dict, xlims):
     or emulates it (e.g. for numpy arrays).
     """
 
+    # the object can have a native plot function defined in the class
     if hasattr(ob, '_plot_'):
         return ob._plot_(opt_dict)
+    # or registered in the plot_function_table variable
+    elif type(ob) in plot_function_table:
+        return plot_function_table[type(ob)](ob, opt_dict)
     elif callable(ob):
         n_points = opt_dict.pop('n_points', 100)
         rx = opt_dict.pop('x_window', None)

--- a/python/triqs/stat/__init__.py
+++ b/python/triqs/stat/__init__.py
@@ -24,4 +24,9 @@ DOC
 """
 from .histograms import Histogram, cdf, pdf
 
+# register the plot function in the plotting table
+from .histogram import plot
+from triqs.plot.protocol import plot_function_table
+plot_function_table[Histogram] = plot
+
 __all__ = ['Histogram', 'cdf', 'pdf']


### PR DESCRIPTION
- functionality to add python only function to a cpp2py generated class does not exist anymore
- add global dict / table to store plotting functions for C++ classes
- register histogram plot function in init