### PR TITLE
Added the sympyfy function alongside its necessary dependencies

### DIFF
--- a/python/triqs/lattice/utils.py
+++ b/python/triqs/lattice/utils.py
@@ -275,9 +275,12 @@ def sympyfy(tb_lat_obj, analytical = True):
         numerical form or reduced analytical form depending on what the user chooses. The default output, 
         which depends on the optional analytical flag or parameter, is the reduced analytical form
 
+        #TODO: Explain what the numerical form means. Only depends on k and no other variables? 
+        # TODO: versus the analytical form. 
+
+
     """
     import sympy as sp
-    from sympy import exp
 
     # imaginary number
     I = sp.I
@@ -370,7 +373,7 @@ def sympyfy(tb_lat_obj, analytical = True):
         """
         for sublist in matrix:
             for element in sublist:
-                if element.is_complex and element.has(exp):
+                if element.is_complex and element.has(sp.exp):
                     return True
         return False
     

--- a/python/triqs/lattice/utils.py
+++ b/python/triqs/lattice/utils.py
@@ -17,6 +17,8 @@
 
 from io import StringIO
 import numpy as np
+from itertools import product as itp
+import warnings
 
 __all__ = ['k_space_path', 'TB_from_wannier90']
 
@@ -248,12 +250,10 @@ def TB_from_pythTB(ptb):
     return TBL
 
 # importing necessary dependencies
-from itertools import product as itp
-from pythtb import *
+
+
 # from triqs.lattice.tight_binding import TBLattice # TRIQS needs to be installed for this dependency to work
-import sympy as sp
-from sympy import *
-import warnings
+
 
 def sympyfy(tb_lat_obj, analytical = True):
     r"""
@@ -270,12 +270,14 @@ def sympyfy(tb_lat_obj, analytical = True):
     
     Returns
     -------
-    Hk_numerical: NumPy Array
-        the hamiltonian of the tight-binding model in momentum space in numerical form
-    Hk: NumPy Array
-        the hamiltonian of the tight-binding model in momentum space in reduced analytical form
+    Hk: NumPy array
+        The hamiltonian of the tight-binding model in momentum space. This can be returned either in
+        numerical form or reduced analytical form depending on what the user chooses. The default output, 
+        which depends on the optional analytical flag or parameter, is the reduced analytical form
 
     """
+    import sympy as sp
+    from sympy import exp
 
     # imaginary number
     I = sp.I
@@ -356,7 +358,7 @@ def sympyfy(tb_lat_obj, analytical = True):
     # converting the numerical Hamiltonian to a NumPy array from a SymPy matrix
     Hk_numerical = np.array(Hk_numerical)
 
-    def has_complex_exponential(matrix):
+    def _has_complex_exponential_sympy(matrix):
         """
         Checks if a NumPy array containing SymPy elements has a complex exponential element.
 
@@ -372,7 +374,7 @@ def sympyfy(tb_lat_obj, analytical = True):
                     return True
         return False
     
-    def is_hermitian(matrix):
+    def _is_hermitian_sympy(matrix):
         """
         Checks if a NumPy array containing SymPy elements is hermitian
 
@@ -390,11 +392,11 @@ def sympyfy(tb_lat_obj, analytical = True):
         return True
     
     # warning indicating when the output Hamiltonian is not hermitian
-    if is_hermitian(Hk) == False or is_hermitian(Hk_numerical) == False:
+    if _is_hermitian_sympy(Hk) == False or _is_hermitian_sympy(Hk_numerical) == False:
         return warnings.warn("The resulting Hamiltonian is not hermitian.")
 
     # warning indicating when the Hamiltonian contains a complex exponential element
-    if has_complex_exponential(Hk_numerical) or has_complex_exponential(Hk):
+    if _has_complex_exponential_sympy(Hk_numerical) or _has_complex_exponential_sympy(Hk):
         return warnings.warn("""Your expression has a complex exponential. 
                                 Choosing a different unit cell could make 
                                 your Hamiltonian expression real.""")


### PR DESCRIPTION
The sympyfy function outputs a reduced analytical or numerical Hamiltonian in momentum space utilizing the Fourier series. The input of this function is a TRIQS tight-binding model that one can get from converting their model from either a Wannier90 model or PythTB model using TRIQS's handy function that enables said conversion.

This function has been tested on 2 compounds with different symmetries. These compounds include a Strontium compound (SrCaCu2O4) and a Palladium compound (PdCoO2). This function mainly follows from the equation in the attached screenshot. This function will help anyone, especially experimentalists, better understand their results in the tight-binding model landscape by visualizing a reduced analytical expression (and a numerical expression should they wish).
![Tight-Binding Hamiltonian in Momentum-Space from Real Space using the Fourier Series](https://github.com/TRIQS/triqs/assets/74094734/4ec879c5-9d60-4d1b-a9bb-c89f7a4dd7bf)
