### PR TITLE
[Gf] add constrained residual minimization dyson solver

### DIFF
--- a/python/triqs/gf/CMakeLists.txt
+++ b/python/triqs/gf/CMakeLists.txt
@@ -11,6 +11,7 @@ SET(PYTHON_SOURCES
   tools.py
   mesh_point.py
   matsubara_freq.py
+  dlr_crm_dyson_solver.py
 )
 
 add_cpp2py_module(meshes)

--- a/python/triqs/gf/dlr_crm_dyson_solver.py
+++ b/python/triqs/gf/dlr_crm_dyson_solver.py
@@ -1,0 +1,206 @@
+# Copyright (c) 2021-2024 Simons Foundation
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You may obtain a copy of the License at
+#     https:#www.gnu.org/licenses/gpl-3.0.txt
+#
+# Authors: Alexander Hampel, Harrison LaBollita, Nils Wentzell
+
+import numpy as np
+
+from scipy.optimize import minimize, NonlinearConstraint
+
+from triqs.gf import (
+    Gf,
+    BlockGf,
+    make_gf_dlr,
+    make_gf_dlr_imfreq,
+    inverse
+)
+from triqs.gf.meshes import MeshDLRImFreq, MeshDLRImTime, MeshDLR
+
+from triqs.utility import mpi
+
+import warnings
+
+warnings.filterwarnings('ignore', message='delta_grad == 0.0. Check if the approximated function is linear.')
+
+def minimize_dyson(
+    G0_dlr,
+    G_dlr,
+    Sigma_moments,
+    method='trust-constr',
+    options=dict(maxiter=5000, disp=True, gtol=1e-32, xtol=1e-100, finite_diff_rel_step=1e-20),
+    **kwargs,
+):
+    """
+    Contrained Residual Minimization Dyson solver as described in https://arxiv.org/abs/2310.01266
+
+    Defines the Dysons equation as an optimization problem:
+
+        G - G0 - G0*Σ*G = 0
+
+    and solves it using scipy.optimize.minimize using the DLR representation for the Green's functions.
+
+    The solver optimizes only the dynamic part of the self-energy Σ_dyn(iν)= Σ(iν) - Σ_0.
+    Here, Σ_0 is the Hartree shift. If provided the second moment Σ_1 is used as a non-linear constraint in the solver.
+
+    The moments can be explicitly calculated in the impurity solver, see for example the `cthyb high frequency moments tutorial <https://triqs.github.io/cthyb/latest/guide/high_freq_moments.html>`_ .
+
+    Alternatively the moments can be approximated by fitting the tail of the self-energy calculated via normal Dyson equation first:
+
+    >>> S_iw = inverse(G0_iw) - inverse(G_iw)
+    >>> tail, err = S_iw.fit_hermitian_tail()
+
+    and then used as input for the Dyson solver:
+
+    >>> S_iw_dlr, Sigma_HF, residual = minimize_dyson(G0_dlr=G0_dlr, G_dlr=G_dlr, Sigma_moments=tail[0:1])
+
+    The input G_dlr can for example obtained via `fit_gf_dlr` from a noisy imaginary time Green's function or by directly setting the DLR mesh points from a full `MeshImFreq` G_iw object:
+
+    >>> for iwn in G_dlr_iw.mesh:
+    >>>     G_dlr_iw[iwn] = G_full_iw(iwn)
+
+    Parameters
+    ----------
+    G0_dlr : triqs.gf.Gf or triqs.gf.BlockGf
+        non-interacting Green's function defined on a DLR, DLRImTime, or DLRImFreq mesh
+    G_dlr : triqs.gf.Gf or triqs.gf.BlockGf
+        interacting Green's function defined on a DLR, DLRImTime, or DLRImFreq mesh
+    Sigma_moments : list of numpy.ndarray or dict of list of numpy.ndarray
+        moments of Σ. The first moment is the Hartree shift, i.e. the constant part of Σ.
+        If provdided, use the second moment as a non-linear constraint for the Dyson solver.
+    method : str, optional
+        optimization method, defaults to 'trust-constr'
+        Note: For non-linear constraints this is one of the few available methods
+    options : dict, optional
+        optimization options, defaults to dict(maxiter=5000, disp=True, gtol=1e-32, xtol=1e-100, finite_diff_rel_step=1e-20)
+
+    Returns
+    -------
+    Sigma_DLR : triqs.gf.Gf or triqs.gf.BlockGf
+        optimized self-energy defined on a DLRImFreq mesh
+    Sigma_0 : numpy.ndarray
+        Hartree shift
+    residual : float
+        L2 norm of residual (G-G₀-G₀ΣG)
+
+    """
+
+    # recursive call for BlockGf, could be MPI parallelized
+    if isinstance(G_dlr, BlockGf) or isinstance(G0_dlr, BlockGf):
+        assert isinstance(G_dlr, BlockGf) and isinstance(G0_dlr, BlockGf), 'G0_dlr and G_dlr must be both Gf or BlockGf'
+        assert list(G_dlr.indices).sort() == list(G0_dlr.indices).sort(), 'G0_dlr and G_dlr must have the same block structure'
+        Sig_dlr_list = []
+        Sig_HF_list = {}
+        residual_dict = {}
+        for block, gtau in G_dlr:
+            Sig_dlr, Sig_HF, res = minimize_dyson(G0_dlr[block], G_dlr[block], Sigma_moments[block], method, options, **kwargs)
+            Sig_dlr_list.append(Sig_dlr)
+            Sig_HF_list[block] = Sig_HF
+            residual_dict[block] = res
+
+        Bgf_Sigma_iw_fit = BlockGf(name_list=list(G_dlr.indices), block_list=Sig_dlr_list)
+
+        return Bgf_Sigma_iw_fit, Sig_HF_list, residual_dict
+
+    # initial checks
+    if len(Sigma_moments) > 0:
+        assert G_dlr.target_shape == G0_dlr.target_shape == Sigma_moments.shape[1:], 'number of orbs inconsistent across G, G0, and moments'
+    else:
+        raise ValueError('Provide self-energy moments for the Dyson solver as list of numpy.ndarray or dict of list of numpy.ndarray')
+
+    # make sure we are working with matrix valued Green's functions
+    if len(G_dlr.target_shape) == 0:
+        G_dlr = Gf(mesh=G_dlr.mesh, data=G_dlr.data.reshape(-1, 1, 1))
+        G0_dlr = Gf(mesh=G0_dlr.mesh, data=G0_dlr.data.reshape(-1, 1, 1))
+        Sigma_moments = Sigma_moments.reshape(-1, 1, 1)
+        scalar_output = True
+    else:
+        scalar_output = False
+
+    # prepare meshes
+    def to_dlr_imfreq(G):
+        if isinstance(G.mesh, (MeshDLRImTime, MeshDLR)):
+            return make_gf_dlr_imfreq(G)
+        elif isinstance(G.mesh, MeshDLRImFreq):
+            return G
+        else:
+            raise ValueError(f'minimize_dyson input Green functions must be defined on MeshDLRImFreq, MeshDLRImTime, or MeshDLR, but got {G.mesh}')
+
+    g0_iwaa  = to_dlr_imfreq(G0_dlr)
+    g_iwaa   = to_dlr_imfreq(G_dlr)
+    assert g0_iwaa.mesh == g_iwaa.mesh, f'G0_dlr and G_dlr have incompatible dlr meshes {g0_iwaa.mesh} and {g_iwaa.mesh}'
+    mesh_iw  = g_iwaa.mesh
+
+    # Gf / mat -> vector conversion
+    def flatten(arr):
+        return arr.flatten().view(float)
+
+    # vector > Gf / mat conversion
+    def unflatten(vec):
+        return vec.view(complex).reshape(G_dlr.data.shape)
+
+    # setup constraints
+    if len(Sigma_moments) == 1:
+        constraints = ()
+    else:  # len(Sigma_moments) >= 2, use only the second moment
+
+        def constraint_func(x):
+            """
+            constraint condition: ∑σk =  Σ_1
+            """
+            temp = Gf(mesh=mesh_iw, data=unflatten(x))
+            sig = make_gf_dlr(temp)
+            mat = sig.data.sum(axis=0)
+            vec = flatten(mat)
+            return vec
+
+        bound = flatten(Sigma_moments[1])
+        constraints = NonlinearConstraint(constraint_func, bound, bound)
+
+    # target function for minimization
+    def dyson_difference(x):
+        """
+        target function for minimize
+        """
+        sig_iwaa = Gf(mesh=mesh_iw, data=unflatten(x))
+        sig_iwaa += Sigma_moments[0]
+        #  G - G0 - G0*Σ*G = 0 done on the DLR nodes
+        r_iwaa = g_iwaa - g0_iwaa - g0_iwaa * sig_iwaa * g_iwaa
+        # the Frobeinus norm
+        r = np.sqrt(np.sum(r_iwaa.tau_L2_norm() ** 2))
+        return r
+
+    # compute initial guess for Sigma from Dyson equation
+    sig0_iwaa = inverse(g0_iwaa) - inverse(g_iwaa) - Sigma_moments[0]
+    x_init = flatten(sig0_iwaa.data)
+
+    # run solver to optimize Σ(iν)
+    solution = minimize(dyson_difference, x_init, method=method, constraints=constraints, options=options)
+
+    mpi.report(solution.message)
+    if not solution.success:
+        mpi.report('[WARNING] Minimization did not converge! Please proceed with caution!')
+
+    # create optimized self-energy from minimizer
+    sig_iwaa = Gf(mesh=mesh_iw, data=unflatten(solution.x))
+
+    mpi.report(f'L2 norm of residual (G-G₀-G₀ΣG): {solution.fun:.4e}')
+    if len(Sigma_moments) >= 2:
+        constraint_violation = np.max(np.abs(make_gf_dlr(sig_iwaa).data.sum(axis=0) - Sigma_moments[1]))
+        mpi.report(f'Σ1 constraint diff: {constraint_violation:.4e}')
+
+    if scalar_output:
+        return sig_iwaa[0, 0], Sigma_moments[0][0, 0], solution.fun
+    else:
+        return sig_iwaa, Sigma_moments[0], solution.fun

--- a/python/triqs/gf/gf_fnt_desc.py
+++ b/python/triqs/gf/gf_fnt_desc.py
@@ -66,6 +66,13 @@ m.add_function("dcomplex density(gf_view<dlr_imfreq, scalar_valued> g)", doc = "
 m.add_function("matrix<dcomplex> density(gf_view<dlr_imtime, matrix_valued> g)", doc = "Density, as a matrix, computed from evaluation in imaginary time")
 m.add_function("dcomplex density(gf_view<dlr_imtime, scalar_valued> g)", doc = "Density, as a complex, computed from evaluation in imaginary time")
 
+# L2 tau norm of DLR Green's function
+for mesh in ['dlr', 'dlr_imfreq', 'dlr_imtime']:
+    for gf_type in ["gf_view", "block_gf_view"]:
+        for target in ["scalar_valued", "matrix_valued"]:
+            m.add_function(f"auto tau_L2_norm({gf_type}<{mesh}, {target}> g)",
+              doc = "Calculate the L2 norm of the DLR Green's function in imaginary time: 1/beta * int_0^beta dt conj(g(t)) g(t). Calculates the norm individually for each set of target indices and each block.")
+
 # ---------------------- miscellaneous --------------------
 for Target in  ["scalar_valued", "tensor_valued<1>", "matrix_valued", "tensor_valued<3>", "tensor_valued<4>"]:
 

--- a/test/python/base/CMakeLists.txt
+++ b/test/python/base/CMakeLists.txt
@@ -67,3 +67,6 @@ add_python_test(cyclic_lattice)
 
 # discretize bath
 add_python_test(discretize_bath)
+
+# constrained residual minimization Dyson solver
+add_python_test(crm_dyson_solver)

--- a/test/python/base/crm_dyson_solver.py
+++ b/test/python/base/crm_dyson_solver.py
@@ -1,0 +1,153 @@
+# Copyright (c) 2021-2024 Simons Foundation
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You may obtain a copy of the License at
+#     https:#www.gnu.org/licenses/gpl-3.0.txt
+#
+# Authors: Alexander Hampel, Harrison LaBollita, Nils Wentzell
+
+import numpy as np
+
+from triqs.gf import Gf, iOmega_n, inverse, BlockGf, make_gf_dlr, make_gf_imfreq, make_gf_dlr_imfreq
+from triqs.gf.meshes import MeshImFreq, MeshDLRImTime
+from triqs.gf.dlr_crm_dyson_solver import minimize_dyson
+from triqs.utility.comparison_tests import assert_gfs_are_close
+
+import unittest
+
+
+class test_crm_dyson_solver(unittest.TestCase):
+    def setUp(self):
+        self.U = 2.0
+        self.beta = 20
+        self.w_max = 4
+        self.lamb = self.beta * self.w_max
+        self.n_iw = 1000
+        self.eps = 1e-10
+        # noise on input G_tau
+        self.tol = 1e-8
+        self.eps1 = 0.5 * self.U
+        self.eps2 = -0.5 * self.U
+        np.random.seed(85281)
+        # create reference solution on full mesh
+        self.iw_mesh = MeshImFreq(beta=self.beta, S='Fermion', n_iw=self.n_iw)
+        self.Sigma_iw_ref = Gf(mesh=self.iw_mesh, target_shape=[1, 1])
+        self.Sigma_iw_ref << self.U / 2 + 0.25 * self.U * self.U * inverse(iOmega_n)
+        # Specify the moments
+        self.moments = np.array([self.U / 2, 0.25 * self.U * self.U], dtype=complex).reshape(2, 1, 1)
+
+    # Create input Green functions: Non-interacting and interacting Green function of the Hubbard atom
+    def make_G0_G_HubbardAtom(self, target_shape):
+        mesh_dlr_tau = MeshDLRImTime(beta=self.beta, statistic='Fermion', w_max=self.w_max, eps=self.eps)
+        G0_tau = Gf(mesh=mesh_dlr_tau, target_shape=target_shape)
+        G_tau = Gf(mesh=mesh_dlr_tau, target_shape=target_shape)
+
+        one_fermion = lambda eps, t: -np.exp((self.beta * (eps < 0) - t) * eps) / (1.0 + np.exp(-self.beta * abs(eps)))
+        for t in mesh_dlr_tau:
+            if target_shape == []:
+                G0_tau[t] = one_fermion(self.eps2, t)
+                G_tau[t] = 0.5 * one_fermion(self.eps1, t) + 0.5 * one_fermion(self.eps2, t)
+            else:
+                np.fill_diagonal(G0_tau[t], one_fermion(self.eps2, t))
+                np.fill_diagonal(G_tau[t], 0.5 * one_fermion(self.eps1, t) + 0.5 * one_fermion(self.eps2, t))
+
+        return G0_tau, G_tau
+
+    def test_DLRImTime_constraint(self):
+        # create input data from Hubbard atom with tol noise
+        G0_tau, G_tau = self.make_G0_G_HubbardAtom(target_shape=[1, 1])
+        G_tau.data[:] += np.random.normal(scale=self.tol, size=G_tau.data.shape)
+
+        # run CRM Dyson solver with constraints
+        Sigma_dlr, Sigma_HF, residual = minimize_dyson(G0_dlr=G0_tau, G_dlr=G_tau, Sigma_moments=self.moments)
+        assert residual < 1e-5
+
+        # comparison with reference solution
+        Sigma_iw_crm = make_gf_imfreq(Sigma_dlr, n_iw=self.n_iw)
+        Sigma_iw_crm += Sigma_HF
+        assert_gfs_are_close(Sigma_iw_crm, self.Sigma_iw_ref, 1e-5)
+
+        # analytic moments of self-energy, use only first moment as constraint for testing
+        bS_moments = {'up': self.moments[0:1], 'dn': self.moments[0:1]}
+
+        # create block Gf
+        bG0_tau = BlockGf(name_list=['up', 'dn'], block_list=[G0_tau, G0_tau], make_copies=True)
+        bG_tau = BlockGf(name_list=['up', 'dn'], block_list=[G_tau, G_tau], make_copies=True)
+
+        # run CRM Dyson solver with constraints
+        Sigma_dlr, Sigma_HF, residual = minimize_dyson(G0_dlr=bG0_tau, G_dlr=bG_tau, Sigma_moments=bS_moments)
+
+        for b in ['up', 'dn']:
+            assert residual[b] < 1e-5
+            # comparison with reference solution
+            Sigma_iw_crm = make_gf_imfreq(Sigma_dlr[b], n_iw=self.n_iw)
+            Sigma_iw_crm += Sigma_HF[b]
+            assert_gfs_are_close(Sigma_iw_crm, self.Sigma_iw_ref, 1e-5)
+
+    def test_DLRImFreq_HF(self):
+        # create input data from Hubbard atom with tol noise
+        G0_tau, G_tau = self.make_G0_G_HubbardAtom(target_shape=[1, 1])
+        G_tau.data[:] += np.random.normal(scale=self.tol, size=G_tau.data.shape)
+
+        G_iw = make_gf_dlr_imfreq(G_tau)
+        G0_iw = make_gf_dlr_imfreq(G0_tau)
+
+        # run CRM Dyson solver with constraints
+        Sigma_dlr, Sigma_HF, residual = minimize_dyson(G0_dlr=G0_iw, G_dlr=G_iw, Sigma_moments=self.moments)
+        assert residual < 1e-5
+
+        # comparison with reference solution
+        Sigma_iw_crm = make_gf_imfreq(Sigma_dlr, n_iw=self.n_iw)
+        Sigma_iw_crm += Sigma_HF
+        assert_gfs_are_close(Sigma_iw_crm, self.Sigma_iw_ref, 1e-5)
+
+    def test_DLR_scalar(self):
+        # create input data from Hubbard atom with tol noise
+        G0_tau, G_tau = self.make_G0_G_HubbardAtom(target_shape=[])
+        G_tau.data[:] += np.random.normal(scale=self.tol, size=G_tau.data.shape)
+
+        G_dlr = make_gf_dlr(G_tau)
+        G0_dlr = make_gf_dlr(G0_tau)
+
+        # run CRM Dyson solver with constraints
+        mom_scalar = self.moments[:, 0, 0]
+        Sigma_dlr, Sigma_HF, residual = minimize_dyson(G0_dlr=G0_dlr, G_dlr=G_dlr, Sigma_moments=mom_scalar)
+        assert residual < 1e-5
+
+        # comparison with reference solution
+        Sigma_iw_crm = make_gf_imfreq(Sigma_dlr, n_iw=self.n_iw)
+        Sigma_iw_crm += Sigma_HF
+        assert_gfs_are_close(Sigma_iw_crm, self.Sigma_iw_ref[0, 0], 1e-5)
+
+    def test_mat_DLRImTime_tailfit(self):
+        # create input data from Hubbard atom with tol noise
+        G0_tau, G_tau = self.make_G0_G_HubbardAtom(target_shape=[2, 2])
+        G_tau.data[:] += np.random.normal(scale=self.tol, size=G_tau.data.shape)
+
+        # get estimate of Hartree shift from tail fit on noisy sigma
+        G_iw = make_gf_imfreq(G_tau, n_iw=self.n_iw)
+        G0_iw = make_gf_imfreq(G0_tau, n_iw=self.n_iw)
+        S_iw = inverse(G0_iw) - inverse(G_iw)
+        tail, err = S_iw.fit_hermitian_tail()
+
+        # run CRM Dyson solver with constraints
+        Sigma_dlr, Sigma_HF, residual = minimize_dyson(G0_dlr=G0_tau, G_dlr=G_tau, Sigma_moments=tail[0:1])
+        assert residual < 1e-5
+
+        # comparison with reference solution
+        Sigma_iw_crm = make_gf_imfreq(Sigma_dlr, n_iw=self.n_iw)
+        Sigma_iw_crm += Sigma_HF
+        assert_gfs_are_close(Sigma_iw_crm[0:1,0:1], self.Sigma_iw_ref, 1e-5)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
* add l2 tau norm function from cppdlr
* add tests for l2 tau norm
* fix loss of prec warning in DLR tests
* add Python bindings for constructors of DLR meshes from other DLR meshes
* add constrained residual minimization (CRM) function to solve Dyson's equation https://arxiv.org/abs/2310.01266
* add tests for CRM Dyson solver

Example of the method for a 3orbital Bethe lattice test at n=0.8 filling with realistic QMC data at beta=1000 eV for D=1 (half-bandwidth):
![crm_test_b1000](https://github.com/TRIQS/triqs/assets/21337117/b6c474dd-89f5-4897-b363-564e36de1c7a)

