### PR TITLE
[gf] fix density function for MeshReFreq Gf

### DIFF
--- a/c++/triqs/gfs/functions/density.cpp
+++ b/c++/triqs/gfs/functions/density.cpp
@@ -156,10 +156,10 @@ namespace triqs::gfs {
 
     // Filter out divergent real parts of g that are inf
     // e.g. flat dos at dos edge (but keep complex matrix structure)
-    diagonal(res) = imag(diagonal(res));
+    diagonal(res) = dcomplex(0.,1.)*imag(diagonal(res));
     res *= dcomplex(0., 1.) * dw / M_PI; // scale to density
 
-    // writing back into res is problematic due to lazy expressionsreturn
+    // writing back into res is problematic due to lazy expressions
     // return directly instead
     return 0.5 * (res + dagger(res)); // A = i( g - g^+ )
   }
@@ -175,10 +175,10 @@ namespace triqs::gfs {
 
     // -- Required to filter out divergent real parts of g that are inf
     // -- eg flat dos at dos edge
-    diagonal(res) = imag(diagonal(res));
+    diagonal(res) = dcomplex(0.,1.)*imag(diagonal(res));
     res *= dcomplex(0., 1.) * g.mesh().delta() / M_PI; // scale to density
 
-    // writing back into res is problematic due to lazy expressionsreturn
+    // writing back into res is problematic due to lazy expressions
     // return directly instead
     return 0.5 * (res + dagger(res)); // A = i( g - g^+ )
   }

--- a/test/c++/gfs/gf_density.cpp
+++ b/test/c++/gfs/gf_density.cpp
@@ -74,16 +74,20 @@ TEST(Gf, Density_with_not_all_moments) {
 
 TEST(Gf, DensityFermionReFreq) {
 
-  double wmax = 10;
-  int N       = 1000;
-  auto h      = matrix<dcomplex>{{{1 + 0i, 1i}, {-1i, 2 + 0i}}};
-  auto G      = gf<refreq>{{-wmax, wmax, N}, {2, 2}};
+  int N  = 20000;
+  auto h = matrix<dcomplex>{{{-2 + 0i, 1i}, {-1i, -3.5 + 0i}}};
+  auto G = gf<refreq>{{-10.0, 3.0, N}, {2, 2}};
 
   //G(iw_) << inverse(w_ - h + eta); // FIXME
-  for (auto const &w : G.mesh()) G[w] = inverse(w - h + 1e-8i);
+  for (auto const &w : G.mesh()) G[w] = inverse(w - h + 1e-3i);
 
+  // test zero temperature implementation here / finite T tested in python
   auto n = triqs::gfs::density(G);
+
   EXPECT_ARRAY_EQ(n, dagger(n));
+
+  // check if filling is correct
+  EXPECT_COMPLEX_NEAR(trace(n), 2.0 + 0.0i, 1.e-3);
 }
 
 MAKE_MAIN;

--- a/test/python/base/gf_density.py
+++ b/test/python/base/gf_density.py
@@ -27,11 +27,10 @@ beta = 50.0
 
 # -- Test Matsubara frequency density for free Gf
 
-g_iw = GfImFreq(beta=beta, indices=[0], n_points=1000)
+iw_mesh = MeshImFreq(beta=beta, S='Fermion', n_iw=1000)
+g_iw = GfImFreq(mesh=iw_mesh, target_shape=[1,1])
 
 print("==============================================")
-
-print(g_iw.density())
 
 for eps in np.random.random(10):
     g_iw << inverse(iOmega_n - eps)
@@ -40,3 +39,19 @@ for eps in np.random.random(10):
     n = np.squeeze(g_iw.density(km))
     n_ref = fermi(eps, beta)
     np.testing.assert_almost_equal(n, n_ref)
+
+
+print("==============================================")
+# -- Test real frequency density for free Gf
+
+energies = np.diag(np.array([-3, -2, -1],dtype=complex))
+
+mesh = MeshReFreq(n_w=20001, window=(-10,3))
+gf_w = Gf(mesh=mesh, target_shape=[3,3])
+eta = 0.001
+
+gf_w[:,:] << inverse(Omega + 1j*eta - energies )
+
+assert( np.allclose(np.eye(3), gf_w.density(beta=1000), rtol=1e-3 ) )
+
+assert( gf_w.total_density(beta=1000).real - 3.0 < 1e-3)


### PR DESCRIPTION
density function always returned 0.0 as result of recent changes. 

Additionally this commit strengthens the test for density(), density(beta), and total_density. Added tests in C++ and Python.