### PR TITLE
[mpi] add envar check to force MPI init

### DIFF
--- a/python/triqs/utility/mpi.py.in
+++ b/python/triqs/utility/mpi.py.in
@@ -26,7 +26,8 @@ def check_for_mpi():
     '''
     Simple function checking if triqs has been called with 
     mpirun or without, by checking for typical MPI environment
-    variables
+    variables. To enforce the MPI init TRIQS_FORCE_MPI_INIT
+    can be set manually as env variable.
 
     Returns: 
     -------
@@ -42,6 +43,9 @@ def check_for_mpi():
     elif os.environ.get('PMI_RANK'):
         is_mpi = True
     elif os.environ.get('CRAY_MPICH_VERSION'):
+        is_mpi = True
+    # to force the MPI init manually
+    elif os.environ.get('TRIQS_FORCE_MPI_INIT'):
         is_mpi = True
     else:
         print('Warning: could not identify MPI environment!')


### PR DESCRIPTION
Add check for environment variable `TRIQS_FORCE_MPI_INIT` to allow enforcing the MPI Init for specific environments and test cases. Should address TRIQS/cthyb issue #166 (https://github.com/TRIQS/cthyb/issues/166)