### PR TITLE
[gf] add array_priority also to BlockGf / Block2Gf

### DIFF
--- a/python/triqs/gf/block2_gf.py
+++ b/python/triqs/gf/block2_gf.py
@@ -28,6 +28,9 @@ class Block2Gf:
     """
     Generic Green's Function by two-index Block.
     """
+
+    __array_priority__ = 10000 # Makes sure the operations of this class are applied as priority
+
     def __init__(self, name_list1, name_list2, block_list, **kwargs):
         """
     * Block2Gf(name_list1, name_list2, block_list, make_copies = False, name = 'G2')

--- a/python/triqs/gf/block_gf.py
+++ b/python/triqs/gf/block_gf.py
@@ -46,6 +46,9 @@ class BlockGf:
     """
     Generic Green's Function by Block.
     """
+
+    __array_priority__ = 10000 # Makes sure the operations of this class are applied as priority
+
     # not implemented as a dictionary since we want to be sure of the order !).
     def __init__(self, **kwargs):
         """


### PR DESCRIPTION
multiplication of type numpy array * BlockGf was broken because ladd operation of numpy was priorized over the triqs implementation. Adding the numpy array_priority attribute solves this. Compare with Gf class implementation.