### PR TITLE
Allow different memory layouts for block_gf and block_gf_view

### DIFF
--- a/c++/triqs/cpp2py_converters/gf.hpp
+++ b/c++/triqs/cpp2py_converters/gf.hpp
@@ -42,7 +42,7 @@ namespace cpp2py {
   template <typename M, typename T> struct is_view<triqs::gfs::gf_view<M, T>> : std::true_type {};
   template <typename M, typename T> struct is_view<triqs::gfs::gf_const_view<M, T>> : std::true_type {};
 
-  template <typename M, typename T, int A, bool C> struct is_view<triqs::gfs::block_gf_view<M, T, A, C>> : std::true_type {};
+  template <typename M, typename T, typename L, int A, bool C> struct is_view<triqs::gfs::block_gf_view<M, T, L, A, C>> : std::true_type {};
 
   // -----------------------------------
   //   gf
@@ -147,11 +147,11 @@ namespace cpp2py {
   //   block_gf
   // -----------------------------------
 
-  template <typename M, typename T, int A> struct py_converter<triqs::gfs::block_gf<M, T, A>> {
-    using conv_t = py_converter<triqs::gfs::block_gf_view<M, T, A>>;
-    using c_type = triqs::gfs::block_gf<M, T, A>;
+  template <typename M, typename T, int A> struct py_converter<triqs::gfs::block_gf<M, T, C_layout, A>> {
+    using conv_t = py_converter<triqs::gfs::block_gf_view<M, T, C_stride_layout, A>>;
+    using c_type = triqs::gfs::block_gf<M, T, C_layout, A>;
 
-    static PyObject *c2py(triqs::gfs::block_gf_view<M, T, A> g) { return conv_t::c2py(g); }
+    static PyObject *c2py(triqs::gfs::block_gf_view<M, T, C_stride_layout, A> g) { return conv_t::c2py(g); }
     static bool is_convertible(PyObject *ob, bool raise_exception) { return conv_t::is_convertible(ob, raise_exception); }
     static c_type py2c(PyObject *ob) { return c_type{conv_t::py2c(ob)}; }
   };
@@ -160,9 +160,9 @@ namespace cpp2py {
   //   block_gf_const_view
   // -----------------------------------
 
-  template <typename M, typename T, int A> struct py_converter<triqs::gfs::block_gf_const_view<M, T, A>> {
-    using conv_t = py_converter<triqs::gfs::block_gf_view<M, T, A>>;
-    using c_type = triqs::gfs::block_gf_const_view<M, T, A>;
+  template <typename M, typename T, int A> struct py_converter<triqs::gfs::block_gf_const_view<M, T, C_stride_layout, A>> {
+    using conv_t = py_converter<triqs::gfs::block_gf_view<M, T, C_stride_layout, A>>;
+    using c_type = triqs::gfs::block_gf_const_view<M, T, C_stride_layout, A>;
 
     static PyObject *c2py(c_type g) = delete; // You can not convert a C++ const_view to a Python Gf ! Violates const correctness.
     static bool is_convertible(PyObject *ob, bool raise_exception) { return conv_t::is_convertible(ob, raise_exception); }

--- a/c++/triqs/gfs/block/expr.hpp
+++ b/c++/triqs/gfs/block/expr.hpp
@@ -148,10 +148,14 @@ namespace triqs {
     // we implement them trivially.
 
 #define DEFINE_OPERATOR(OP1, OP2)                                                                                                                    \
-  template <typename Mesh, typename Target, int Arity, typename T> void operator OP1(block_gf_view<Mesh, Target, Arity> g, T const &x) {             \
+  template <typename Mesh, typename Target, typename Layout, int Arity, typename T>                                                                  \
+  void operator OP1(block_gf_view<Mesh, Target, Layout, Arity> g, T const &x) {                                                                      \
     g = g OP2 x;                                                                                                                                     \
   }                                                                                                                                                  \
-  template <typename Mesh, typename Target, int Arity, typename T> void operator OP1(block_gf<Mesh, Target, Arity> &g, T const &x) { g = g OP2 x; }
+  template <typename Mesh, typename Target, typename Layout, int Arity, typename T>                                                                  \
+  void operator OP1(block_gf<Mesh, Target, Layout, Arity> &g, T const &x) {                                                                          \
+    g = g OP2 x;                                                                                                                                     \
+  }
 
     DEFINE_OPERATOR(+=, +);
     DEFINE_OPERATOR(-=, -);

--- a/c++/triqs/gfs/block/factories.hpp
+++ b/c++/triqs/gfs/block/factories.hpp
@@ -22,24 +22,27 @@ namespace triqs::gfs {
   // -------------------------------   Free Factories for regular type  --------------------------------------------------
 
   ///
-  template <typename V, typename T> block_gf<V, T> make_block_gf(int n, gf<V, T> const &g) { return {n, g}; }
+  template <typename V, typename T, typename L> block_gf<V, T, L> make_block_gf(int n, gf<V, T, L> const &g) { return {n, g}; }
 
   ///
-  template <typename V, typename T> block_gf<V, T> make_block_gf(std::vector<gf<V, T>> v) { return {std::move(v)}; }
+  template <typename V, typename T, typename L> block_gf<V, T, L> make_block_gf(std::vector<gf<V, T, L>> v) { return {std::move(v)}; }
 
   ///
-  template <typename V, typename T> block_gf<V, T> make_block_gf(std::initializer_list<gf<V, T>> const &v) { return {v}; }
+  template <typename V, typename T, typename L> block_gf<V, T, L> make_block_gf(std::initializer_list<gf<V, T, L>> const &v) { return {v}; }
 
   ///
-  template <typename V, typename T> block_gf<V, T> make_block_gf(std::vector<std::string> const &b, gf<V, T> const &g) { return {b, g}; }
+  template <typename V, typename T, typename L> block_gf<V, T, L> make_block_gf(std::vector<std::string> const &b, gf<V, T, L> const &g) {
+    return {b, g};
+  }
 
   ///
-  template <typename V, typename T> block_gf<V, T> make_block_gf(std::vector<std::string> const &b, std::vector<gf<V, T>> v) {
+  template <typename V, typename T, typename L> block_gf<V, T, L> make_block_gf(std::vector<std::string> const &b, std::vector<gf<V, T, L>> v) {
     return {b, std::move(v)};
   }
 
   ///
-  template <typename V, typename T> block_gf<V, T> make_block_gf(std::vector<std::string> b, std::initializer_list<gf<V, T>> const &v) {
+  template <typename V, typename T, typename L>
+  block_gf<V, T, L> make_block_gf(std::vector<std::string> b, std::initializer_list<gf<V, T, L>> const &v) {
     return {b, v};
   }
 
@@ -99,12 +102,12 @@ namespace triqs::gfs {
   // -------------------------------   Free Factories for block2_gf   --------------------------------------------------
 
   /// From the size n x p and the g from a number and a gf to be copied
-  template <typename V, typename T> block2_gf<V, T> make_block2_gf(int n, int p, gf<V, T> const &g) { return {n, p, g}; }
+  template <typename V, typename T, typename L> block2_gf<V, T, L> make_block2_gf(int n, int p, gf<V, T, L> const &g) { return {n, p, g}; }
 
   // from vector<tuple<string,string>>, vector<gf>
-  template <typename V, typename T>
-  block2_gf<V, T> make_block2_gf(std::vector<std::string> const &block_names1, std::vector<std::string> const &block_names2,
-                                 std::vector<std::vector<gf<V, T>>> vv) {
+  template <typename V, typename T, typename L>
+  block2_gf<V, T, L> make_block2_gf(std::vector<std::string> const &block_names1, std::vector<std::string> const &block_names2,
+                                    std::vector<std::vector<gf<V, T, L>>> vv) {
     if (block_names1.size() != vv.size())
       TRIQS_RUNTIME_ERROR << "make_block2_gf(vector<string>, vector<string>>, vector<vector<gf>>): incompatible outer vector size!";
     for (auto const &v : vv) {

--- a/c++/triqs/gfs/block/functions.hpp
+++ b/c++/triqs/gfs/block/functions.hpp
@@ -19,15 +19,15 @@
 
 namespace triqs::gfs {
 
-  template <typename V, typename T, int A> auto fourier(block_gf<V, T, A> const &g) {
+  template <typename V, typename T, typename L, int A> auto fourier(block_gf<V, T, L, A> const &g) {
     return make_lazy_transform([](auto &&x) { return fourier(x); }, g);
   };
 
-  template <typename V, typename T, int A> auto fourier(block_gf<V, T, A> &g) {
+  template <typename V, typename T, typename L, int A> auto fourier(block_gf<V, T, L, A> &g) {
     return make_lazy_transform([](auto &&x) { return fourier(x); }, g);
   };
 
-  template <typename V, typename T, int A, bool C> auto fourier(block_gf_view<V, T, A, C> g) {
+  template <typename V, typename T, typename L, int A, bool C> auto fourier(block_gf_view<V, T, L, A, C> g) {
     return make_lazy_transform([](auto &&x) { return fourier(x); }, g);
   };
 

--- a/c++/triqs/gfs/block/mapped_functions.hxx
+++ b/c++/triqs/gfs/block/mapped_functions.hxx
@@ -16,17 +16,17 @@
   
     VIMEXPAND inverse reinterpret_scalar_valued_gf_as_matrix_valued make_gf_from_fourier make_gf_from_inverse_fourier
     ///
-    template <typename M, typename T, int A> auto @(block_gf<M, T, A> &g) {
+    template <typename M, typename T, typename L, int A> auto @(block_gf<M, T, L, A> &g) {
       auto l = [](auto &&x) { return @(x); };
       return map_block_gf(l, g);
     }
     ///
-    template <typename M, typename T, int A> auto @(block_gf<M, T, A> const &g) {
+    template <typename M, typename T, typename L, int A> auto @(block_gf<M, T, L, A> const &g) {
       auto l = [](auto &&x) { return @(x); };
       return map_block_gf(l, g);
     }
     ///  
-    template <typename M, typename T, int A, bool C> auto @(block_gf_view<M, T, A, C> g) {
+    template <typename M, typename T, typename L, int A, bool C> auto @(block_gf_view<M, T, L, A, C> g) {
       auto l = [](auto &&x) { return @(x); };
       return map_block_gf(l, g);
     }
@@ -38,65 +38,65 @@ namespace triqs::gfs {
   // --- VIMEXPAND_START  --DO NOT EDIT BELOW --
 
   ///
-  template <typename M, typename T, int A> auto inverse(block_gf<M, T, A> &g) {
+  template <typename M, typename T, typename L, int A> auto inverse(block_gf<M, T, L, A> &g) {
     auto l = [](auto &&x) { return inverse(x); };
     return map_block_gf(l, g);
   }
   ///
-  template <typename M, typename T, int A> auto inverse(block_gf<M, T, A> const &g) {
+  template <typename M, typename T, typename L, int A> auto inverse(block_gf<M, T, L, A> const &g) {
     auto l = [](auto &&x) { return inverse(x); };
     return map_block_gf(l, g);
   }
   ///
-  template <typename M, typename T, int A, bool C> auto inverse(block_gf_view<M, T, A, C> g) {
+  template <typename M, typename T, typename L, int A, bool C> auto inverse(block_gf_view<M, T, L, A, C> g) {
     auto l = [](auto &&x) { return inverse(x); };
     return map_block_gf(l, g);
   }
 
   ///
-  template <typename M, typename T, int A> auto reinterpret_scalar_valued_gf_as_matrix_valued(block_gf<M, T, A> &g) {
+  template <typename M, typename T, typename L, int A> auto reinterpret_scalar_valued_gf_as_matrix_valued(block_gf<M, T, L, A> &g) {
     auto l = [](auto &&x) { return reinterpret_scalar_valued_gf_as_matrix_valued(x); };
     return map_block_gf(l, g);
   }
   ///
-  template <typename M, typename T, int A> auto reinterpret_scalar_valued_gf_as_matrix_valued(block_gf<M, T, A> const &g) {
+  template <typename M, typename T, typename L, int A> auto reinterpret_scalar_valued_gf_as_matrix_valued(block_gf<M, T, L, A> const &g) {
     auto l = [](auto &&x) { return reinterpret_scalar_valued_gf_as_matrix_valued(x); };
     return map_block_gf(l, g);
   }
   ///
-  template <typename M, typename T, int A, bool C> auto reinterpret_scalar_valued_gf_as_matrix_valued(block_gf_view<M, T, A, C> g) {
+  template <typename M, typename T, typename L, int A, bool C> auto reinterpret_scalar_valued_gf_as_matrix_valued(block_gf_view<M, T, L, A, C> g) {
     auto l = [](auto &&x) { return reinterpret_scalar_valued_gf_as_matrix_valued(x); };
     return map_block_gf(l, g);
   }
 
   ///
-  template <typename M, typename T, int A> auto make_gf_from_fourier(block_gf<M, T, A> &g) {
+  template <typename M, typename T, typename L, int A> auto make_gf_from_fourier(block_gf<M, T, L, A> &g) {
     auto l = [](auto &&x) { return make_gf_from_fourier(x); };
     return map_block_gf(l, g);
   }
   ///
-  template <typename M, typename T, int A> auto make_gf_from_fourier(block_gf<M, T, A> const &g) {
+  template <typename M, typename T, typename L, int A> auto make_gf_from_fourier(block_gf<M, T, L, A> const &g) {
     auto l = [](auto &&x) { return make_gf_from_fourier(x); };
     return map_block_gf(l, g);
   }
   ///
-  template <typename M, typename T, int A, bool C> auto make_gf_from_fourier(block_gf_view<M, T, A, C> g) {
+  template <typename M, typename T, typename L, int A, bool C> auto make_gf_from_fourier(block_gf_view<M, T, L, A, C> g) {
     auto l = [](auto &&x) { return make_gf_from_fourier(x); };
     return map_block_gf(l, g);
   }
 
   ///
-  template <typename M, typename T, int A> auto make_gf_from_inverse_fourier(block_gf<M, T, A> &g) {
+  template <typename M, typename T, typename L, int A> auto make_gf_from_inverse_fourier(block_gf<M, T, L, A> &g) {
     auto l = [](auto &&x) { return make_gf_from_inverse_fourier(x); };
     return map_block_gf(l, g);
   }
   ///
-  template <typename M, typename T, int A> auto make_gf_from_inverse_fourier(block_gf<M, T, A> const &g) {
+  template <typename M, typename T, typename L, int A> auto make_gf_from_inverse_fourier(block_gf<M, T, L, A> const &g) {
     auto l = [](auto &&x) { return make_gf_from_inverse_fourier(x); };
     return map_block_gf(l, g);
   }
   ///
-  template <typename M, typename T, int A, bool C> auto make_gf_from_inverse_fourier(block_gf_view<M, T, A, C> g) {
+  template <typename M, typename T, typename L, int A, bool C> auto make_gf_from_inverse_fourier(block_gf_view<M, T, L, A, C> g) {
     auto l = [](auto &&x) { return make_gf_from_inverse_fourier(x); };
     return map_block_gf(l, g);
   }

--- a/c++/triqs/gfs/block/mpi.hpp
+++ b/c++/triqs/gfs/block/mpi.hpp
@@ -33,7 +33,8 @@ namespace triqs::gfs {
     *
     */
   // mako ${mpidoc("Bcast")}
-  template <typename V, typename T, int Arity> void mpi_broadcast(block_gf<V, T, Arity> &g, mpi::communicator c = {}, int root = 0) {
+  template <typename V, typename T, typename Layout, int Arity>
+  void mpi_broadcast(block_gf<V, T, Layout, Arity> &g, mpi::communicator c = {}, int root = 0) {
     // Shall we bcast mesh ?
     mpi::broadcast(g.data(), c, root);
   }
@@ -52,8 +53,8 @@ namespace triqs::gfs {
     *
     */
   // mako ${mpidoc("Bcast")}
-  template <typename V, typename T, int Arity, bool IsConst>
-  void mpi_broadcast(block_gf_view<V, T, Arity, IsConst> &g, mpi::communicator c = {}, int root = 0) {
+  template <typename V, typename T, typename Layout, int Arity, bool IsConst>
+  void mpi_broadcast(block_gf_view<V, T, Layout, Arity, IsConst> &g, mpi::communicator c = {}, int root = 0) {
     // Shall we bcast mesh ?
     mpi::broadcast(g.data(), c, root);
   }
@@ -70,9 +71,9 @@ namespace triqs::gfs {
     * @param root The root of the broadcast communication in the MPI sense.
     * @return Returns a lazy object describing the object and the MPI operation to be performed.
     */
-  template <typename V, typename T, int Arity>
-  mpi::lazy<mpi::tag::reduce, block_gf_const_view<V, T, Arity>> mpi_reduce(block_gf<V, T, Arity> const &a, mpi::communicator c = {}, int root = 0,
-                                                                           bool all = false, MPI_Op op = MPI_SUM) {
+  template <typename V, typename T, typename Layout, int Arity>
+  mpi::lazy<mpi::tag::reduce, typename block_gf<V, T, Layout, Arity>::const_view_type>
+  mpi_reduce(block_gf<V, T, Layout, Arity> const &a, mpi::communicator c = {}, int root = 0, bool all = false, MPI_Op op = MPI_SUM) {
     return {a(), c, root, all, op};
   }
 
@@ -88,9 +89,9 @@ namespace triqs::gfs {
     * @param root The root of the broadcast communication in the MPI sense.
     * @return Returns a lazy object describing the object and the MPI operation to be performed.
     */
-  template <typename V, typename T, int Arity, bool IsConst>
-  mpi::lazy<mpi::tag::reduce, block_gf_const_view<V, T, Arity>> mpi_reduce(block_gf_view<V, T, Arity, IsConst> const &a, mpi::communicator c = {},
-                                                                           int root = 0, bool all = false, MPI_Op op = MPI_SUM) {
+  template <typename V, typename T, typename Layout, int Arity, bool IsConst>
+  mpi::lazy<mpi::tag::reduce, block_gf_const_view<V, T, Layout, Arity>>
+  mpi_reduce(block_gf_view<V, T, Layout, Arity, IsConst> const &a, mpi::communicator c = {}, int root = 0, bool all = false, MPI_Op op = MPI_SUM) {
     return {a, c, root, all, op};
   }
 

--- a/c++/triqs/gfs/functions/density.hpp
+++ b/c++/triqs/gfs/functions/density.hpp
@@ -48,8 +48,7 @@ namespace triqs {
      * @return auto A tensor/matrix or a scalar, depending on the target
      */
     auto density(MemoryGf<mesh::dlr> auto const &g) {
-      auto res = g.target().make_value();
-      res      = -g(g.mesh().beta());
+      auto res = make_regular(-g(g.mesh().beta()));
       // Transpose to get <cdag_i c_j> instead of <cdag_j c_i>
       if constexpr (requires { transpose(res); }) {
         res = transpose(res);

--- a/c++/triqs/gfs/gf/gf.hpp
+++ b/c++/triqs/gfs/gf/gf.hpp
@@ -145,12 +145,6 @@ namespace triqs::gfs {
       target_shape_t _shape;
       using target_t = Target;
       target_shape_t const &shape() const { return _shape; }
-      typename Target::value_t make_value() const {
-        if constexpr (target_t::rank == 0)
-          return 0;
-        else
-          return typename Target::value_t{shape()};
-      }
     };
 
     // ------------- Accessors -----------------------------

--- a/c++/triqs/gfs/gf/gf.hpp
+++ b/c++/triqs/gfs/gf/gf.hpp
@@ -69,6 +69,11 @@ namespace triqs::gfs {
       return g.mesh();
   }
 
+  /// ---------------------------  target_value_t  ---------------------------------
+
+  // Trait to obtain the type of the values obtained when accessing the Green function with a mesh point
+  template <MemoryGf G> using target_value_t = decltype(std::declval<G>()[std::declval<typename G::mesh_point_t>()]);
+
   /// ---------------------------  tags for some implementation details  ---------------------------------
 
   struct impl_tag {};

--- a/c++/triqs/gfs/gf/gf_const_view.hpp
+++ b/c++/triqs/gfs/gf/gf_const_view.hpp
@@ -86,12 +86,6 @@ namespace triqs::gfs {
       target_shape_t _shape;
       using target_t = Target;
       target_shape_t const &shape() const { return _shape; }
-      typename Target::value_t make_value() const {
-        if constexpr (target_t::rank == 0)
-          return 0;
-        else
-          return typename Target::value_t{shape()};
-      }
     };
 
     // ------------- Accessors -----------------------------

--- a/c++/triqs/gfs/gf/gf_view.hpp
+++ b/c++/triqs/gfs/gf/gf_view.hpp
@@ -87,12 +87,6 @@ namespace triqs::gfs {
       target_shape_t _shape;
       using target_t = Target;
       target_shape_t const &shape() const { return _shape; }
-      typename Target::value_t make_value() const {
-        if constexpr (target_t::rank == 0)
-          return 0;
-        else
-          return typename Target::value_t{shape()};
-      }
     };
 
     // ------------- Accessors -----------------------------
@@ -283,7 +277,7 @@ namespace triqs::gfs {
  *                                     View  assignment
  *-----------------------------------------------------------------------------------------------------*/
 
-  template <typename M, typename T, typename RHS> void triqs_gf_view_assign_delegation(gf_view<M, T> g, RHS const &rhs) {
+  template <typename M, typename T, typename L, typename RHS> void triqs_gf_view_assign_delegation(gf_view<M, T, L> g, RHS const &rhs) {
     if constexpr (nda::is_scalar_v<RHS>) {
       for (auto w : g.mesh()) g[w] = rhs;
     } else {

--- a/c++/triqs/gfs/gf/targets.hpp
+++ b/c++/triqs/gfs/gf/targets.hpp
@@ -22,98 +22,91 @@
 #include <triqs/arrays.hpp>
 #include <nda/stdutil/complex.hpp>
 
-namespace triqs {
-  namespace gfs {
+namespace triqs::gfs {
 
-    template <int R> struct tensor_valued;
-    template <int R> struct tensor_real_valued {
-      static_assert(R > 0, "tensor_real_valued : R must be > 0");
-      static constexpr int rank       = R;
-      static constexpr int is_real    = true;
-      static constexpr bool is_matrix = false;
-      using scalar_t                  = double;
-      using value_t                   = nda::array<scalar_t, rank>;
-      using real_t                    = tensor_real_valued;
-      using complex_t                 = tensor_valued<R>;
-    };
+  template <int R> struct tensor_valued;
+  template <int R> struct tensor_real_valued {
+    static_assert(R > 0, "tensor_real_valued : R must be > 0");
+    static constexpr int rank       = R;
+    static constexpr int is_real    = true;
+    static constexpr bool is_matrix = false;
+    using scalar_t                  = double;
+    using real_t                    = tensor_real_valued;
+    using complex_t                 = tensor_valued<R>;
+  };
 
-    template <int R> struct tensor_valued {
-      static_assert(R > 0, "tensor_valued : R must be > 0");
-      static constexpr int rank       = R;
-      static constexpr int is_real    = false;
-      static constexpr bool is_matrix = false;
-      using scalar_t                  = dcomplex;
-      using value_t                   = nda::array<scalar_t, rank>;
-      using real_t                    = tensor_real_valued<R>;
-      using complex_t                 = tensor_valued;
-    };
+  template <int R> struct tensor_valued {
+    static_assert(R > 0, "tensor_valued : R must be > 0");
+    static constexpr int rank       = R;
+    static constexpr int is_real    = false;
+    static constexpr bool is_matrix = false;
+    using scalar_t                  = dcomplex;
+    using real_t                    = tensor_real_valued<R>;
+    using complex_t                 = tensor_valued;
+  };
 
-    struct matrix_valued;
-    struct matrix_real_valued {
-      static constexpr int rank       = 2;
-      static constexpr int is_real    = true;
-      static constexpr bool is_matrix = true;
-      using scalar_t                  = double;
-      using value_t                   = nda::matrix<scalar_t>;
-      using real_t                    = matrix_real_valued;
-      using complex_t                 = matrix_valued;
-    };
+  struct matrix_valued;
+  struct matrix_real_valued {
+    static constexpr int rank       = 2;
+    static constexpr int is_real    = true;
+    static constexpr bool is_matrix = true;
+    using scalar_t                  = double;
+    using real_t                    = matrix_real_valued;
+    using complex_t                 = matrix_valued;
+  };
 
-    struct matrix_valued {
-      static constexpr int rank       = 2;
-      static constexpr int is_real    = false;
-      static constexpr bool is_matrix = true;
-      using scalar_t                  = dcomplex;
-      using value_t                   = nda::matrix<scalar_t>;
-      using real_t                    = matrix_real_valued;
-      using complex_t                 = matrix_valued;
-    };
+  struct matrix_valued {
+    static constexpr int rank       = 2;
+    static constexpr int is_real    = false;
+    static constexpr bool is_matrix = true;
+    using scalar_t                  = dcomplex;
+    using real_t                    = matrix_real_valued;
+    using complex_t                 = matrix_valued;
+  };
 
-    struct scalar_valued;
-    struct scalar_real_valued {
-      static constexpr int rank       = 0;
-      static constexpr int is_real    = true;
-      static constexpr bool is_matrix = false;
-      using scalar_t                  = double;
-      using value_t                   = scalar_t;
-      using real_t                    = scalar_real_valued;
-      using complex_t                 = scalar_valued;
-    };
+  struct scalar_valued;
+  struct scalar_real_valued {
+    static constexpr int rank       = 0;
+    static constexpr int is_real    = true;
+    static constexpr bool is_matrix = false;
+    using scalar_t                  = double;
+    using real_t                    = scalar_real_valued;
+    using complex_t                 = scalar_valued;
+  };
 
-    struct scalar_valued {
-      static constexpr int rank       = 0;
-      static constexpr int is_real    = false;
-      static constexpr bool is_matrix = false;
-      using scalar_t                  = dcomplex;
-      using value_t                   = scalar_t;
-      using real_t                    = scalar_real_valued;
-      using complex_t                 = scalar_valued;
-    };
+  struct scalar_valued {
+    static constexpr int rank       = 0;
+    static constexpr int is_real    = false;
+    static constexpr bool is_matrix = false;
+    using scalar_t                  = dcomplex;
+    using real_t                    = scalar_real_valued;
+    using complex_t                 = scalar_valued;
+  };
 
-    /// invert the relation:  type, rank -> target.
-    template <typename T, int R> struct _target_from_type_rank;
-    template <int R> struct _target_from_type_rank<dcomplex, R> {
-      using type = tensor_valued<R>;
-    };
-    template <> struct _target_from_type_rank<dcomplex, 2> {
-      using type = matrix_valued;
-    };
-    template <> struct _target_from_type_rank<dcomplex, 0> {
-      using type = scalar_valued;
-    };
-    template <int R> struct _target_from_type_rank<double, R> {
-      using type = tensor_real_valued<R>;
-    };
-    template <> struct _target_from_type_rank<double, 2> {
-      using type = matrix_real_valued;
-    };
-    template <> struct _target_from_type_rank<double, 0> {
-      using type = scalar_real_valued;
-    };
+  /// invert the relation:  type, rank -> target.
+  template <typename T, int R> struct _target_from_type_rank;
+  template <int R> struct _target_from_type_rank<dcomplex, R> {
+    using type = tensor_valued<R>;
+  };
+  template <> struct _target_from_type_rank<dcomplex, 2> {
+    using type = matrix_valued;
+  };
+  template <> struct _target_from_type_rank<dcomplex, 0> {
+    using type = scalar_valued;
+  };
+  template <int R> struct _target_from_type_rank<double, R> {
+    using type = tensor_real_valued<R>;
+  };
+  template <> struct _target_from_type_rank<double, 2> {
+    using type = matrix_real_valued;
+  };
+  template <> struct _target_from_type_rank<double, 0> {
+    using type = scalar_real_valued;
+  };
 
-    // Given an array A, compute the target, with A::rank - nvar
-    template <typename A, int nvar>
-    using target_from_array =
-       typename _target_from_type_rank<typename std::decay_t<typename std::decay_t<A>::value_type>, std::decay_t<A>::rank - nvar>::type;
-  } // namespace gfs
-} // namespace triqs
+  // Given an array A, compute the target, with A::rank - nvar
+  template <typename A, int nvar>
+  using target_from_array =
+     typename _target_from_type_rank<typename std::decay_t<typename std::decay_t<A>::value_type>, std::decay_t<A>::rank - nvar>::type;
+
+} // namespace triqs::gfs

--- a/test/c++/gfs/block.cpp
+++ b/test/c++/gfs/block.cpp
@@ -141,4 +141,22 @@ TEST(Block, Arithmetic) {
   EXPECT_BLOCK_GF_NEAR(block_gf<imfreq>{2 * B}, block_gf<imfreq>{1.0 * B + B * 1.0});
 }
 
+TEST(Block, F_Layout) {
+  double beta  = 1;
+  auto iw_mesh = mesh::dlr_imfreq{beta, Fermion, /*w_max*/ 10, /*eps*/ 1e-8};
+  auto G1      = gf<dlr_imfreq, matrix_valued, F_layout>(iw_mesh, {2, 2});
+  auto G2      = G1;
+  triqs::clef::placeholder<0> w_;
+  G1(w_) << 1 / (w_ + 2);
+  G2(w_) << 1 / (w_ - 2);
+
+  auto B = make_block_gf({"a", "b"}, {G1, G2});
+
+  EXPECT_BLOCK_GF_NEAR(block_gf<dlr_imfreq>{2 * B}, block_gf<dlr_imfreq>{1.0 * B + B * 1.0});
+
+  auto w0 = iw_mesh(0);
+  EXPECT_TRUE(B[0][w0].indexmap().is_stride_order_Fortran());
+  static_assert(nda::is_matrix_or_view_v<decltype(B[0][w0])>);
+}
+
 MAKE_MAIN;


### PR DESCRIPTION
- Forward Layout to the underlying gf and gf_view types
- Adjust various generic block_gf functions, operators, and traits accordingly
- Extend block_gf test
- Remove `value_t` from targets, Layout propagation unclear