### PR TITLE
Partially revert c5b8670, restore k_space_path TPRF compat

### DIFF
--- a/python/triqs/lattice/utils.py
+++ b/python/triqs/lattice/utils.py
@@ -24,12 +24,12 @@ import warnings
 __all__ = ['k_space_path', 'TB_from_wannier90']
 
 
-def k_space_path(paths, num=101, bz=None, relative_coordinates=True, return_ticks=False):
+def k_space_path(segments, num=101, bz=None, relative_coordinates=True):
     """ Generate an array of k-vectors along a path defined by a list of pairs of k-vectors
 
     Parameters
     ----------
-    paths : list of pairs of three-vectors of floats
+    segments : list of pairs of three-vectors of floats
        List of pairs of k-vectors in reciprocal units to create a path in-between.
     num : int, default=100
        Number of k-vectors along each segment of the overall path
@@ -42,16 +42,15 @@ def k_space_path(paths, num=101, bz=None, relative_coordinates=True, return_tick
 
     Returns
     -------
-    kvecs: numpy.ndarray [shape=(len(paths)*num,3)]
+    kvecs: numpy.ndarray [shape=(len(segments)*num,3)]
         Two-dimensional numpy array containing the path vectors (in reciprocal units) as rows
     dist: numpy.ndarray  [shape=(kvecs.shape[0])]
         One-dimensional numpy array containing, for each element in kvecs,
         the distance travelled along the path. Useful for plotting.
         If bz is provided, calculate the distance in absolute units.
-        The distances for the relevant k-points in paths can be obtained with dist[num::num].
-    ticks : numpy.ndarray [shape=(len(paths)+1)], optional
-        Array with tick points, i.e. distances at the interfaces of path segments.
-        Only returned if `return_ticks` is `True`.
+    ticks : numpy.ndarray [shape=(len(segments)+1)]
+        Array with tick points, i.e. distances at the interfaces between segment.
+        Includes the initial and final distance.
     """
 
     if bz is None:
@@ -60,8 +59,8 @@ def k_space_path(paths, num=101, bz=None, relative_coordinates=True, return_tick
         cell = bz.units
 
     x = np.linspace(0., 1., num=num)
-    paths = [(np.asarray(ki), np.asarray(kf)) for ki, kf in paths]
-    kvecs = [ki[None, :] + x[:, None] * (kf - ki)[None, :] for ki, kf in paths]
+    segments = [(np.asarray(ki), np.asarray(kf)) for ki, kf in segments]
+    kvecs    = [ki[None, :] + x[:, None] * (kf - ki)[None, :] for ki, kf in segments]
 
     cur_dist = 0.0
     dist = np.array([], dtype=float)
@@ -73,10 +72,7 @@ def k_space_path(paths, num=101, bz=None, relative_coordinates=True, return_tick
         cur_dist = dist[-1]
 
     if not relative_coordinates: kvecs = kvecs_abs
-    if return_ticks:
-        return np.vstack(kvecs), dist, np.concatenate(([dist[0]], dist[num::num], [dist[-1]]))
-    else:
-        return np.vstack(kvecs), dist
+    return np.vstack(kvecs), dist, np.concatenate(([0], dist[num-1::num]))
 
 
 # ----------------------------------------------------------------------

--- a/python/triqs/lattice/utils.py
+++ b/python/triqs/lattice/utils.py
@@ -49,7 +49,7 @@ def k_space_path(paths, num=101, bz=None, relative_coordinates=True, return_tick
         the distance travelled along the path. Useful for plotting.
         If bz is provided, calculate the distance in absolute units.
         The distances for the relevant k-points in paths can be obtained with dist[num::num].
-    ticks : numpy.ndarray [shape=(len(paths)-1)], optional
+    ticks : numpy.ndarray [shape=(len(paths)+1)], optional
         Array with tick points, i.e. distances at the interfaces of path segments.
         Only returned if `return_ticks` is `True`.
     """
@@ -74,7 +74,7 @@ def k_space_path(paths, num=101, bz=None, relative_coordinates=True, return_tick
 
     if not relative_coordinates: kvecs = kvecs_abs
     if return_ticks:
-        return np.vstack(kvecs), dist, dist[num::num]
+        return np.vstack(kvecs), dist, np.concatenate(([dist[0]], dist[num::num], [dist[-1]]))
     else:
         return np.vstack(kvecs), dist
 

--- a/test/python/lattice_utils.py
+++ b/test/python/lattice_utils.py
@@ -41,9 +41,9 @@ class test_utils(unittest.TestCase):
 
         num = 101
         paths = [(Gamma, M), (M, R), (X, Z)]
-        kvecs, dist = k_space_path(paths, num=num, bz=bz)
+        kvecs, dist, ticks = k_space_path(paths, num=num, bz=bz)
 
-        dist_cmp_exact = [0.]
+        ticks_exact = [0.]
         for n, (ki, kf) in enumerate(paths):
             dk = kf - ki
 
@@ -52,10 +52,9 @@ class test_utils(unittest.TestCase):
             self.assertTrue(np.array_equal(kvec, kvec_exact))
 
             dd = np.linalg.norm(np.dot(dk, bz.units))
-            dist_cmp_exact.append(dd + dist_cmp_exact[-1])
+            ticks_exact.append(dd + ticks_exact[-1])
 
-        dist_cmp = np.concatenate((dist[0:1], dist[num-1::num]))
-        self.assertTrue(np.array_equal(dist_cmp, dist_cmp_exact))
+        self.assertTrue(np.array_equal(ticks, ticks_exact))
 
     def test_TB_from_w90(self):
 
@@ -80,7 +79,7 @@ class test_utils(unittest.TestCase):
         Gamma = np.array([0.0, 0.0, 0.0])
         M = np.array([0.5, 0.5, 0.0])
         paths = [(Gamma, M)]
-        kvecs, dist = k_space_path(paths, num=101, bz=tbl_w90.bz)
+        kvecs, dist, ticks = k_space_path(paths, num=101, bz=tbl_w90.bz)
         epsilon_k = tbl_w90.dispersion(kvecs)
         self.assertTrue(epsilon_k.shape == (101, 3))
 
@@ -136,7 +135,7 @@ class test_utils(unittest.TestCase):
         Gamma = np.array([0.0, 0.0, 0.0])
         M = np.array([0.5, 0.5, 0.0])
         paths = [(Gamma, M)]
-        kvecs, dist = k_space_path(paths, num=101, bz=tbl_ptb.bz)
+        kvecs, dist, ticks = k_space_path(paths, num=101, bz=tbl_ptb.bz)
         epsilon_k = tbl_ptb.dispersion(kvecs)
         self.assertTrue(epsilon_k.shape == (101, 3))
 


### PR DESCRIPTION
Suggestion by @HugoStrand, to be discussed.

I think the API is less clear this way, ticks should contain the actual tick positions along the way and not the edges?