### PR TITLE
Add dlr symmetrize accessor in c++ and Python

### DIFF
--- a/c++/triqs/mesh/dlr.hpp
+++ b/c++/triqs/mesh/dlr.hpp
@@ -152,6 +152,9 @@ namespace triqs::mesh {
     /// Representation accuracy
     [[nodiscard]] double eps() const noexcept { return _eps; }
 
+    /// Symmetric grid flag
+    [[nodiscard]] bool symmetrize() const noexcept { return _symmetrize; }
+
     /// The vector of DLR frequencies
     [[nodiscard]] auto const &dlr_freq() const { return _dlr->freq; }
 

--- a/c++/triqs/mesh/dlr_imfreq.hpp
+++ b/c++/triqs/mesh/dlr_imfreq.hpp
@@ -144,6 +144,9 @@ namespace triqs::mesh {
     /// Representation accuracy
     [[nodiscard]] double eps() const noexcept { return _eps; }
 
+    /// Symmetric grid flag
+    [[nodiscard]] bool symmetrize() const noexcept { return _symmetrize; }
+
     /// The vector of DLR frequencies
     [[nodiscard]] auto const &dlr_freq() const { return _dlr->freq; }
 

--- a/c++/triqs/mesh/dlr_imtime.hpp
+++ b/c++/triqs/mesh/dlr_imtime.hpp
@@ -147,6 +147,9 @@ namespace triqs::mesh {
     /// Representation accuracy
     [[nodiscard]] double eps() const noexcept { return _eps; }
 
+    /// Symmetric grid flag
+    [[nodiscard]] bool symmetrize() const noexcept { return _symmetrize; }
+
     /// The vector of DLR frequencies
     [[nodiscard]] auto const &dlr_freq() const { return _dlr->freq; }
 

--- a/python/triqs/gf/meshes_desc.py
+++ b/python/triqs/gf/meshes_desc.py
@@ -172,6 +172,10 @@ m.add_property(name = "eps",
                getter = cfunction(calling_pattern="double result = self_c.eps()",
                signature = "double()",
                doc = "Representation accuracy"))
+m.add_property(name = "symmetrize",
+               getter = cfunction(calling_pattern="bool result = self_c.symmetrize()",
+               signature = "bool()",
+               doc = "Symmetry grid flag"))
 
 module.add_class(m)
 
@@ -256,6 +260,10 @@ m.add_property(name = "eps",
                getter = cfunction(calling_pattern="double result = self_c.eps()",
                signature = "double()",
                doc = "Representation accuracy"))
+m.add_property(name = "symmetrize",
+               getter = cfunction(calling_pattern="bool result = self_c.symmetrize()",
+               signature = "bool()",
+               doc = "Symmetry grid flag"))
 
 module.add_class(m)
 
@@ -307,6 +315,10 @@ m.add_property(name = "eps",
                getter = cfunction(calling_pattern="double result = self_c.eps()",
                signature = "double()",
                doc = "Representation accuracy"))
+m.add_property(name = "symmetrize",
+               getter = cfunction(calling_pattern="bool result = self_c.symmetrize()",
+               signature = "bool()",
+               doc = "Symmetry grid flag"))
 
 module.add_class(m)
 

--- a/test/c++/gfs/gf_dlr.cpp
+++ b/test/c++/gfs/gf_dlr.cpp
@@ -36,6 +36,46 @@ using std::exp;
 auto onefermion(auto tau, double eps, double beta) { return -exp(-eps * tau) / (1 + exp(-beta * eps)); }
 
 // ------------------------------------------------------------
+// Check mesh accessors
+TEST(Gf, dlr_accessors) {
+
+  double beta  = 5;
+  double w_max = 20.0;
+  double eps   = 1e-10;
+  bool symmetrize = true;
+
+  { // dlr mesh
+  auto g = gf<dlr, matrix_valued>{{beta, Fermion, w_max, eps, symmetrize}, {1, 1}};
+
+  EXPECT_EQ(g.mesh().beta(), beta);
+  EXPECT_EQ(g.mesh().eps(), eps);
+  EXPECT_EQ(g.mesh().w_max(), w_max);
+  EXPECT_EQ(g.mesh().statistic(), Fermion);
+  EXPECT_EQ(g.mesh().symmetrize(), symmetrize);
+  }
+
+  { // dlr_imtime
+  auto g = gf<dlr_imtime, matrix_valued>{{beta, Fermion, w_max, eps, symmetrize}, {1, 1}};
+
+  EXPECT_EQ(g.mesh().beta(), beta);
+  EXPECT_EQ(g.mesh().eps(), eps);
+  EXPECT_EQ(g.mesh().w_max(), w_max);
+  EXPECT_EQ(g.mesh().statistic(), Fermion);
+  EXPECT_EQ(g.mesh().symmetrize(), symmetrize);
+  }
+
+  { // dlr_imfreq
+  auto g = gf<dlr_imfreq, matrix_valued>{{beta, Fermion, w_max, eps, symmetrize}, {1, 1}};
+
+  EXPECT_EQ(g.mesh().beta(), beta);
+  EXPECT_EQ(g.mesh().eps(), eps);
+  EXPECT_EQ(g.mesh().w_max(), w_max);
+  EXPECT_EQ(g.mesh().statistic(), Fermion);
+  EXPECT_EQ(g.mesh().symmetrize(), symmetrize);
+  }
+}
+
+// ------------------------------------------------------------
 // Take a gf in time, go to coeffs, to freq, and back and check evals.
 TEST(Gf, dlr_mat) {
 

--- a/test/python/base/gf_dlr.py
+++ b/test/python/base/gf_dlr.py
@@ -33,18 +33,19 @@ class test_dlr_mesh(unittest.TestCase):
 
     def test_dlr_meshes(self):
 
-        beta, eps, w_max = 1.337, 1e-9, 100.
+        beta, eps, w_max, symmetrize = 1.337, 1e-9, 100., True
 
         MeshTypes = [MeshDLRImTime, MeshDLRImFreq, MeshDLR]
 
         for MeshType in MeshTypes:
 
-            m = MeshType(beta, 'Fermion', w_max, eps)
+            m = MeshType(beta, 'Fermion', w_max, eps, symmetrize)
 
             assert( m.beta == beta )
             assert( m.statistic == 'Fermion' )
             assert( m.eps == eps )
             assert( m.w_max == w_max )
+            assert( m.symmetrize == symmetrize )
 
             mps = np.array([ p.value for p in m ])
 


### PR DESCRIPTION
Dear Triqs developers,

We have a need to detect whether a DLR mesh is symmetrized or not in TPRF. Currently we are doing an ugly workaround as shown here,
https://github.com/TRIQS/tprf/commit/e3be3255daa94470677ceb3a280a47429bcc0fef#diff-78485b87de5ccec7d62189eee29d596341dd684b44a2d6b24038040225c1fe94R206

This pull request exposes the `symmetrize` mesh internal flag to the user in c++ and Python.

I would appreciate feedback and consideration to merge in unstable. If possible a backport to 3.3.x would be very much appreciated.

Best, Hugo