### PR TITLE
fix: python AtomDiag force real if real

### DIFF
--- a/c++/triqs/atom_diag/atom_diag.hpp
+++ b/c++/triqs/atom_diag/atom_diag.hpp
@@ -140,7 +140,7 @@ namespace triqs {
        */
       atom_diag(many_body_op_t const &h, fundamental_operator_set const &fops);
 
-      atom_diag(many_body_op_t const &h, many_body_op_t const &hyb, fundamental_operator_set const &fops);
+      atom_diag(many_body_op_t const &h, fundamental_operator_set const &fops, many_body_op_t const &hyb);
 
       atom_diag(many_body_op_t const &h, fundamental_operator_set const &fops, int n_min, int n_max);
 
@@ -156,6 +156,8 @@ namespace triqs {
        * @param qn_vector Vector of quantum number operators.
        */
       atom_diag(many_body_op_t const &h, fundamental_operator_set const &fops, std::vector<many_body_op_t> const &qn_vector);
+      atom_diag(many_body_op_t const &h, fundamental_operator_set const &fops, std::initializer_list<many_body_op_t> const &init_lst)
+         : atom_diag(h, fops, std::vector<many_body_op_t>{init_lst}){};
 
       /// The Hamiltonian used at construction
       many_body_op_t const &get_h_atomic() const { return h_atomic; }

--- a/c++/triqs/atom_diag/impl/atom_diag.cpp
+++ b/c++/triqs/atom_diag/impl/atom_diag.cpp
@@ -43,7 +43,7 @@ namespace triqs {
 
     // -----------------------------------------------------------------
 
-    ATOM_DIAG_CONSTRUCTOR((many_body_op_t const &h, many_body_op_t const &hyb, fundamental_operator_set const &fops))
+    ATOM_DIAG_CONSTRUCTOR((many_body_op_t const &h, fundamental_operator_set const &fops, many_body_op_t const &hyb))
        : h_atomic(h), fops(fops), full_hs(fops), vacuum(full_hs.size()) {
       atom_diag_worker<Complex>{this}.autopartition(hyb);
       fill_first_eigenstate_of_subspace();

--- a/python/triqs/atom_diag/__init__.py
+++ b/python/triqs/atom_diag/__init__.py
@@ -37,7 +37,7 @@ def AtomDiag(*args, **kwargs):
     if any(abs(term[-1].imag) > 0 for term in h):
         return AtomDiagComplex(*args, **kwargs)
     else:
-        return AtomDiagReal(*args, **kwargs)
+        return AtomDiagReal(h.real, *args[1:], **{k: v for k, v in kwargs.items() if k != 'h'})
 
 AtomDiag.__doc__ = AtomDiagReal.__doc__.replace("Lightweight exact diagonalization solver (Real)",
                                                 "Create and return an exact diagonalization solver.\nDepending on the type of h returns :py:class:`AtomDiagReal <triqs.atom_diag.atom_diag.AtomDiagReal>` or :py:class:`AtomDiagComplex <triqs.atom_diag.atom_diag.AtomDiagComplex>`")

--- a/python/triqs/atom_diag/atom_diag_desc.py
+++ b/python/triqs/atom_diag/atom_diag_desc.py
@@ -84,7 +84,7 @@ for c_py, c_cpp, in (('Real','false'),('Complex','true')):
     c.add_constructor("(many_body_operator h, fundamental_operator_set fops, int n_min, int n_max)",
                       doc = "Reduce a given Hamiltonian to a block diagonal form, and diagonalize subspaces with particle numbers from n_min to n_max")
 
-    c.add_constructor("(many_body_operator h, many_body_operator hyb, fundamental_operator_set fops)",
+    c.add_constructor("(many_body_operator h, fundamental_operator_set fops, many_body_operator hyb)",
                       doc = "Reduce a given Hamiltonian to a block-diagonal form and respect the block structure defined by the operator hyb")
 
     c.add_constructor("(many_body_operator h, fundamental_operator_set fops, std::vector<%s::many_body_op_t> qn_vector)" % c_type,

--- a/test/c++/atom_diag/atom_diag_hyb.cpp
+++ b/test/c++/atom_diag/atom_diag_hyb.cpp
@@ -152,7 +152,7 @@ TEST(atom_diag_real, Autopartition2) {
   EXPECT_EQ(16, ad.get_full_hilbert_space_dim());
 
   std::printf("\n\n-----------------\n ad with hyb\n-----------------\n");
-  auto ad_hyb = atom_diag_real(h, hyb_effecive, fops);
+  auto ad_hyb = atom_diag_real(h, fops, hyb_effecive);
   print_atom_diag(ad_hyb);
 
   EXPECT_EQ(ad_hyb.n_subspaces(), 5);

--- a/test/python/atom_diag/CMakeLists.txt
+++ b/test/python/atom_diag/CMakeLists.txt
@@ -4,5 +4,6 @@ file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/${all_h5_files} DESTINATION ${CMAKE_CURREN
 
 add_python_test(atom_diag)
 add_python_test(issue819)
+add_python_test(atom_diag_constructors)
 
 add_python_test(atom_diag_bcast MPI_NUMPROC 4)

--- a/test/python/atom_diag/atom_diag_constructors.py
+++ b/test/python/atom_diag/atom_diag_constructors.py
@@ -9,27 +9,36 @@ from triqs.operators import n
 # many_body_operator h, fundamental_operator_set fops, std::vector<triqs::atom_diag::atom_diag<false>::many_body_op_t> qn_vector
 
 # list of tuple(args, kwargs) for constructor
-def get_param_list(h, fops, qn_vector, h_hyb):
+def get_param_list(h, fops, qn_vector, hyb):
     return [( [h, fops], {} ),
             ( [h, fops, qn_vector], {} ),
             ( [h], {'fops':fops, 'qn_vector':qn_vector} ),
             ( [], {'h':h, 'fops':fops, 'qn_vector':qn_vector} ),
             ( [h, fops], {'n_min':1, 'n_max':1} ),
-            ( [h, h_hyb, fops], {} ),
+            ( [h, hyb, fops], {} ),
     ]
 
 class test_atom_diag_constructors(unittest.TestCase):
 
     def setUp(self):
-        self.h_real = (1 + 0*1j) * n('up',0) * n('dn',0)
+        self.h_real = n('up',0) * n('dn',0)
+        self.h_real_valued = (1 + 0*1j) * n('up',0) * n('dn',0)
         self.h_complex = (1 + 1j) * n('up',0) * n('dn',0)
-        self.h_hyb_real = n('up',0) + n('dn',0)
-        self.h_hyb_complex = (1 + 1j) * n('up',0) + n('dn',0)
+        self.hyb_real = n('up',0) + n('dn',0)
+        self.hyb_complex = (1 + 1j) * n('up',0) + n('dn',0)
         self.fops = [('up',0), ('dn',0)]
         self.qn_vector = [n('up',0), n('dn',0)]
 
     def test_real(self):
-        for args, kwargs in get_param_list(self.h_real, self.fops, self.qn_vector, self.h_hyb_real):
+        for args, kwargs in get_param_list(self.h_real, self.fops, self.qn_vector, self.hyb_real):
+            with self.subTest(p1=args, p2=kwargs):
+                try:
+                    AtomDiag(*args, **kwargs)
+                except Exception as e:
+                    self.fail(f"args {args} and kwargs {kwargs} raised {e} !")
+
+    def test_real_valued(self):
+        for args, kwargs in get_param_list(self.h_real_valued, self.fops, self.qn_vector, self.hyb_real):
             with self.subTest(p1=args, p2=kwargs):
                 try:
                     AtomDiag(*args, **kwargs)
@@ -37,24 +46,28 @@ class test_atom_diag_constructors(unittest.TestCase):
                     self.fail(f"args {args} and kwargs {kwargs} raised {e} !")
 
     def test_complex(self):
-        for args, kwargs in get_param_list(self.h_complex, self.fops, self.qn_vector, self.h_hyb_complex):
+        for args, kwargs in get_param_list(self.h_complex, self.fops, self.qn_vector, self.hyb_complex):
             with self.subTest(p1=args, p2=kwargs):
                 try:
                     AtomDiag(*args, **kwargs)
                 except Exception as e:
                     self.fail(f"args {args} and kwargs {kwargs} raised {e} !")
-    
-    # Probably doesn't have to be tested
+
     def test_h_real_hyb_complex(self):
-        with self.assertRaises(Exception) as context:
-            AtomDiag(self.h_real, self.h_hyb_complex, self.fops)
-        self.assertTrue('the number is not real, it is complex' in str(context.exception))
+        for args, kwargs in get_param_list(self.h_real, self.fops, self.qn_vector, self.hyb_complex):
+            with self.subTest(p1=args, p2=kwargs):
+                try:
+                    AtomDiag(*args, **kwargs)
+                except Exception as e:
+                    self.fail(f"args {args} and kwargs {kwargs} raised {e} !")
 
     def test_h_complex_hyb_real(self):
-        try:
-            AtomDiag(self.h_complex, self.h_hyb_real, self.fops)
-        except Exception as e:
-            self.fail(f"h_complex and hybr_real raised {e} !")
+        for args, kwargs in get_param_list(self.h_complex, self.fops, self.qn_vector, self.hyb_real):
+            with self.subTest(p1=args, p2=kwargs):
+                try:
+                    AtomDiag(*args, **kwargs)
+                except Exception as e:
+                    self.fail(f"args {args} and kwargs {kwargs} raised {e} !")
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/python/atom_diag/atom_diag_constructors.py
+++ b/test/python/atom_diag/atom_diag_constructors.py
@@ -15,7 +15,7 @@ def get_param_list(h, fops, qn_vector, hyb):
             ( [h], {'fops':fops, 'qn_vector':qn_vector} ),
             ( [], {'h':h, 'fops':fops, 'qn_vector':qn_vector} ),
             ( [h, fops], {'n_min':1, 'n_max':1} ),
-            ( [h, hyb, fops], {} ),
+            ( [h, fops, hyb], {} ),
     ]
 
 class test_atom_diag_constructors(unittest.TestCase):

--- a/test/python/atom_diag/atom_diag_constructors.py
+++ b/test/python/atom_diag/atom_diag_constructors.py
@@ -1,0 +1,60 @@
+import unittest
+from triqs.atom_diag import AtomDiag
+from triqs.operators import n
+
+# possible constructors are
+# many_body_operator h, fundamental_operator_set fops
+# many_body_operator h, fundamental_operator_set fops, int n_min, int n_max
+# many_body_operator h, many_body_operator hyb, fundamental_operator_set fops
+# many_body_operator h, fundamental_operator_set fops, std::vector<triqs::atom_diag::atom_diag<false>::many_body_op_t> qn_vector
+
+# list of tuple(args, kwargs) for constructor
+def get_param_list(h, fops, qn_vector, h_hyb):
+    return [( [h, fops], {} ),
+            ( [h, fops, qn_vector], {} ),
+            ( [h], {'fops':fops, 'qn_vector':qn_vector} ),
+            ( [], {'h':h, 'fops':fops, 'qn_vector':qn_vector} ),
+            ( [h, fops], {'n_min':1, 'n_max':1} ),
+            ( [h, h_hyb, fops], {} ),
+    ]
+
+class test_atom_diag_constructors(unittest.TestCase):
+
+    def setUp(self):
+        self.h_real = (1 + 0*1j) * n('up',0) * n('dn',0)
+        self.h_complex = (1 + 1j) * n('up',0) * n('dn',0)
+        self.h_hyb_real = n('up',0) + n('dn',0)
+        self.h_hyb_complex = (1 + 1j) * n('up',0) + n('dn',0)
+        self.fops = [('up',0), ('dn',0)]
+        self.qn_vector = [n('up',0), n('dn',0)]
+
+    def test_real(self):
+        for args, kwargs in get_param_list(self.h_real, self.fops, self.qn_vector, self.h_hyb_real):
+            with self.subTest(p1=args, p2=kwargs):
+                try:
+                    AtomDiag(*args, **kwargs)
+                except Exception as e:
+                    self.fail(f"args {args} and kwargs {kwargs} raised {e} !")
+
+    def test_complex(self):
+        for args, kwargs in get_param_list(self.h_complex, self.fops, self.qn_vector, self.h_hyb_complex):
+            with self.subTest(p1=args, p2=kwargs):
+                try:
+                    AtomDiag(*args, **kwargs)
+                except Exception as e:
+                    self.fail(f"args {args} and kwargs {kwargs} raised {e} !")
+    
+    # Probably doesn't have to be tested
+    def test_h_real_hyb_complex(self):
+        with self.assertRaises(Exception) as context:
+            AtomDiag(self.h_real, self.h_hyb_complex, self.fops)
+        self.assertTrue('the number is not real, it is complex' in str(context.exception))
+
+    def test_h_complex_hyb_real(self):
+        try:
+            AtomDiag(self.h_complex, self.h_hyb_real, self.fops)
+        except Exception as e:
+            self.fail(f"h_complex and hybr_real raised {e} !")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes triqs/triqs#918

Forces h to be real when passed to AtomDiagReal

The unit test might also be useful to check that python is passing the correct objects to the c++ constructors.