### PR TITLE
generalize U_matrix_kanamori and fix U_matrix doc

### DIFF
--- a/python/triqs/operators/util/U_matrix.py
+++ b/python/triqs/operators/util/U_matrix.py
@@ -32,8 +32,14 @@ def U_matrix_slater(l, radial_integrals=None, U_int=None, J_hund=None, basis='sp
 
     .. math:: U^{spherical}_{m1 m2 m3 m4} = \sum_{k=0}^{2l} F_k \alpha(l, k, m1, m2, m3, m4)
 
-    being given either radial_integrals or U_int and J_hund.
-    The convetion for the U matrix is that used to construct the Hamiltonians, namely:
+    where :math:`F_k` [:math:`F_0, F_2, F_4, ...`] are radial Slater integrals
+    and :math:`\alpha(l, k, m1, m2, m3, m4)` denote angular Racah_Wigner numbers for
+    a spherical symmetric interaction tensor. The user can either specify directly the
+    radial integral :math:`F_k`, or U_int / J_hund are given using the function
+    :func:`U_J_to_radial_integrals` to convert back to radial integrals.
+
+    The convetion for the U matrix is given by the definition of the following
+    Hamiltonian:
 
     .. math:: H = \frac{1}{2} \sum_{ijkl,\sigma \sigma'} U_{ijkl} a_{i \sigma}^\dagger a_{j \sigma'}^\dagger a_{l \sigma'} a_{k \sigma}.
 
@@ -149,8 +155,15 @@ def U_matrix_kanamori(n_orb, U_int, J_hund, Up_int=None, full_Uijkl=False, Jc_hu
 
     .. math:: U_{m m'}^{\sigma \bar{\sigma}} \equiv U_{m m' m m'}
 
-    If full_Uijkl=True is specified instead the full four index 
-    Uijkl tensor is returned. 
+    If full_Uijkl=True is specified the full four index
+    Uijkl tensor is returned instead:
+
+        .. math:: U_{m m m m} = U, \\
+                  U_{m m' m m'} = U', \\
+                  U_{m m' m' m} = J, \\
+                  U_{m m m' m'} = J_C,
+
+    with :math:`m \neq m'`.
 
     Parameters
     ----------
@@ -184,10 +197,10 @@ def U_matrix_kanamori(n_orb, U_int, J_hund, Up_int=None, full_Uijkl=False, Jc_hu
     if Jc_hund is not None and not full_Uijkl:
         raise ValueError('Jc_hund can only be specified if the full four index tensor is returned')
 
-    if not Up_int:
+    if Up_int is None:
         Up_int = U_int-2*J_hund
-    if not Jc_hund:
-        Jc_hund = Jc_hund
+    if Jc_hund is None:
+        Jc_hund = J_hund
 
     m_range = range(n_orb)
 
@@ -199,7 +212,7 @@ def U_matrix_kanamori(n_orb, U_int, J_hund, Up_int=None, full_Uijkl=False, Jc_hu
             if m == mp:
                 Uprime[m, mp] = U_int
             else:
-                U[m, mp] = Up_int - 1.0*J_hund
+                U[m, mp] = Up_int - J_hund
                 Uprime[m, mp] = Up_int
 
         return U, Uprime
@@ -365,7 +378,7 @@ def spherical_to_cubic(l, convention='triqs'):
             T[0,2] = 1.0;           T[1,1] = 1.0/sqrt(2);
             T[1,3] =-1.0/sqrt(2);   T[2,1] = 1j/sqrt(2);
             T[2,3] = 1j/sqrt(2);    T[3,0] = 1.0/sqrt(2);
-            T[3,4] = 1.0/sqrt(2);   T[4,0] = 1j/sqrt(2);    
+            T[3,4] = 1.0/sqrt(2);   T[4,0] = 1j/sqrt(2);
             T[4,4] = -1j/sqrt(2);
         elif convention == 'triqs' or convention == 'vasp':
             cubic_names = ("xy","yz","z^2","xz","x^2-y^2")

--- a/python/triqs/operators/util/__init__.py
+++ b/python/triqs/operators/util/__init__.py
@@ -27,7 +27,7 @@ from .extractors import *
 
 __all__ = ['h_int_slater','h_int_kanamori','h_int_density','diagonal_part',
            'get_mkind','set_operator_structure', 'U_J_to_radial_integrals',
-           'U_matrix', 'U_matrix_kanamori', 'angular_matrix_element', 'clebsch_gordan',
+           'U_matrix_slater', 'U_matrix_kanamori', 'angular_matrix_element', 'clebsch_gordan',
            'cubic_names', 'eg_submatrix', 'radial_integrals_to_U_J',
            'reduce_4index_to_2index', 'spherical_to_cubic', 't2g_submatrix',
            'three_j_symbol', 'transform_U_matrix',

--- a/test/python/base/U_mat.py
+++ b/test/python/base/U_mat.py
@@ -23,12 +23,34 @@ from triqs.operators.util import *
 from triqs.utility.comparison_tests import *
 import numpy
 
+
+# test slater
 U_sph = U_matrix_slater(l=2, U_int=2.0, J_hund=0.5)
-U_cubic = transform_U_matrix(U_sph,spherical_to_cubic(l=2))
-U,Up = reduce_4index_to_2index(U_cubic)
+U_cubic = transform_U_matrix(U_sph, spherical_to_cubic(l=2))
+U, Up = reduce_4index_to_2index(U_cubic)
 
 with HDFArchive('U_mat.ref.h5', 'r') as ar:
    assert_arrays_are_close(ar['Ufull_sph'], U_sph)
    assert_arrays_are_close(ar['Ufull_cubic'], U_cubic)
    assert_arrays_are_close(ar['U'], U)
    assert_arrays_are_close(ar['Up'], Up)
+
+
+# test Kanamori
+U_kan_ijkl = U_matrix_kanamori(n_orb=5, U_int=3.5, J_hund=1.1, full_Uijkl=True)
+U_ref, U_p_ref = reduce_4index_to_2index(U_kan_ijkl)
+
+U, U_p = U_matrix_kanamori(n_orb=5, U_int=3.5, J_hund=1.1, full_Uijkl=False)
+
+assert_arrays_are_close(U_ref, U)
+assert_arrays_are_close(U_p_ref, U_p)
+
+
+# test Kanamori with different Up
+U_kan_ijkl = U_matrix_kanamori(n_orb=3, U_int=3.2, Up_int=1.67, J_hund=1.35, full_Uijkl=True)
+U_ref, U_p_ref = reduce_4index_to_2index(U_kan_ijkl)
+
+U, U_p = U_matrix_kanamori(n_orb=3, U_int=3.2, Up_int=1.67, J_hund=1.35, full_Uijkl=False)
+
+assert_arrays_are_close(U_ref, U)
+assert_arrays_are_close(U_p_ref, U_p)

--- a/test/python/base/U_mat.py
+++ b/test/python/base/U_mat.py
@@ -23,7 +23,7 @@ from triqs.operators.util import *
 from triqs.utility.comparison_tests import *
 import numpy
 
-U_sph = U_matrix(l=2, U_int=2.0, J_hund=0.5)
+U_sph = U_matrix_slater(l=2, U_int=2.0, J_hund=0.5)
 U_cubic = transform_U_matrix(U_sph,spherical_to_cubic(l=2))
 U,Up = reduce_4index_to_2index(U_cubic)
 


### PR DESCRIPTION
* generalize U_matrix_kanamori to allow for Uprime != U-2J cases
* allow to generate full four index Uijkl tensor as in U_matrix_slater
* rename U_matrix to U_matrix_slater because a function should not have the same name a module (sphinx autodoc currently broken see emptiness of https://triqs.github.io/triqs/latest/documentation/python_api/triqs.operators.util.U_matrix.html )
* clean up weird before function comments and merge missing info into docstrings

Warning: this will break backward compatibility due to renaming U_matrix -> U_matrix_slater !!! Please discuss.