### PR TITLE
[h5] suppress GfIndices warning when reading Gf from h5

### DIFF
--- a/python/triqs/gf/gf.py
+++ b/python/triqs/gf/gf.py
@@ -792,6 +792,10 @@ def bckwd(hdf_scheme):
             break
     return { 'mesh': 'Mesh'+m }
 
+# backward compatibility: suppress unrecognized GfIndices warnings
+# when reading a Gf stored with triqs <3.2.x
+warnings.filterwarnings("ignore", message="The hdf5 format GfIndices")
+
 register_backward_compatibility_method("GfImFreq", "Gf", bckwd)
 register_backward_compatibility_method("GfImTime", "Gf", bckwd)
 register_backward_compatibility_method("GfLegendre", "Gf", bckwd)


### PR DESCRIPTION
fixes issue #886 by filtering the corresponding warning. Works together with https://github.com/TRIQS/h5/pull/16 , by making the issued warning a proper warning. 