### PR TITLE
[test] MeshCycLat iteration

### DIFF
--- a/test/python/base/CMakeLists.txt
+++ b/test/python/base/CMakeLists.txt
@@ -61,6 +61,7 @@ add_python_test(gf_tensor_valued)
 add_python_test(histograms)
 add_python_test(histogram_bcast)
 add_python_test(brillouin_zone)
+add_python_test(cyclic_lattice)
 
 # discretize bath
 add_python_test(discretize_bath)

--- a/test/python/base/cyclic_lattice.py
+++ b/test/python/base/cyclic_lattice.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2023 Hugo U.R. Strand
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You may obtain a copy of the License at
+#     https:#www.gnu.org/licenses/gpl-3.0.txt
+#
+# Authors: Hugo U.R. Strand
+
+import numpy as np
+
+from triqs.lattice import BrillouinZone, BravaisLattice
+from triqs.gf import MeshBrZone, MeshCycLat
+
+import unittest
+
+class test_cyclic_lattice(unittest.TestCase):
+
+    def test_mesh_iteration(self):
+        
+        units = np.eye(3)
+        per_mat = np.diag([8, 1, 1])
+        
+        bl = BravaisLattice(units)
+
+        rm = MeshCycLat(bl, per_mat)
+        print(rm)
+
+        for r in rm:
+            print(r)
+
+        bz = BrillouinZone(bl)
+
+        km = MeshBrZone(bz, per_mat)
+        print(km)
+        
+        for k in km:
+            print(k)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Dear Triqs devs,

Iteration over `MeshCycLat` in Python is broken on `triqs/unstable` after `gfv2` the merge. It seems like the cyclic lattice mesh point python wrapping has gone missing. We hit this error in `tprf` and it is holding us back getting `tprf/unstable` passing all test. Please help.

This pull request contains a failing test that attempts to iterate over the mesh.

```
        rm = MeshCycLat(bl, per_mat)
        print(rm)

        for r in rm:
            print(r)
```

producing the error

```
264: Test timeout computed to be: 10000000
264: E
264: ======================================================================
264: ERROR: test_mesh_iteration (__main__.test_cyclic_lattice)
264: ----------------------------------------------------------------------
264: Traceback (most recent call last):
264:   File "/Users/hugstr/dev/triqs_dlr_dev/test/python/base/cyclic_lattice.py", line 39, in test_mesh_iteration
264:     for r in rm:
264: RuntimeError: The type N5triqs7lattice15bravais_lattice7point_tE can not be converted
264: 
264: ----------------------------------------------------------------------
264: Ran 1 test in 0.000s
264: 
264: FAILED (errors=1)
264: Cyclic Lattice Mesh with linear dimensions (8 1 1)
264:  -- units = 
264: [[1,0,0]
264:  [0,1,0]
264:  [0,0,1]]
264:  -- lattice: Bravais Lattice with dimension 3, units 
264: [[1,0,0]
264:  [0,1,0]
264:  [0,0,1]], n_orbitals 1
1/1 Test #264: py_cyclic_lattice ................***Failed    0.15 sec
```