### PR TITLE
[feat] selectively add SF / PH terms in Kanamori

### DIFF
--- a/c++/triqs/mesh/utils.hpp
+++ b/c++/triqs/mesh/utils.hpp
@@ -53,6 +53,15 @@ namespace triqs::mesh {
 
   //------------------------------------------------------------------------
 
+  /// Given a mesh, return an array of the values of the mesh
+  template <Mesh M> [[nodiscard]] nda::vector<typename M::value_t> values(M const &m) {
+    auto res = nda::vector<typename M::value_t>(m.size());
+    for (auto i : range(m.size())) res(i) = m[i].value();
+    return res;
+  }
+
+  //------------------------------------------------------------------------
+
   template <Mesh M> static constexpr bool is_product  = false;
   template <Mesh Ms> static constexpr int n_variables = 1;
 

--- a/python/triqs/gf/gf.py
+++ b/python/triqs/gf/gf.py
@@ -18,7 +18,7 @@
 # Authors: Michel Ferrero, Olivier Gingras, Alexander Hampel, Jonathan Karp, Manuel, Olivier Parcollet, Markus Richter, Hugo U. R. Strand, Nils Wentzell
 
 import itertools, warnings, numbers
-from functools import reduce # Valid in Python 2.6+, required in Python 3
+from functools import reduce  # Valid in Python 2.6+, required in Python 3
 import operator
 import numpy as np
 from . import mesh_product
@@ -27,7 +27,7 @@ from . import descriptors, descriptor_base
 from .mesh_product import MeshProduct
 from triqs.plot.protocol import clip_array
 from . import meshes
-from . import plot 
+from . import plot
 from . import gf_fnt, wrapped_aux
 from .mesh_point import MeshPoint
 from .matsubara_freq import MatsubaraFreq
@@ -36,43 +36,54 @@ from operator import mul
 # list of all the meshes
 all_meshes = (MeshProduct,) + tuple(c for c in list(meshes.__dict__.values()) if isinstance(c, type) and c.__name__.startswith('Mesh'))
 # list of call_proxies
-all_call_proxies = dict( (c.__name__, c) for c in list(wrapped_aux.__dict__.values()) if isinstance(c, type) and c.__name__.startswith('CallProxy'))
+all_call_proxies = dict(
+    (c.__name__, c) for c in list(wrapped_aux.__dict__.values()) if isinstance(c, type) and c.__name__.startswith('CallProxy')
+)
+
 
 class CallProxyNone:
     """Default do nothing value"""
+
     def __init__(self, *args):
         pass
+
     def __call__(self, *args):
         raise NotImplementedError
 
+
 # For IO later
-def call_factory_from_dict(cl,name, dic):
+def call_factory_from_dict(cl, name, dic):
     """Given a class cl and a dict dic, it calls cl.__factory_from_dict__(dic)"""
     return cl.__factory_from_dict__(name, dic)
 
-# a metaclass that adds all functions of gf_fnt as methods 
+
+# a metaclass that adds all functions of gf_fnt as methods
 # the C++ will take care of the dispatch
-def add_method_helper(a,cls): 
+def add_method_helper(a, cls):
     def _(self, *args, **kw):
-       return a(self, *args, **kw)
-    _.__doc__ =  a.__doc__
-    #_.__doc__ = 50*'-' + '\n' + a.__doc__
+        return a(self, *args, **kw)
+
+    _.__doc__ = a.__doc__
+    # _.__doc__ = 50*'-' + '\n' + a.__doc__
     _.__name__ = a.__name__
     return _
 
-class AddMethod(type): 
+
+class AddMethod(type):
     def __init__(cls, name, bases, dct):
         super(AddMethod, cls).__init__(name, bases, dct)
         for a in [f for f in list(gf_fnt.__dict__.values()) if callable(f)]:
             if not hasattr(cls, a.__name__):
-                setattr(cls, a.__name__, add_method_helper(a,cls))
+                setattr(cls, a.__name__, add_method_helper(a, cls))
+
 
 class Idx:
     def __init__(self, *x):
-        self.index = x[0] if len(x)==1 else x
+        self.index = x[0] if len(x) == 1 else x
+
 
 class Gf(metaclass=AddMethod):
-    r""" TRIQS Greens function container class
+    r"""TRIQS Greens function container class
 
     Parameters
     ----------
@@ -92,7 +103,7 @@ class Gf(metaclass=AddMethod):
              If true, and target_shape is set, the data will be real.
              Mutually exclusive with argument ``data``.
 
-    name: str 
+    name: str
           The name of the Greens function for plotting.
 
     Notes
@@ -101,38 +112,39 @@ class Gf(metaclass=AddMethod):
     One of ``target_shape`` or ``data`` must be set, and the other must be `None`.
 
     """
-    
+
     _hdf5_data_scheme_ = 'Gf'
-    __array_priority__ = 10000 # Makes sure the operations of this class are applied as priority
+    __array_priority__ = 10000  # Makes sure the operations of this class are applied as priority
 
-    def __init__(self, **kw): # enforce keyword only policy 
-        
-        #print "Gf construct args", kw
+    def __init__(self, **kw):  # enforce keyword only policy
+        # print "Gf construct args", kw
 
-        def delegate(self, mesh, data=None, target_shape=None, name = '', is_real = False, indices=None):
+        def delegate(self, mesh, data=None, target_shape=None, name='', is_real=False, indices=None):
             """
             target_shape and data  : must provide exactly one of them
             """
             # FIXME ? name is deprecated
-            #if name: 
+            # if name:
             #    warnings.warn("constructor parameter 'name' is deprecated in gf constructor.\n It is only used in plots.\n Pass the name to the oplot function directly")
             self.name = name
 
             # input check
-            assert (target_shape is None) or (data is None), "data and target_shape : one must be None"
-            assert (data is None) or (is_real is False), "is_real can not be True if data is not None"
-            if target_shape : 
-                for i in target_shape : 
-                    assert i>0, "Target shape elements must be >0"
-     
+            assert (target_shape is None) or (data is None), 'data and target_shape : one must be None'
+            assert (data is None) or (is_real is False), 'is_real can not be True if data is not None'
+            if target_shape:
+                for i in target_shape:
+                    assert i > 0, 'Target shape elements must be >0'
+
             # mesh
-            assert isinstance(mesh, all_meshes), "Mesh is unknown. Possible type of meshes are %s" % ', '.join([m.__name__ for m in all_meshes])
+            assert isinstance(mesh, all_meshes), 'Mesh is unknown. Possible type of meshes are %s' % ', '.join(
+                [m.__name__ for m in all_meshes]
+            )
             self._mesh = mesh
 
             # indices backward compat layer
             if indices is not None:
-                warnings.warn("The use of string indices is no longer supported, converting to target_shape instead.", DeprecationWarning)
-                assert target_shape is None, "target_shape must be None if indices is not None"
+                warnings.warn('The use of string indices is no longer supported, converting to target_shape instead.', DeprecationWarning)
+                assert target_shape is None, 'target_shape must be None if indices is not None'
                 if isinstance(indices[0], (list, range)):
                     target_shape = [len(li) for li in indices]
                 else:
@@ -141,31 +153,35 @@ class Gf(metaclass=AddMethod):
             # data
             if data is None:
                 # if no data, we need target_shape
-                assert target_shape is not None, "target_shape must be provided if data is None"
+                assert target_shape is not None, 'target_shape must be provided if data is None'
                 # we now allocate the data
                 l = mesh.size_of_components() if isinstance(mesh, MeshProduct) else [len(mesh)]
-                data = np.zeros(list(l) + list(target_shape), dtype = np.float64 if is_real else np.complex128)
+                data = np.zeros(list(l) + list(target_shape), dtype=np.float64 if is_real else np.complex128)
             else:
                 l = tuple(mesh.size_of_components()) if isinstance(mesh, MeshProduct) else (len(mesh),)
-                assert l == data.shape[0:len(l)], "Mismatch between data shape %s and sizes of mesh(es) %s\n " % (data.shape, l)
+                assert l == data.shape[0 : len(l)], 'Mismatch between data shape %s and sizes of mesh(es) %s\n ' % (data.shape, l)
 
             # Now we have the data at correct size. Set up a few short cuts
             self._data = data
-            len_data_shape = len(self._data.shape) 
-            self._target_rank = len_data_shape - (self._mesh.rank if isinstance(mesh, MeshProduct) else 1)  
-            self._rank = len_data_shape - self._target_rank 
+            len_data_shape = len(self._data.shape)
+            self._target_rank = len_data_shape - (self._mesh.rank if isinstance(mesh, MeshProduct) else 1)
+            self._rank = len_data_shape - self._target_rank
             assert self._rank >= 0
 
             # target_shape. Ensure it is correct in any case.
-            assert target_shape is None or tuple(target_shape) == self._data.shape[self._rank:] # Debug only
-            self._target_shape = self._data.shape[self._rank:]
+            assert target_shape is None or tuple(target_shape) == self._data.shape[self._rank :]  # Debug only
+            self._target_shape = self._data.shape[self._rank :]
 
-            # NB : at this stage, enough checks should have been made in Python in order for the C++ view 
+            # NB : at this stage, enough checks should have been made in Python in order for the C++ view
             # to be constructed without any INTERNAL exceptions.
             # Set up the C proxy for call operator for speed. The name has to
             # agree with the wrapped_aux module, it is of only internal use
-            s = '_x_'.join( m.__class__.__name__[4:] for m in self.mesh._mlist) if isinstance(mesh, MeshProduct) else self._mesh.__class__.__name__[4:]
-            proxyname = 'CallProxy%s_%s%s'%(s, self.target_rank,'_R' if data.dtype == np.float64 else '') 
+            s = (
+                '_x_'.join(m.__class__.__name__[4:] for m in self.mesh._mlist)
+                if isinstance(mesh, MeshProduct)
+                else self._mesh.__class__.__name__[4:]
+            )
+            proxyname = 'CallProxy%s_%s%s' % (s, self.target_rank, '_R' if data.dtype == np.float64 else '')
             try:
                 self._c_proxy = all_call_proxies.get(proxyname, CallProxyNone)(self)
             except:
@@ -179,9 +195,13 @@ class Gf(metaclass=AddMethod):
     def __check_invariants(self):
         """Check various invariant. Mainly for debug"""
         # rank
-        assert self.rank == self._mesh.rank if isinstance (self._mesh, MeshProduct) else 1
+        assert self.rank == self._mesh.rank if isinstance(self._mesh, MeshProduct) else 1
         # The mesh size must correspond to the size of the data
-        assert self._data.shape[:self._rank] == tuple(len(m) for m in self._mesh.components) if isinstance (self._mesh, MeshProduct) else (len(self._mesh),)
+        assert (
+            self._data.shape[: self._rank] == tuple(len(m) for m in self._mesh.components)
+            if isinstance(self._mesh, MeshProduct)
+            else (len(self._mesh),)
+        )
 
     def density(self, *args, **kwargs):
         r"""Compute the density matrix of the Greens function
@@ -213,12 +233,12 @@ class Gf(metaclass=AddMethod):
         return self._rank
 
     @property
-    def target_rank(self): 
+    def target_rank(self):
         """int : The rank of the target space."""
         return self._target_rank
 
     @property
-    def target_shape(self): 
+    def target_shape(self):
         """(int, ...) : The shape of the target space."""
         return self._target_shape
 
@@ -229,7 +249,7 @@ class Gf(metaclass=AddMethod):
 
     @property
     def indices(self):
-        warnings.warn("Gf.indices is deprecated, use Gf.target_shape", DeprecationWarning)
+        warnings.warn('Gf.indices is deprecated, use Gf.target_shape', DeprecationWarning)
         """(int, ...) : Deprecated. Use target_indices instead."""
         return [range(d) for d in self.target_shape]
 
@@ -242,13 +262,13 @@ class Gf(metaclass=AddMethod):
     def data(self):
         """ndarray : Raw data of the Greens function.
 
-           Storage convention is ``self.data[x,y,z, ..., n0,n1,n2]``
-           where ``x,y,z`` correspond to the mesh variables (the mesh) and 
-           ``n0, n1, n2`` to the ``target_space``.
+        Storage convention is ``self.data[x,y,z, ..., n0,n1,n2]``
+        where ``x,y,z`` correspond to the mesh variables (the mesh) and
+        ``n0, n1, n2`` to the ``target_space``.
         """
         return self._data
 
-    def copy(self) : 
+    def copy(self):
         """Deep copy of the Greens function.
 
         Returns
@@ -256,30 +276,30 @@ class Gf(metaclass=AddMethod):
         G : Gf
             Copy of self.
         """
-        return Gf (mesh = self._mesh.copy(), 
-                   data = self._data.copy(), 
-                   name = self.name)
+        return Gf(mesh=self._mesh.copy(), data=self._data.copy(), name=self.name)
 
     def copy_from(self, another):
         """Copy the data of another Greens function into self."""
         self._mesh.copy_from(another.mesh)
-        assert self._data.shape == another._data.shape, "Shapes are incompatible: " + str(self._data.shape) + " vs " + str(another._data.shape)
+        assert self._data.shape == another._data.shape, (
+            'Shapes are incompatible: ' + str(self._data.shape) + ' vs ' + str(another._data.shape)
+        )
         self._data[:] = another._data[:]
         self.__check_invariants()
 
     def __repr__(self):
-        return "Greens Function %s with mesh %s and target_shape %s: \n"%(self.name, self.mesh, self.target_shape)
- 
-    def __str__ (self): 
+        return 'Greens Function %s with mesh %s and target_shape %s: \n' % (self.name, self.mesh, self.target_shape)
+
+    def __str__(self):
         return self.__repr__()
 
-    #--------------  Bracket operator []  -------------------------
+    # --------------  Bracket operator []  -------------------------
 
     # Helper: Convert Idx or MeshPoint into data_index, else forward argument
     @staticmethod
     def _to_data_index(x, m):
         if isinstance(x, MeshPoint):
-            assert x.mesh_hash == m.mesh_hash, "Green function Mesh and MeshPoint have incompatible hash"
+            assert x.mesh_hash == m.mesh_hash, 'Green function Mesh and MeshPoint have incompatible hash'
             return x.data_index
         elif isinstance(x, Idx):
             return m.to_data_index(x.index)
@@ -287,11 +307,10 @@ class Gf(metaclass=AddMethod):
             return m.to_data_index(x)
         else:
             return x
-    
-    _full_slice = slice(None, None, None) 
+
+    _full_slice = slice(None, None, None)
 
     def __getitem__(self, key):
-
         # First case : g[:] = RHS ... will be g << RHS
         if key == self._full_slice:
             return self
@@ -300,39 +319,43 @@ class Gf(metaclass=AddMethod):
         if not isinstance(key, tuple):
             if isinstance(key, (Idx, MeshPoint, MatsubaraFreq)):
                 return self.data[self._to_data_index(key, self._mesh)]
-            else: key = (key,)
+            else:
+                key = (key,)
 
         # If all arguments are MeshPoint, we are slicing the mesh or evaluating
         if all(isinstance(x, (MeshPoint, Idx, MatsubaraFreq)) for x in key):
-            assert len(key) == self.rank, "wrong number of arguments in [ ]. Expected %s, got %s"%(self.rank, len(key))
-            return self.data[tuple(self._to_data_index(x,m) for x,m in zip(key,self._mesh._mlist))]
+            assert len(key) == self.rank, 'wrong number of arguments in [ ]. Expected %s, got %s' % (self.rank, len(key))
+            return self.data[tuple(self._to_data_index(x, m) for x, m in zip(key, self._mesh._mlist))]
 
         # If any argument is a MeshPoint, we are slicing the mesh or evaluating
         elif any(isinstance(x, (MeshPoint, Idx, MatsubaraFreq)) for x in key):
-            assert len(key) == self.rank, "wrong number of arguments in [[ ]]. Expected %s, got %s"%(self.rank, len(key))
-            assert all(isinstance(x, (MeshPoint, Idx, MatsubaraFreq, slice)) for x in key), "Invalid accessor of Greens function, please combine only MeshPoints, Idx and slice"
-            assert self.rank > 1, "Internal error : impossible case" # here all == any for one argument
-            mlist = self._mesh._mlist 
+            assert len(key) == self.rank, 'wrong number of arguments in [[ ]]. Expected %s, got %s' % (self.rank, len(key))
+            assert all(
+                isinstance(x, (MeshPoint, Idx, MatsubaraFreq, slice)) for x in key
+            ), 'Invalid accessor of Greens function, please combine only MeshPoints, Idx and slice'
+            assert self.rank > 1, 'Internal error : impossible case'  # here all == any for one argument
+            mlist = self._mesh._mlist
             for x in key:
-                if isinstance(x, slice) and x != self._full_slice: raise NotImplementedError("Partial slice of the mesh not implemented")
+                if isinstance(x, slice) and x != self._full_slice:
+                    raise NotImplementedError('Partial slice of the mesh not implemented')
             # slice the data
-            k = tuple(self._to_data_index(x,m) for x,m in zip(key,mlist)) + self._target_rank * (slice(0, None),)
+            k = tuple(self._to_data_index(x, m) for x, m in zip(key, mlist)) + self._target_rank * (slice(0, None),)
             dat = self._data[k]
             # list of the remaining lists
-            mlist = [m for i,m in filter(lambda tup_im : not isinstance(tup_im[0], (MeshPoint, Idx, MatsubaraFreq)), zip(key, mlist))]
-            assert len(mlist) > 0, "Internal error" 
-            mesh = MeshProduct(*mlist) if len(mlist)>1 else mlist[0]
-            sing = None 
-            r = Gf(mesh = mesh, data = dat)
+            mlist = [m for i, m in filter(lambda tup_im: not isinstance(tup_im[0], (MeshPoint, Idx, MatsubaraFreq)), zip(key, mlist))]
+            assert len(mlist) > 0, 'Internal error'
+            mesh = MeshProduct(*mlist) if len(mlist) > 1 else mlist[0]
+            sing = None
+            r = Gf(mesh=mesh, data=dat)
             r.__check_invariants()
             return r
 
         # In all other cases, we are slicing the target space
-        else : 
-            assert self.target_rank == len(key), "wrong number of arguments. Expected %s, got %s"%(self.target_rank, len(key))
+        else:
+            assert self.target_rank == len(key), 'wrong number of arguments. Expected %s, got %s' % (self.target_rank, len(key))
 
             # Slicing with ranges
-            if all(isinstance(x, slice) for x in key): 
+            if all(isinstance(x, slice) for x in key):
                 key_tpl = tuple(key)
 
             # Integer access
@@ -341,76 +364,79 @@ class Gf(metaclass=AddMethod):
 
             # Invalid Access
             elif any(isinstance(x, str) for x in key):
-                raise RuntimeError("String indices are no longer supported. Please use integer indices for the target.")
+                raise RuntimeError('String indices are no longer supported. Please use integer indices for the target.')
             else:
-                raise NotImplementedError("Partial slice of the target space not implemented")
+                raise NotImplementedError('Partial slice of the target space not implemented')
 
-            dat = self._data[ self._rank*(slice(0,None),) + key_tpl ]
-            r = Gf(mesh = self._mesh, data = dat)
+            dat = self._data[self._rank * (slice(0, None),) + key_tpl]
+            r = Gf(mesh=self._mesh, data=dat)
 
             r.__check_invariants()
             return r
 
     def __setitem__(self, key, val):
-
         # Only one argument and not a slice. Must be a mesh point, Idx
         if isinstance(key, (MeshPoint, Idx, MatsubaraFreq)):
             self.data[self._to_data_index(key, self._mesh)] = val
 
         # If all arguments are MeshPoint, we are slicing the mesh or evaluating
         elif isinstance(key, tuple) and all(isinstance(x, (MeshPoint, Idx, MatsubaraFreq)) for x in key):
-            assert len(key) == self.rank, "wrong number of arguments in [ ]. Expected %s, got %s"%(self.rank, len(key))
-            self.data[tuple(self._to_data_index(x,m) for x,m in zip(key,self._mesh._mlist))] = val
+            assert len(key) == self.rank, 'wrong number of arguments in [ ]. Expected %s, got %s' % (self.rank, len(key))
+            self.data[tuple(self._to_data_index(x, m) for x, m in zip(key, self._mesh._mlist))] = val
 
         else:
             self[key] << val
 
     # -------------- Various operations -------------------------------------
-    
-    @property
-    def real(self): 
-        """Gf : A Greens function with a view of the real part."""
-        return Gf(mesh = self._mesh, data = self._data.real, name = ("Re " + self.name) if self.name else '') 
 
     @property
-    def imag(self): 
+    def real(self):
+        """Gf : A Greens function with a view of the real part."""
+        return Gf(mesh=self._mesh, data=self._data.real, name=('Re ' + self.name) if self.name else '')
+
+    @property
+    def imag(self):
         """Gf : A Greens function with a view of the imaginary part."""
-        return Gf(mesh = self._mesh, data = self._data.imag, name = ("Im " + self.name) if self.name else '') 
- 
+        return Gf(mesh=self._mesh, data=self._data.imag, name=('Im ' + self.name) if self.name else '')
+
     # --------------  Lazy system -------------------------------------
 
-    def __lazy_expr_eval_context__(self) : 
+    def __lazy_expr_eval_context__(self):
         return LazyCTX(self)
 
     def __lshift__(self, A):
-        """ A can be two things:
-          * G << any_init will init the GFBloc with the initializer
-          * G << g2 where g2 is a GFBloc will copy g2 into self
+        """A can be two things:
+        * G << any_init will init the GFBloc with the initializer
+        * G << g2 where g2 is a GFBloc will copy g2 into self
         """
         if isinstance(A, Gf):
-            if self is not A: # otherwise it is useless AND does not work !!
-                assert self.mesh == A.mesh, "Green function meshes are not compatible:\n  %s\nand\n  %s" % (self.mesh, A.mesh)
+            if self is not A:  # otherwise it is useless AND does not work !!
+                assert self.mesh == A.mesh, 'Green function meshes are not compatible:\n  %s\nand\n  %s' % (self.mesh, A.mesh)
                 self.copy_from(A)
-        elif isinstance(A, lazy_expressions.LazyExpr): # A is a lazy_expression made of GF, scalars, descriptors
+        elif isinstance(A, lazy_expressions.LazyExpr):  # A is a lazy_expression made of GF, scalars, descriptors
             A2 = descriptors.convert_scalar_to_const(A)
-            def e_t (x):
-                if not isinstance(x, descriptors.Base): return x
+
+            def e_t(x):
+                if not isinstance(x, descriptors.Base):
+                    return x
                 tmp = self.copy()
                 x(tmp)
                 return tmp
-            self.copy_from (lazy_expressions.eval_expr_with_context(e_t, A2) )
-        elif isinstance(A, lazy_expressions.LazyExprTerminal): #e.g. g<< SemiCircular (...)
+
+            self.copy_from(lazy_expressions.eval_expr_with_context(e_t, A2))
+        elif isinstance(A, lazy_expressions.LazyExprTerminal):  # e.g. g<< SemiCircular (...)
             self << lazy_expressions.LazyExpr(A)
-        elif descriptors.is_scalar(A): #in the case it is a scalar ....
+        elif descriptors.is_scalar(A):  # in the case it is a scalar ....
             self << lazy_expressions.LazyExpr(A)
         else:
             raise NotImplemented
         return self
 
     # -------------- call -------------------------------------
-    
-    def __call__(self, *args) : 
-        assert self._c_proxy, " no proxy"
+
+    def __call__(self, *args):
+        assert self._c_proxy, ' no proxy'
+
         def filt(x):
             if isinstance(x, MeshPoint):
                 if x.value is not None:
@@ -419,85 +445,90 @@ class Gf(metaclass=AddMethod):
             elif isinstance(x, Idx):
                 return x.index
             return x
+
         return self._c_proxy(*[filt(x) for x in args])
 
     # -------------- Various operations -------------------------------------
- 
-    def __le__(self, other): 
-        raise RuntimeError(" Operator <= not defined ")
 
-    # ---------- Addition   
+    def __le__(self, other):
+        raise RuntimeError(' Operator <= not defined ')
 
-    def __iadd__(self,arg):
-        if descriptor_base.is_lazy(arg): return lazy_expressions.make_lazy(self) + arg
+    # ---------- Addition
+
+    def __iadd__(self, arg):
+        if descriptor_base.is_lazy(arg):
+            return lazy_expressions.make_lazy(self) + arg
         if isinstance(arg, Gf):
-            assert type(self.mesh) == type(arg.mesh), "Can not add two Gf with meshes of different type"
-            assert self.mesh == arg.mesh, "Can not add two Gf with different mesh"
-            self._data += arg._data 
+            assert type(self.mesh) == type(arg.mesh), 'Can not add two Gf with meshes of different type'
+            assert self.mesh == arg.mesh, 'Can not add two Gf with different mesh'
+            self._data += arg._data
         else:
             if self._target_rank != 2 and not isinstance(arg, np.ndarray):
-                 self._data[:] += arg
+                self._data[:] += arg
             elif self._target_rank == 2:
-                 wrapped_aux._iadd_g_matrix_scalar(self, arg) 
+                wrapped_aux._iadd_g_matrix_scalar(self, arg)
             else:
-                 raise NotImplemented
+                raise NotImplemented
         return self
 
-    def __add__(self,y):
+    def __add__(self, y):
         c = self.copy()
         c += y
         return c
 
-    def __radd__(self,y): return self.__add__(y)
+    def __radd__(self, y):
+        return self.__add__(y)
 
     # ---------- Substraction
 
-    def __isub__(self,arg):
-       if descriptor_base.is_lazy(arg): return lazy_expressions.make_lazy(self) - arg
-       if isinstance(arg, Gf):
-           assert type(self.mesh) == type(arg.mesh), "Can not subtract two Gf with meshes of different type"
-           assert self.mesh == arg.mesh, "Can not subtract two Gf with different mesh"
-           self._data -= arg._data 
-       else:
+    def __isub__(self, arg):
+        if descriptor_base.is_lazy(arg):
+            return lazy_expressions.make_lazy(self) - arg
+        if isinstance(arg, Gf):
+            assert type(self.mesh) == type(arg.mesh), 'Can not subtract two Gf with meshes of different type'
+            assert self.mesh == arg.mesh, 'Can not subtract two Gf with different mesh'
+            self._data -= arg._data
+        else:
             if self._target_rank != 2 and not isinstance(arg, np.ndarray):
-               self._data[:] -= arg
+                self._data[:] -= arg
             elif self._target_rank == 2:
-               wrapped_aux._isub_g_matrix_scalar(self, arg) 
+                wrapped_aux._isub_g_matrix_scalar(self, arg)
             else:
-               raise NotImplemented
-       return self
+                raise NotImplemented
+        return self
 
-    def __sub__(self,y):
+    def __sub__(self, y):
         c = self.copy()
         c -= y
         return c
 
-    def __rsub__(self,y):
-        c = (-1)*self.copy()
+    def __rsub__(self, y):
+        c = (-1) * self.copy()
         c += y
         return c
 
     # ---------- Matrix Multiplication (@)
 
-    def __imatmul__(self,arg):
-        if descriptor_base.is_lazy(arg): return lazy_expressions.make_lazy(self) * arg
+    def __imatmul__(self, arg):
+        if descriptor_base.is_lazy(arg):
+            return lazy_expressions.make_lazy(self) * arg
         # If arg is a Gf
         if isinstance(arg, Gf):
-            assert type(self.mesh) == type(arg.mesh), "Can not multiply two Gf with meshes of different type"
-            assert self.mesh == arg.mesh, "Can not use in-place multiplication for two Gf with different mesh"
+            assert type(self.mesh) == type(arg.mesh), 'Can not multiply two Gf with meshes of different type'
+            assert self.mesh == arg.mesh, 'Can not use in-place multiplication for two Gf with different mesh'
 
             if self.target_rank == 2:
                 if arg.target_rank == 2:
-                    assert arg.target_shape[0] != arg.target_shape[1], "In place multiplication not supported if"
-                    "the argument is a nonsquare matrix. Use regular multiplication instead."
+                    assert arg.target_shape[0] != arg.target_shape[1], 'In place multiplication not supported if'
+                    'the argument is a nonsquare matrix. Use regular multiplication instead.'
                     np.matmul(self.data, arg.data, out=self.data)
                 elif arg.target_rank == 0:
                     self.data[:] *= arg.data[..., None, None]
                 else:
-                    raise NotImplementedError("argument of in place multiplication must be rank 0 or 2")
+                    raise NotImplementedError('argument of in place multiplication must be rank 0 or 2')
 
             elif self.target_rank == 0:
-                assert arg.target_rank == 0, "argument of in place multiplication must have rank 0 if self does"
+                assert arg.target_rank == 0, 'argument of in place multiplication must have rank 0 if self does'
                 self.data[:] = self.data * arg.data
 
             else:
@@ -506,29 +537,29 @@ class Gf(metaclass=AddMethod):
         elif isinstance(arg, numbers.Number):
             self._data[:] *= arg
         elif isinstance(arg, np.ndarray):
-            assert len(arg.shape) == 2, "Multiplication only supported for matrices"
-            assert len(self.target_shape) == 2, "Multiplication only supported for matrix_valued Gfs"
+            assert len(arg.shape) == 2, 'Multiplication only supported for matrices'
+            assert len(self.target_shape) == 2, 'Multiplication only supported for matrix_valued Gfs'
             self.data[:] = np.tensordot(self.data, arg, axes=([-1], [-2]))
         else:
-            assert False, "Invalid operand type for Gf in-place multiplication"
+            assert False, 'Invalid operand type for Gf in-place multiplication'
         return self
-    
+
     @staticmethod
     def _combine_mesh_mul(l, r):
-        """ Apply the Fermion/Boson rules for ImTime mesh, and recursively for MeshProduct"""
-        assert type(l) == type(r), "Can not multiply two Gf with meshes of different type"
-        
-        if type(l) is MeshProduct:
-            return MeshProduct(*[Gf._combine_mesh_mul(l,r) for (l,r) in zip(l.components, r.components)])
+        """Apply the Fermion/Boson rules for ImTime mesh, and recursively for MeshProduct"""
+        assert type(l) == type(r), 'Can not multiply two Gf with meshes of different type'
 
-        if not type(l) is meshes.MeshImTime: #regular case
-            assert l==r, "Can not multiply two Gf with different mesh"
+        if type(l) is MeshProduct:
+            return MeshProduct(*[Gf._combine_mesh_mul(l, r) for (l, r) in zip(l.components, r.components)])
+
+        if not type(l) is meshes.MeshImTime:  # regular case
+            assert l == r, 'Can not multiply two Gf with different mesh'
             return l.copy()
         else:
-            assert abs(l.beta-r.beta) < 1.e-15 and len(l)== len(r), "Can not multiply two Gf with different mesh"
-            return meshes.MeshImTime(l.beta, 'Boson' if l.statistic == r.statistic else 'Fermion', len(l)) 
+            assert abs(l.beta - r.beta) < 1.0e-15 and len(l) == len(r), 'Can not multiply two Gf with different mesh'
+            return meshes.MeshImTime(l.beta, 'Boson' if l.statistic == r.statistic else 'Fermion', len(l))
 
-    def __matmul__(self,y):
+    def __matmul__(self, y):
         if isinstance(y, Gf):
             # make a copy, but special treatment of the mesh in the Imtime case.
             result_mesh = Gf._combine_mesh_mul(self._mesh, y.mesh)
@@ -552,65 +583,64 @@ class Gf(metaclass=AddMethod):
             c = self.copy()
             c *= y
         else:
-            assert False, "Invalid operand type for Gf multiplication"
+            assert False, 'Invalid operand type for Gf multiplication'
         return c
 
-    def __rmatmul__(self,y):
+    def __rmatmul__(self, y):
         c = self.copy()
         if isinstance(y, np.ndarray):
-            assert len(y.shape) == 2, "Multiplication only supported for matrices"
-            assert len(self.target_shape) == 2, "Multiplication only supported for matrix_valued Gfs"
+            assert len(y.shape) == 2, 'Multiplication only supported for matrices'
+            assert len(self.target_shape) == 2, 'Multiplication only supported for matrix_valued Gfs'
             c.data[:] = np.moveaxis(np.tensordot(y, self.data, axes=([-1], [-2])), 0, -2)
         elif isinstance(y, numbers.Number):
             c *= y
         else:
-            assert False, "Invalid operand type for Gf multiplication"
+            assert False, 'Invalid operand type for Gf multiplication'
         return c
 
     # ---------- Multiplication (with *, for now it's equivalent to the matrix multiplication)
-    def __imul__(self,arg):
+    def __imul__(self, arg):
         return self.__imatmul__(arg)
 
-    def __mul__(self,y):
+    def __mul__(self, y):
         return self.__matmul__(y)
 
-    def __rmul__(self,y):
+    def __rmul__(self, y):
         return self.__rmatmul__(y)
 
     # ---------- Division
-    def __itruediv__(self,arg):
+    def __itruediv__(self, arg):
         self._data[:] /= arg
         return self
 
-    def __truediv__(self,y):
+    def __truediv__(self, y):
         c = self.copy()
         c /= y
         return c
-  
+
     # ---------- unary -
     def __neg__(self):
         c = self.copy()
         c *= -1
         return c
 
-   #----------------------------- other operations -----------------------------------
+    # ----------------------------- other operations -----------------------------------
 
     def invert(self):
         """Inverts the Greens function (in place)."""
 
-        if self.target_rank == 0: # Scalar target space
-            self.data[:] = 1. / self.data
-        elif self.target_rank == 2: # Matrix target space
+        if self.target_rank == 0:  # Scalar target space
+            self.data[:] = 1.0 / self.data
+        elif self.target_rank == 2:  # Matrix target space
             # TODO: Replace by np.linag.inv, since v1.8
             # Cf https://docs.scipy.org/doc/numpy/reference/generated/numpy.reshape.html
             d = self.data.view()
-            d.shape = (np.prod(d.shape[:-2]),) + d.shape[-2:] # reshaped view, guarantee no copy
+            d.shape = (np.prod(d.shape[:-2]),) + d.shape[-2:]  # reshaped view, guarantee no copy
             wrapped_aux._gf_invert_data_in_place(d)
         else:
-            raise TypeError(
-                "Inversion only makes sense for matrix or scalar_valued Greens functions")
+            raise TypeError('Inversion only makes sense for matrix or scalar_valued Greens functions')
 
-    def inverse(self): 
+    def inverse(self):
         """Computes the inverse of the Greens function.
 
         Returns
@@ -622,7 +652,7 @@ class Gf(metaclass=AddMethod):
         r.invert()
         return r
 
-    def transpose(self): 
+    def transpose(self):
         """Take the transpose of a matrix valued Greens function.
 
         Returns
@@ -639,13 +669,13 @@ class Gf(metaclass=AddMethod):
         """
 
         # FIXME Why this assert ?
-        #assert any( (isinstance(self.mesh, x) for x in [meshes.MeshImFreq, meshes.MeshReFreq])), "Method invalid for this Gf"
+        # assert any( (isinstance(self.mesh, x) for x in [meshes.MeshImFreq, meshes.MeshReFreq])), "Method invalid for this Gf"
 
-        assert self.rank == 1, "Transpose only implemented for single mesh Greens functions"
-        assert self.target_rank == 2, "Transpose only implemented for matrix valued Greens functions"
+        assert self.rank == 1, 'Transpose only implemented for single mesh Greens functions'
+        assert self.target_rank == 2, 'Transpose only implemented for matrix valued Greens functions'
 
         d = np.transpose(self.data.copy(), (0, 2, 1))
-        return Gf(mesh = self.mesh, data= d)
+        return Gf(mesh=self.mesh, data=d)
 
     def conjugate(self):
         """Conjugate of the Greens function.
@@ -655,7 +685,7 @@ class Gf(metaclass=AddMethod):
         G : Gf (copy)
             Conjugate of the Greens function.
         """
-        return Gf(mesh = self.mesh, data= np.conj(self.data))
+        return Gf(mesh=self.mesh, data=np.conj(self.data))
 
     def zero(self):
         """Set all values to zero."""
@@ -686,17 +716,17 @@ class Gf(metaclass=AddMethod):
         Only implemented for Greens functions with a single mesh.
         """
 
-        assert self.rank == 1, "Only implemented for Greens functions with one mesh"
-        assert self.target_rank == 2, "Matrix transform only valid for matrix valued Greens functions"
+        assert self.rank == 1, 'Only implemented for Greens functions with one mesh'
+        assert self.target_rank == 2, 'Matrix transform only valid for matrix valued Greens functions'
 
-        assert len(L.shape) == 2, "L needs to be two dimensional"
-        assert len(R.shape) == 2, "R needs to be two dimensional"
+        assert len(L.shape) == 2, 'L needs to be two dimensional'
+        assert len(R.shape) == 2, 'R needs to be two dimensional'
 
-        assert L.shape[1] == G.target_shape[0], "Dimension mismatch between L and G"
-        assert R.shape[0] == G.target_shape[1], "Dimension mismatch between G and R"
+        assert L.shape[1] == G.target_shape[0], 'Dimension mismatch between L and G'
+        assert R.shape[0] == G.target_shape[1], 'Dimension mismatch between G and R'
 
-        assert L.shape[0] == self.target_shape[0], "Dimension mismatch between L and self"
-        assert R.shape[1] == self.target_shape[1], "Dimension mismatch between R and self"
+        assert L.shape[0] == self.target_shape[0], 'Dimension mismatch between L and self'
+        assert R.shape[1] == self.target_shape[1], 'Dimension mismatch between R and self'
 
         if not L.strides == sorted(L.strides):
             L = L.copy(order='C')
@@ -722,13 +752,13 @@ class Gf(metaclass=AddMethod):
         """
         return np.trace(gf_fnt.density(self, *args, **kwargs))
 
-    #-----------------------------  IO  -----------------------------------
-    
+    # -----------------------------  IO  -----------------------------------
+
     def __reduce__(self):
         return call_factory_from_dict, (Gf, self.name, self.__reduce_to_dict__())
 
     def __reduce_to_dict__(self):
-        d = {'mesh' : self._mesh, 'data' : self._data}
+        d = {'mesh': self._mesh, 'data': self._data}
         return d
 
     _hdf5_format_ = 'Gf'
@@ -742,18 +772,18 @@ class Gf(metaclass=AddMethod):
         # Drop indices from the grp and ignore it
         d.pop('indices', None)
         #
-        r = cls(name = name, **d)
+        r = cls(name=name, **d)
         # Backward compatibility layer
         # In the case of an ImFreq function, old archives did store only the >0
         # frequencies, we need to duplicate it for negative freq.
         # Same code as in the C++ h5_read for gf.
-        need_unfold = isinstance(r.mesh, meshes.MeshImFreq) and r.mesh.positive_only() 
+        need_unfold = isinstance(r.mesh, meshes.MeshImFreq) and r.mesh.positive_only()
         return r if not need_unfold else wrapped_aux._make_gf_from_real_gf(r)
-    
-    #-----------------------------plot protocol -----------------------------------
+
+    # -----------------------------plot protocol -----------------------------------
 
     def _plot_(self, opt_dict):
-        """ Implement the plot protocol"""
+        """Implement the plot protocol"""
         return plot.dispatcher(self)(self, opt_dict)
 
     def x_data_view(self, x_window=None, flatten_y=False):
@@ -775,41 +805,43 @@ class Gf(metaclass=AddMethod):
             data is a 3d numpy array of dim (:,:, len(X)), the corresponding slice of data.
             If flatten_y is True and dim is (1, 1, *) it returns a 1d numpy array.
         """
-        
-        X = [x.imag for x in self.mesh] if isinstance(self.mesh, meshes.MeshImFreq) \
-            else [x for x in self.mesh]
-        
+
+        X = [x.imag for x in self.mesh] if isinstance(self.mesh, meshes.MeshImFreq) else [x for x in self.mesh]
+
         X, data = np.array(X), self.data
         if x_window:
             # the slice due to clip option x_window
             sl = clip_array(X, *x_window) if x_window else slice(len(X))
-            X, data = X[sl],  data[sl, :, :]
+            X, data = X[sl], data[sl, :, :]
         if flatten_y and data.shape[1:3] == (1, 1):
             data = data[:, 0, 0]
         return X, data
 
-#---------------------------------------------------------
+
+# ---------------------------------------------------------
 
 from h5.formats import register_class, register_backward_compatibility_method
-register_class (Gf)
+
+register_class(Gf)
+
 
 # A backward compatility function
 def bckwd(hdf_scheme):
     # we know scheme is of the form GfM1_x_M2_s/tv3
-    m, t= hdf_scheme[2:], '' # get rid of Gf
-    for suffix in ['_s', 'Tv3', 'Tv4'] : 
-        if m.endswith(suffix) :
-            m, t = m[:-len(suffix)], suffix
+    m, t = hdf_scheme[2:], ''  # get rid of Gf
+    for suffix in ['_s', 'Tv3', 'Tv4']:
+        if m.endswith(suffix):
+            m, t = m[: -len(suffix)], suffix
             break
-    return { 'mesh': 'Mesh'+m }
+    return {'mesh': 'Mesh' + m}
+
 
 # backward compatibility: suppress unrecognized GfIndices warnings
 # when reading a Gf stored with triqs <3.2.x
-warnings.filterwarnings("ignore", message="The hdf5 format GfIndices")
+warnings.filterwarnings('ignore', message='The hdf5 format GfIndices')
 
-register_backward_compatibility_method("GfImFreq", "Gf", bckwd)
-register_backward_compatibility_method("GfImTime", "Gf", bckwd)
-register_backward_compatibility_method("GfLegendre", "Gf", bckwd)
-register_backward_compatibility_method("GfReFreq", "Gf", bckwd)
-register_backward_compatibility_method("GfReTime", "Gf", bckwd)
-
+register_backward_compatibility_method('GfImFreq', 'Gf', bckwd)
+register_backward_compatibility_method('GfImTime', 'Gf', bckwd)
+register_backward_compatibility_method('GfLegendre', 'Gf', bckwd)
+register_backward_compatibility_method('GfReFreq', 'Gf', bckwd)
+register_backward_compatibility_method('GfReTime', 'Gf', bckwd)

--- a/python/triqs/gf/gf.py
+++ b/python/triqs/gf/gf.py
@@ -806,12 +806,10 @@ class Gf(metaclass=AddMethod):
             If flatten_y is True and dim is (1, 1, *) it returns a 1d numpy array.
         """
 
-        if isinstance(self.mesh, meshes.MeshReFreq):
-            X = np.linspace(self.mesh.w_min, self.mesh.w_max, len(self.mesh))
+        if isinstance(self.mesh, (meshes.MeshReFreq, meshes.MeshImTime)):
+            X = self.mesh.values
         elif isinstance(self.mesh, meshes.MeshImFreq):
-            X = np.linspace(self.mesh(self.mesh.first_index()).imag, self.mesh(self.mesh.last_index()).imag, len(self.mesh))
-        elif isinstance(self.mesh, meshes.MeshImTime):
-            X = np.linspace(0, self.mesh.beta, len(self.mesh))
+            X = np.vectorize(lambda x: x.imag)(self.mesh.values)
         else:
             raise AttributeError('input mesh must be either MeshReFreq, MeshImFreq, or MeshImTime')
 

--- a/python/triqs/gf/gf.py
+++ b/python/triqs/gf/gf.py
@@ -806,7 +806,14 @@ class Gf(metaclass=AddMethod):
             If flatten_y is True and dim is (1, 1, *) it returns a 1d numpy array.
         """
 
-        X = [x.imag for x in self.mesh] if isinstance(self.mesh, meshes.MeshImFreq) else [x for x in self.mesh]
+        if isinstance(self.mesh, meshes.MeshReFreq):
+            X = np.linspace(self.mesh.w_min, self.mesh.w_max, len(self.mesh))
+        elif isinstance(self.mesh, meshes.MeshImFreq):
+            X = np.linspace(self.mesh(self.mesh.first_index()).imag, self.mesh(self.mesh.last_index()).imag, len(self.mesh))
+        elif isinstance(self.mesh, meshes.MeshImTime):
+            X = np.linspace(0, self.mesh.beta, len(self.mesh))
+        else:
+            raise AttributeError('input mesh must be either MeshReFreq, MeshImFreq, or MeshImTime')
 
         X, data = np.array(X), self.data
         if x_window:

--- a/python/triqs/gf/matsubara_freq.py
+++ b/python/triqs/gf/matsubara_freq.py
@@ -66,6 +66,12 @@ class MatsubaraFreq:
     def value(self):
         return complex(self)
 
+    def __eq__(self, other):
+        if isinstance(other, MatsubaraFreq):
+            return self.n == other.n and self.beta == other.beta and self.statistic == other.statistic
+        else:
+            return False
+
     def __abs__(self):
         return abs(complex(self))
 

--- a/python/triqs/gf/meshes_desc.py
+++ b/python/triqs/gf/meshes_desc.py
@@ -64,18 +64,19 @@ def make_mesh(py_type, c_tag, doc="", with_values=True):
     m.add_iterator()
 
     if with_values:
-        m.add_method("PyObject * values()",
-                     calling_pattern = """
-                        static auto cls = pyref::get_class("triqs.gf", "MeshValueGenerator", /* raise_exception */ true);
-                        pyref args = PyTuple_Pack(1, self);
-                        auto result = PyObject_CallObject(cls, args);
-                     """, doc = "A numpy array of all the values of the mesh points")
-        m.add_method(f"{c_tag}::value_t to_value({c_tag}::index_t index)", doc = "index -> value")
+        m.add_property(name = "values",
+            getter = cfunction(calling_pattern="auto result = values(self_c)",
+                signature = "nda::vector<{c_tag}::value_t>()",
+                doc = "A numpy array of all the values of the mesh points"))
+        m.add_method(
+            f"{c_tag}::value_t to_value({c_tag}::index_t index)", doc="index -> value"
+        )
 
     m.add_method_copy()
     m.add_method_copy_from()
 
     return m
+
 
 ########################
 ##   MeshImFreq

--- a/python/triqs/operators/util/hamiltonians.py
+++ b/python/triqs/operators/util/hamiltonians.py
@@ -113,6 +113,8 @@ def h_int_kanamori(
     U,
     Uprime,
     J_hund,
+    spin_flip=True,
+    pair_hopping=True,
     off_diag=None,
     map_operator_structure=None,
     H_dump=None,
@@ -138,6 +140,10 @@ def h_int_kanamori(
                :math:`U_{ij}^{\sigma \bar{\sigma}} (opposite spins)`
     J_hund : scalar
                :math:`J`
+    spin_flip : boolean
+                include spin-flip terms
+    pair_hopping : boolean
+                include pair-hopping terms
     off_diag : boolean
                Do we have (orbital) off-diagonal elements?
                If yes, the operators and blocks are denoted by ('spin', 'orbital'),
@@ -184,40 +190,42 @@ def h_int_kanamori(
                 H_dump_file.write(str(U_val) + '\n')
 
     # spin-flip terms:
-    if H_dump:
-        H_dump_file.write('Spin-flip terms:' + '\n')
-    for s1, s2 in product(spin_names, spin_names):
-        if s1 == s2:
-            continue
-        for a1, a2 in product(range(n_orb), range(n_orb)):
-            if a1 == a2:
+    if spin_flip:
+        if H_dump:
+            H_dump_file.write('Spin-flip terms:' + '\n')
+        for s1, s2 in product(spin_names, spin_names):
+            if s1 == s2:
                 continue
-            H_term = -0.5 * J_hund * c_dag(*mkind(s1, a1)) * c(*mkind(s2, a1)) * c_dag(*mkind(s2, a2)) * c(*mkind(s1, a2))
-            H += H_term
+            for a1, a2 in product(range(n_orb), range(n_orb)):
+                if a1 == a2:
+                    continue
+                H_term = -0.5 * J_hund * c_dag(*mkind(s1, a1)) * c(*mkind(s2, a1)) * c_dag(*mkind(s2, a2)) * c(*mkind(s1, a2))
+                H += H_term
 
-            # Dump terms of H
-            if H_dump and not H_term.is_zero():
-                H_dump_file.write('%s' % (mkind(s1, a1),) + '\t')
-                H_dump_file.write('%s' % (mkind(s2, a2),) + '\t')
-                H_dump_file.write(str(-J_hund) + '\n')
+                # Dump terms of H
+                if H_dump and not H_term.is_zero():
+                    H_dump_file.write('%s' % (mkind(s1, a1),) + '\t')
+                    H_dump_file.write('%s' % (mkind(s2, a2),) + '\t')
+                    H_dump_file.write(str(-J_hund) + '\n')
 
     # pair-hopping terms:
-    if H_dump:
-        H_dump_file.write('Pair-hopping terms:' + '\n')
-    for s1, s2 in product(spin_names, spin_names):
-        if s1 == s2:
-            continue
-        for a1, a2 in product(range(n_orb), range(n_orb)):
-            if a1 == a2:
+    if pair_hopping:
+        if H_dump:
+            H_dump_file.write('Pair-hopping terms:' + '\n')
+        for s1, s2 in product(spin_names, spin_names):
+            if s1 == s2:
                 continue
-            H_term = 0.5 * J_hund * c_dag(*mkind(s1, a1)) * c_dag(*mkind(s2, a1)) * c(*mkind(s2, a2)) * c(*mkind(s1, a2))
-            H += H_term
+            for a1, a2 in product(range(n_orb), range(n_orb)):
+                if a1 == a2:
+                    continue
+                H_term = 0.5 * J_hund * c_dag(*mkind(s1, a1)) * c_dag(*mkind(s2, a1)) * c(*mkind(s2, a2)) * c(*mkind(s1, a2))
+                H += H_term
 
-            # Dump terms of H
-            if H_dump and not H_term.is_zero():
-                H_dump_file.write('%s' % (mkind(s1, a1),) + '\t')
-                H_dump_file.write('%s' % (mkind(s2, a2),) + '\t')
-                H_dump_file.write(str(-J_hund) + '\n')
+                # Dump terms of H
+                if H_dump and not H_term.is_zero():
+                    H_dump_file.write('%s' % (mkind(s1, a1),) + '\t')
+                    H_dump_file.write('%s' % (mkind(s2, a2),) + '\t')
+                    H_dump_file.write(str(-J_hund) + '\n')
 
     return H
 

--- a/python/triqs/operators/util/hamiltonians.py
+++ b/python/triqs/operators/util/hamiltonians.py
@@ -19,24 +19,26 @@
 # Authors: Michel Ferrero, Gernot Kraberger, Igor Krivenko, Priyanka Seth, Nils Wentzell
 
 import operator
-from triqs.operators import *
-from .op_struct import *
+from triqs.operators import c, c_dag, n, Operator
+from .op_struct import get_mkind
 from itertools import product
 from functools import reduce
 
+
 # Helper function for backward compat and improved error messages
-def backward_compat(fname,n_orb,orb_names):
+def backward_compat(fname, n_orb, orb_names):
     if orb_names is not None:
-        raise RuntimeError("Argument orb_names is no longer supported. Please provide n_orb instead.")
+        raise RuntimeError('Argument orb_names is no longer supported. Please provide n_orb instead.')
     if isinstance(n_orb, list):
         import warnings
-        warnings.warn("{} takes as a second argument the number of orbitals, not a list of orbital names".format(fname))
+
+        warnings.warn('{} takes as a second argument the number of orbitals, not a list of orbital names'.format(fname))
         n_orb = len(n_orb)
     return n_orb
 
-# Define commonly-used Hamiltonians here: Slater, Kanamori, density-density
 
-def h_int_slater(spin_names,n_orb,U_matrix,off_diag=None,map_operator_structure=None,H_dump=None,complex=False,orb_names=None):
+# Define commonly-used Hamiltonians here: Slater, Kanamori, density-density
+def h_int_slater(spin_names, n_orb, U_matrix, off_diag=None, map_operator_structure=None, H_dump=None, complex=False, orb_names=None):
     r"""
     Create a Slater Hamiltonian using fully rotationally-invariant 4-index interactions:
 
@@ -70,34 +72,52 @@ def h_int_slater(spin_names,n_orb,U_matrix,off_diag=None,map_operator_structure=
         The Hamiltonian.
 
     """
-    n_orb = backward_compat("h_int_slater",n_orb,orb_names)
+    n_orb = backward_compat('h_int_slater', n_orb, orb_names)
 
     if H_dump:
-        H_dump_file = open(H_dump,'w')
-        H_dump_file.write("Slater Hamiltonian:" + '\n')
+        H_dump_file = open(H_dump, 'w')
+        H_dump_file.write('Slater Hamiltonian:' + '\n')
 
     H = Operator()
-    mkind = get_mkind(off_diag,map_operator_structure)
-    for s1, s2 in product(spin_names,spin_names):
+    mkind = get_mkind(off_diag, map_operator_structure)
+    for s1, s2 in product(spin_names, spin_names):
         for a1, a2, a3, a4 in product(range(n_orb), range(n_orb), range(n_orb), range(n_orb)):
-            U_val = U_matrix[a1,a2,a3,a4]
+            U_val = U_matrix[a1, a2, a3, a4]
             if abs(U_val.imag) > 1e-10 and not complex:
-                raise RuntimeError("Matrix elements of U are not real. Are you using a cubic basis?")
+                raise RuntimeError('Matrix elements of U are not real. Are you using a cubic basis?')
 
-            H_term = 0.5 * (U_val if complex else U_val.real) * c_dag(*mkind(s1,a1)) * c_dag(*mkind(s2,a2)) * c(*mkind(s2,a4)) * c(*mkind(s1,a3))
+            H_term = (
+                0.5
+                * (U_val if complex else U_val.real)
+                * c_dag(*mkind(s1, a1))
+                * c_dag(*mkind(s2, a2))
+                * c(*mkind(s2, a4))
+                * c(*mkind(s1, a3))
+            )
             H += H_term
 
             # Dump terms of H
             if H_dump and not H_term.is_zero():
-                H_dump_file.write('%s'%(mkind(s1,a1),) + '\t')
-                H_dump_file.write('%s'%(mkind(s2,a2),) + '\t')
-                H_dump_file.write('%s'%(mkind(s2,a3),) + '\t')
-                H_dump_file.write('%s'%(mkind(s1,a4),) + '\t')
+                H_dump_file.write('%s' % (mkind(s1, a1),) + '\t')
+                H_dump_file.write('%s' % (mkind(s2, a2),) + '\t')
+                H_dump_file.write('%s' % (mkind(s2, a3),) + '\t')
+                H_dump_file.write('%s' % (mkind(s1, a4),) + '\t')
                 H_dump_file.write(str(U_val.real) + '\n')
 
     return H
 
-def h_int_kanamori(spin_names,n_orb,U,Uprime,J_hund,off_diag=None,map_operator_structure=None,H_dump=None,orb_names=None):
+
+def h_int_kanamori(
+    spin_names,
+    n_orb,
+    U,
+    Uprime,
+    J_hund,
+    off_diag=None,
+    map_operator_structure=None,
+    H_dump=None,
+    orb_names=None,
+):
     r"""
     Create a Kanamori Hamiltonian using the density-density, spin-fip and pair-hopping interactions.
 
@@ -135,70 +155,74 @@ def h_int_kanamori(spin_names,n_orb,U,Uprime,J_hund,off_diag=None,map_operator_s
         The Hamiltonian.
 
     """
-    n_orb = backward_compat("h_int_kanamori",n_orb,orb_names)
+    n_orb = backward_compat('h_int_kanamori', n_orb, orb_names)
 
     if H_dump:
-        H_dump_file = open(H_dump,'w')
-        H_dump_file.write("Kanamori Hamiltonian:" + '\n')
+        H_dump_file = open(H_dump, 'w')
+        H_dump_file.write('Kanamori Hamiltonian:' + '\n')
 
     H = Operator()
-    mkind = get_mkind(off_diag,map_operator_structure)
+    mkind = get_mkind(off_diag, map_operator_structure)
 
     # density terms:
-    if H_dump: H_dump_file.write("Density-density terms:" + '\n')
-    for s1, s2 in product(spin_names,spin_names):
+    if H_dump:
+        H_dump_file.write('Density-density terms:' + '\n')
+    for s1, s2 in product(spin_names, spin_names):
         for a1, a2 in product(range(n_orb), range(n_orb)):
-            if (s1==s2):
-                U_val = U[a1,a2]
+            if s1 == s2:
+                U_val = U[a1, a2]
             else:
-                U_val = Uprime[a1,a2]
+                U_val = Uprime[a1, a2]
 
-            H_term = 0.5 * U_val * n(*mkind(s1,a1)) * n(*mkind(s2,a2))
+            H_term = 0.5 * U_val * n(*mkind(s1, a1)) * n(*mkind(s2, a2))
             H += H_term
 
             # Dump terms of H
             if H_dump and not H_term.is_zero():
-                H_dump_file.write('%s'%(mkind(s1,a1),) + '\t')
-                H_dump_file.write('%s'%(mkind(s2,a2),) + '\t')
+                H_dump_file.write('%s' % (mkind(s1, a1),) + '\t')
+                H_dump_file.write('%s' % (mkind(s2, a2),) + '\t')
                 H_dump_file.write(str(U_val) + '\n')
 
     # spin-flip terms:
-    if H_dump: H_dump_file.write("Spin-flip terms:" + '\n')
-    for s1, s2 in product(spin_names,spin_names):
-        if (s1==s2):
+    if H_dump:
+        H_dump_file.write('Spin-flip terms:' + '\n')
+    for s1, s2 in product(spin_names, spin_names):
+        if s1 == s2:
             continue
         for a1, a2 in product(range(n_orb), range(n_orb)):
-            if (a1==a2):
+            if a1 == a2:
                 continue
-            H_term = -0.5 * J_hund * c_dag(*mkind(s1,a1)) * c(*mkind(s2,a1)) * c_dag(*mkind(s2,a2)) * c(*mkind(s1,a2))
+            H_term = -0.5 * J_hund * c_dag(*mkind(s1, a1)) * c(*mkind(s2, a1)) * c_dag(*mkind(s2, a2)) * c(*mkind(s1, a2))
             H += H_term
 
             # Dump terms of H
             if H_dump and not H_term.is_zero():
-                H_dump_file.write('%s'%(mkind(s1,a1),) + '\t')
-                H_dump_file.write('%s'%(mkind(s2,a2),) + '\t')
+                H_dump_file.write('%s' % (mkind(s1, a1),) + '\t')
+                H_dump_file.write('%s' % (mkind(s2, a2),) + '\t')
                 H_dump_file.write(str(-J_hund) + '\n')
 
     # pair-hopping terms:
-    if H_dump: H_dump_file.write("Pair-hopping terms:" + '\n')
-    for s1, s2 in product(spin_names,spin_names):
-        if (s1==s2):
+    if H_dump:
+        H_dump_file.write('Pair-hopping terms:' + '\n')
+    for s1, s2 in product(spin_names, spin_names):
+        if s1 == s2:
             continue
         for a1, a2 in product(range(n_orb), range(n_orb)):
-            if (a1==a2):
+            if a1 == a2:
                 continue
-            H_term = 0.5 * J_hund * c_dag(*mkind(s1,a1)) * c_dag(*mkind(s2,a1)) * c(*mkind(s2,a2)) * c(*mkind(s1,a2))
+            H_term = 0.5 * J_hund * c_dag(*mkind(s1, a1)) * c_dag(*mkind(s2, a1)) * c(*mkind(s2, a2)) * c(*mkind(s1, a2))
             H += H_term
 
             # Dump terms of H
             if H_dump and not H_term.is_zero():
-                H_dump_file.write('%s'%(mkind(s1,a1),) + '\t')
-                H_dump_file.write('%s'%(mkind(s2,a2),) + '\t')
+                H_dump_file.write('%s' % (mkind(s1, a1),) + '\t')
+                H_dump_file.write('%s' % (mkind(s2, a2),) + '\t')
                 H_dump_file.write(str(-J_hund) + '\n')
 
     return H
 
-def h_int_density(spin_names,n_orb,U,Uprime,off_diag=None,map_operator_structure=None,H_dump=None,orb_names=None):
+
+def h_int_density(spin_names, n_orb, U, Uprime, off_diag=None, map_operator_structure=None, H_dump=None, orb_names=None):
     r"""
     Create a density-density Hamiltonian.
 
@@ -232,32 +256,34 @@ def h_int_density(spin_names,n_orb,U,Uprime,off_diag=None,map_operator_structure
         The Hamiltonian.
 
     """
-    n_orb = backward_compat("h_int_density",n_orb,orb_names)
+    n_orb = backward_compat('h_int_density', n_orb, orb_names)
 
     if H_dump:
-        H_dump_file = open(H_dump,'w')
-        H_dump_file.write("Density-density Hamiltonian:" + '\n')
+        H_dump_file = open(H_dump, 'w')
+        H_dump_file.write('Density-density Hamiltonian:' + '\n')
 
     H = Operator()
-    mkind = get_mkind(off_diag,map_operator_structure)
-    if H_dump: H_dump_file.write("Density-density terms:" + '\n')
-    for s1, s2 in product(spin_names,spin_names):
-        for a1, a2 in product(range(n_orb),range(n_orb)):
-            if (s1==s2):
-                U_val = U[a1,a2]
+    mkind = get_mkind(off_diag, map_operator_structure)
+    if H_dump:
+        H_dump_file.write('Density-density terms:' + '\n')
+    for s1, s2 in product(spin_names, spin_names):
+        for a1, a2 in product(range(n_orb), range(n_orb)):
+            if s1 == s2:
+                U_val = U[a1, a2]
             else:
-                U_val = Uprime[a1,a2]
+                U_val = Uprime[a1, a2]
 
-            H_term = 0.5 * U_val * n(*mkind(s1,a1)) * n(*mkind(s2,a2))
+            H_term = 0.5 * U_val * n(*mkind(s1, a1)) * n(*mkind(s2, a2))
             H += H_term
 
             # Dump terms of H
             if H_dump and not H_term.is_zero():
-                H_dump_file.write('%s'%(mkind(s1,a1),) + '\t')
-                H_dump_file.write('%s'%(mkind(s2,a2),) + '\t')
+                H_dump_file.write('%s' % (mkind(s1, a1),) + '\t')
+                H_dump_file.write('%s' % (mkind(s2, a2),) + '\t')
                 H_dump_file.write(str(U_val) + '\n')
 
     return H
+
 
 def diagonal_part(H):
     r"""
@@ -281,13 +307,14 @@ def diagonal_part(H):
         c_ind, c_dag_ind = set(), set()
         for dag, ind in indices:
             (c_dag_ind if dag else c_ind).add(tuple(ind))
-        if c_ind == c_dag_ind: # This monomial is of n-type
-            n_part += coeff * reduce(operator.mul,
-                              [c_dag(*dag_ind[1]) if dag_ind[0] else c(*dag_ind[1]) for dag_ind in indices],
-                              Operator(1))
+        if c_ind == c_dag_ind:  # This monomial is of n-type
+            n_part += coeff * reduce(
+                operator.mul, [c_dag(*dag_ind[1]) if dag_ind[0] else c(*dag_ind[1]) for dag_ind in indices], Operator(1)
+            )
     return n_part
 
-def make_operator_real(H, tol = 0):
+
+def make_operator_real(H, tol=0):
     r"""
     Return the real part of a given operator H checking that its
     imaginary part is below tolerance.
@@ -306,5 +333,5 @@ def make_operator_real(H, tol = 0):
              The real part of H.
     """
     if any(abs(term[-1].imag) > tol for term in H):
-        raise RuntimeError("A coefficient of the operator has an imaginary part above tolerance")
+        raise RuntimeError('A coefficient of the operator has an imaginary part above tolerance')
     return H.real

--- a/test/python/base/brillouin_zone.py
+++ b/test/python/base/brillouin_zone.py
@@ -46,7 +46,7 @@ class test_brillouin_zone(unittest.TestCase):
         
         tol = 1e-9
         
-        for idx, (k, k_val) in enumerate(zip(k_mesh, k_mesh.values())):
+        for idx, (k, k_val) in enumerate(zip(k_mesh, k_mesh.values)):
 
             assert( max(abs(k.value - k_val)) < tol )
             

--- a/test/python/base/gf_dlr.py
+++ b/test/python/base/gf_dlr.py
@@ -206,7 +206,7 @@ class test_dlr_mesh(unittest.TestCase):
         beta = 20
         tau_mesh = MeshDLRImTime(beta = beta, statistic = 'Boson', w_max = 2.0, eps = 1e-14, symmetrize = True)
 
-        tau_values = np.fromiter(tau_mesh.values(), dtype=float)
+        tau_values = tau_mesh.values
         assert(np.allclose(tau_values, beta - tau_values[::-1]))
 
         gtau = Gf(mesh = tau_mesh, target_shape = [])
@@ -216,8 +216,8 @@ class test_dlr_mesh(unittest.TestCase):
         gdlr = make_gf_dlr(gtau)
         giw  = make_gf_dlr_imfreq(gdlr)
 
-        iw_values = np.fromiter(giw.mesh.values(), dtype=complex)
-        assert(np.allclose(iw_values, -iw_values[::-1]))
+        iw_values = giw.mesh.values
+        assert(np.array_equal(iw_values, -iw_values[::-1]))
         assert(len(iw_values) % 2 == 1) # odd number of frequencies
 
         assert_gfs_are_close(make_gf_dlr_imtime(make_gf_dlr(giw)), gtau)


### PR DESCRIPTION
This PR allows 
* to select specifically spin-flip and / or pair-hopping terms are added in the construction of the `h_int_kanamori` many-body operator. Additionally I run auto format on the python file. 
* fixes `x_data_view`: for MeshReFreq objects it would only give back a np array of mesh points for `X`
* extend `x_data_view` to MeshImTime
* speed up `x_data_view` by removing for loop to extract `X` values