### PR TITLE
Enabled callback function in the accumulator

### DIFF
--- a/c++/triqs/gfs/transform/fourier.hpp
+++ b/c++/triqs/gfs/transform/fourier.hpp
@@ -39,6 +39,10 @@ namespace triqs::gfs {
   gf_vec_t<imfreq> _fourier_impl(imfreq const &iw_mesh, gf_vec_cvt<imtime> gt, array_const_view<dcomplex, 2> known_moments = {});
   gf_vec_t<imtime> _fourier_impl(imtime const &tau_mesh, gf_vec_cvt<imfreq> gw, array_const_view<dcomplex, 2> known_moments = {});
 
+  // dlr
+  inline gf_vec_t<dlr_imfreq> _fourier_impl(dlr_imfreq const &, gf_vec_cvt<dlr_imtime> gt) { return make_gf_dlr_imfreq(gt); }
+  inline gf_vec_t<dlr_imtime> _fourier_impl(dlr_imtime const &, gf_vec_cvt<dlr_imfreq> gw) { return make_gf_dlr_imtime(gw); }
+
   // real
   gf_vec_t<refreq> _fourier_impl(refreq const &w_mesh, gf_vec_cvt<retime> gt, array_const_view<dcomplex, 2> known_moments = {});
   gf_vec_t<retime> _fourier_impl(retime const &t_mesh, gf_vec_cvt<refreq> gw, array_const_view<dcomplex, 2> known_moments = {});
@@ -133,6 +137,14 @@ namespace triqs::gfs {
 
   template <int N = 0, typename T> gf<imfreq, typename T::complex_t> make_gf_from_fourier(gf_const_view<imtime, T> gin, int n_iw = -1) {
     return make_gf_from_fourier(gin, make_adjoint_mesh(gin.mesh(), n_iw));
+  }
+
+  template <int N = 0, typename T> gf<dlr_imtime, T> make_gf_from_fourier(gf_const_view<dlr_imfreq, T> gin) {
+    return make_gf_from_fourier(gin, make_adjoint_mesh(gin.mesh()));
+  }
+
+  template <int N = 0, typename T> gf<dlr_imfreq, typename T::complex_t> make_gf_from_fourier(gf_const_view<dlr_imtime, T> gin) {
+    return make_gf_from_fourier(gin, make_adjoint_mesh(gin.mesh()));
   }
 
   template <int N = 0, typename T> gf<retime, T> make_gf_from_fourier(gf_const_view<refreq, T> gin, bool shift_half_bin = false) {

--- a/c++/triqs/mc_tools/mc_generic.hpp
+++ b/c++/triqs/mc_tools/mc_generic.hpp
@@ -276,7 +276,7 @@ namespace triqs::mc_tools {
             ++config_id;
           }
           if (after_cycle_duty) { after_cycle_duty(); }
-          if (calibrate_moves) AllMoves.calibrate();
+          if (calibrate_moves) AllMoves.calibrate(c);
           if (do_measure) {
             nmeasures++;
             for (auto &x : AllMeasuresAux) x();

--- a/c++/triqs/mc_tools/mc_generic.hpp
+++ b/c++/triqs/mc_tools/mc_generic.hpp
@@ -305,12 +305,12 @@ namespace triqs::mc_tools {
           }
           if (do_measure) report(3) << AllMeasures.report();
           next_info_time = 1.25 * timer_run + 2.0; // Increase time interval non-linearly
+
+          // Stop if an emergeny occured on any node
+          if (node_monitor) stop_it = node_monitor->emergency_occured();
         }
         finished = NC + 1 >= n_cycles and not infinite;
-        stop_it  = (stop_callback() || triqs::signal_handler::received() || finished);
-
-        // Stop if an emergeny occured on any node
-        if (node_monitor) stop_it |= node_monitor->emergency_occured();
+        stop_it |= (stop_callback() || triqs::signal_handler::received() || finished);
 
       } // end main NC loop
 

--- a/c++/triqs/mc_tools/mc_generic.hpp
+++ b/c++/triqs/mc_tools/mc_generic.hpp
@@ -263,14 +263,14 @@ namespace triqs::mc_tools {
         try {
           // Metropolis loop. Switch here for HeatBath, etc...
           for (int64_t k = 1; (k <= length_cycle); k++) {
-            if (triqs::signal_handler::received()) throw triqs::signal_handler::exception{};
+            if ((k % 10 == 0) and (triqs::signal_handler::received())) throw triqs::signal_handler::exception{};
             double r = AllMoves.attempt();
             if (RandomGenerator() < std::min(1.0, r)) {
-              if (debug) std::cerr << " Move accepted " << std::endl;
+              if constexpr (debug) std::cerr << " Move accepted " << std::endl;
               sign *= AllMoves.accept();
-              if (debug) std::cerr << " New sign = " << sign << std::endl;
+              if constexpr (debug) std::cerr << " New sign = " << sign << std::endl;
             } else {
-              if (debug) std::cerr << " Move rejected " << std::endl;
+              if constexpr (debug) std::cerr << " Move rejected " << std::endl;
               AllMoves.reject();
             }
             ++config_id;
@@ -296,7 +296,7 @@ namespace triqs::mc_tools {
 
         // recompute fraction done
         done_percent = int64_t(floor(((NC + 1) * 100.0) / n_cycles));
-        if (timer_run > next_info_time || done_percent == 100) {
+        if (timer_run > next_info_time || done_percent >= 100) {
           if (infinite) {
             report(3) << utility::timestamp() << " cycle " << NC << std::endl;
           } else {

--- a/c++/triqs/mc_tools/mc_generic.hpp
+++ b/c++/triqs/mc_tools/mc_generic.hpp
@@ -240,7 +240,8 @@ namespace triqs::mc_tools {
      *    =  =============================================
      *
      */
-    int run(int64_t n_cycles, int64_t length_cycle, std::function<bool()> stop_callback, bool do_measure, mpi::communicator c = mpi::communicator{}) {
+    int run(int64_t n_cycles, int64_t length_cycle, std::function<bool()> stop_callback, bool do_measure, mpi::communicator c = mpi::communicator{},
+            bool calibrate_moves = false) {
       EXPECTS(length_cycle > 0);
 
       AllMoves.clear_statistics();
@@ -275,6 +276,7 @@ namespace triqs::mc_tools {
             ++config_id;
           }
           if (after_cycle_duty) { after_cycle_duty(); }
+          if (calibrate_moves) AllMoves.calibrate();
           if (do_measure) {
             nmeasures++;
             for (auto &x : AllMeasuresAux) x();

--- a/c++/triqs/mc_tools/mc_move_set.hpp
+++ b/c++/triqs/mc_tools/mc_move_set.hpp
@@ -25,303 +25,321 @@
 #include <functional>
 #include "./random_generator.hpp"
 
-namespace triqs {
-  namespace mc_tools {
+namespace triqs::mc_tools {
 
-    template <typename MCSignType> class move_set;
+  template <typename MCSignType> class move_set;
 
-    // Type erasure for any object modeling the Move concept
-    template <typename MCSignType> class move {
+  // Type erasure for any object modeling the Move concept
+  template <typename MCSignType> class move {
 
-      // using a simple erasure pattern.
-      // i) Take the method as lambda, capturing the object
-      // ii) keep it in a shared_ptr (impl_).
-      // iii) restore almost Regular Type semantics, except default construction.
-      //      in particular copy DOES copy ...
+    // using a simple erasure pattern.
+    // i) Take the method as lambda, capturing the object
+    // ii) keep it in a shared_ptr (impl_).
+    // iii) restore almost Regular Type semantics, except default construction.
+    //      in particular copy DOES copy ...
 
-      std::shared_ptr<void> impl_;
-      std::function<MCSignType()> attempt_, accept_;
-      std::function<void()> reject_;
-      std::function<void(mpi::communicator const &)> collect_statistics_;
-      std::function<void(h5::group, std::string const &)> h5_r, h5_w;
+    std::shared_ptr<void> impl_;
+    std::function<MCSignType()> attempt_, accept_;
+    std::function<void()> reject_;
+    std::function<void(mpi::communicator const &)> calibrate_;
+    std::function<void(mpi::communicator const &)> collect_statistics_;
+    std::function<void(h5::group, std::string const &)> h5_r, h5_w;
 
-      uint64_t NProposed, Naccepted;
-      double acceptance_rate_;
-      bool is_move_set_; // need to remember if the move was a move_set for printing details later.
+    uint64_t NProposed, Naccepted;
+    double acceptance_rate_;
+    bool is_move_set_; // need to remember if the move was a move_set for printing details later.
 
 #ifdef TRIQS_MCTOOLS_DEBUG
-      static constexpr bool debug = true;
+    static constexpr bool debug = true;
 #else
-      static constexpr bool debug = false;
+    static constexpr bool debug = false;
 #endif
 
-      public:
-      /// Construct from any m modeling MoveType. bool is here to disambiguate with basic copy/move construction.
-      template <typename MoveType> move(bool, MoveType &&m) {
-        static_assert(std::is_move_constructible<MoveType>::value, "This move is not MoveConstructible");
-        static_assert(
-           requires { m.attempt(); }, "This move has no attempt method (or is has an incorrect signature) !");
-        static_assert(
-           requires { m.accept(); }, "This move has no accept method (or is has an incorrect signature) !");
-        static_assert(
-           requires { m.reject(); }, "This move has no reject method (or is has an incorrect signature) !");
-        using m_t           = std::decay_t<MoveType>;
-        m_t *p              = new m_t(std::forward<MoveType>(m)); // moving or copying
-        impl_               = std::shared_ptr<m_t>(p);
-        attempt_            = [p]() { return p->attempt(); };
-        accept_             = [p]() { return p->accept(); };
-        reject_             = [p]() { p->reject(); };
-        collect_statistics_ = [p](mpi::communicator c) {
-          if constexpr (requires { p->collect_statistics(c); }) p->collect_statistics(c);
-          else (void)p; // suppress clang -Wunused-lambda-capture warning
-        };
-        h5_r = [p](h5::group g, std::string const &name) {
-          if constexpr (requires { h5_read(g, name, *p); }) h5_read(g, name, *p);
-          else (void)p; // suppress clang -Wunused-lambda-capture warning
-        };
-        h5_w = [p](h5::group g, std::string const &name) {
-          if constexpr (requires { h5_write(g, name, *p); }) h5_write(g, name, *p);
-          else (void)p; // suppress clang -Wunused-lambda-capture warning
-        };
-        NProposed        = 0;
-        Naccepted        = 0;
-        acceptance_rate_ = -1;
-        is_move_set_     = std::is_same<MoveType, move_set<MCSignType>>::value;
-      }
+    public:
+    /// Construct from any m modeling MoveType. bool is here to disambiguate with basic copy/move construction.
+    template <typename MoveType> move(bool, MoveType &&m) {
+      static_assert(std::is_move_constructible<MoveType>::value, "This move is not MoveConstructible");
+      static_assert(requires { m.attempt(); }, "This move has no attempt method (or is has an incorrect signature) !");
+      static_assert(requires { m.accept(); }, "This move has no accept method (or is has an incorrect signature) !");
+      static_assert(requires { m.reject(); }, "This move has no reject method (or is has an incorrect signature) !");
+      using m_t = std::decay_t<MoveType>;
+      m_t *p    = new m_t(std::forward<MoveType>(m)); // moving or copying
+      impl_     = std::shared_ptr<m_t>(p);
+      attempt_  = [p]() { return p->attempt(); };
+      accept_   = [p]() { return p->accept(); };
+      reject_   = [p]() { p->reject(); };
 
-      // no default constructor.
-      move(move const &rhs)            = delete;
-      move(move &&rhs)                 = default;
-      move &operator=(move const &rhs) = delete;
-      move &operator=(move &&rhs)      = default;
-
-      MCSignType attempt() {
-        NProposed++;
-        return attempt_();
-      }
-      MCSignType accept() {
-        Naccepted++;
-        return accept_();
-      }
-      void reject() { reject_(); }
-
-      double acceptance_rate() const { return acceptance_rate_; }
-      uint64_t n_proposed_config() const { return NProposed; }
-      uint64_t n_accepted_config() const { return Naccepted; }
-
-      void clear_statistics() {
-        NProposed        = 0;
-        Naccepted        = 0;
-        acceptance_rate_ = -1;
-      }
-
-      void collect_statistics(mpi::communicator const &c) {
-        uint64_t nacc_tot  = mpi::all_reduce(Naccepted, c);
-        uint64_t nprop_tot = mpi::all_reduce(NProposed, c);
-        acceptance_rate_   = nacc_tot / static_cast<double>(nprop_tot);
-        if (collect_statistics_) collect_statistics_(c);
-      }
-
-      move_set<MCSignType> *as_move_set() const { return is_move_set_ ? static_cast<move_set<MCSignType> *>(impl_.get()) : nullptr; }
-
-      // redirect the h5 call to the object lambda, if it not empty (i.e. if the underlying object can be called with h5_read/write
-      friend void h5_write(h5::group g, std::string const &name, move const &m) {
-        if (m.h5_w) m.h5_w(g, name);
+      calibrate_ = [p](mpi::communicator c) {
+        if constexpr (requires { p->calibrate(c); })
+          p->calibrate(c);
+        else if constexpr (requires { p->calibrate(); })
+          p->calibrate();
+        else
+          (void)p; // suppress clang -Wunused-lambda-capture warning
       };
-      friend void h5_read(h5::group g, std::string const &name, move &m) {
-        if (m.h5_r) m.h5_r(g, name);
+      collect_statistics_ = [p](mpi::communicator c) {
+        if constexpr (requires { p->collect_statistics(c); })
+          p->collect_statistics(c);
+        else
+          (void)p; // suppress clang -Wunused-lambda-capture warning
       };
+      h5_r = [p](h5::group g, std::string const &name) {
+        if constexpr (requires { h5_read(g, name, *p); })
+          h5_read(g, name, *p);
+        else
+          (void)p; // suppress clang -Wunused-lambda-capture warning
+      };
+      h5_w = [p](h5::group g, std::string const &name) {
+        if constexpr (requires { h5_write(g, name, *p); })
+          h5_write(g, name, *p);
+        else
+          (void)p; // suppress clang -Wunused-lambda-capture warning
+      };
+      NProposed        = 0;
+      Naccepted        = 0;
+      acceptance_rate_ = -1;
+      is_move_set_     = std::is_same<MoveType, move_set<MCSignType>>::value;
+    }
+
+    // no default constructor.
+    move(move const &rhs)            = delete;
+    move(move &&rhs)                 = default;
+    move &operator=(move const &rhs) = delete;
+    move &operator=(move &&rhs)      = default;
+
+    MCSignType attempt() {
+      NProposed++;
+      return attempt_();
+    }
+    MCSignType accept() {
+      Naccepted++;
+      return accept_();
+    }
+    void reject() { reject_(); }
+
+    double acceptance_rate() const { return acceptance_rate_; }
+    uint64_t n_proposed_config() const { return NProposed; }
+    uint64_t n_accepted_config() const { return Naccepted; }
+
+    void clear_statistics() {
+      NProposed        = 0;
+      Naccepted        = 0;
+      acceptance_rate_ = -1;
+    }
+
+    void calibrate(mpi::communicator c) { calibrate_(c); }
+
+    void collect_statistics(mpi::communicator const &c) {
+      uint64_t nacc_tot  = mpi::all_reduce(Naccepted, c);
+      uint64_t nprop_tot = mpi::all_reduce(NProposed, c);
+      acceptance_rate_   = nacc_tot / static_cast<double>(nprop_tot);
+      if (collect_statistics_) collect_statistics_(c);
+    }
+
+    move_set<MCSignType> *as_move_set() const { return is_move_set_ ? static_cast<move_set<MCSignType> *>(impl_.get()) : nullptr; }
+
+    // redirect the h5 call to the object lambda, if it not empty (i.e. if the underlying object can be called with h5_read/write
+    friend void h5_write(h5::group g, std::string const &name, move const &m) {
+      if (m.h5_w) m.h5_w(g, name);
     };
+    friend void h5_read(h5::group g, std::string const &name, move &m) {
+      if (m.h5_r) m.h5_r(g, name);
+    };
+  };
 
-    //--------------------------------------------------------------------
+  //--------------------------------------------------------------------
 
-    /// A vector of (moves, proposition_probability), which is also a move itself
-    template <typename MCSignType> class move_set {
-      std::vector<move<MCSignType>> move_vec;
-      std::vector<std::string> names_;
-      move<MCSignType> *current;
-      size_t current_move_number;
-      random_generator *RNG;
-      std::vector<double> Proba_Moves, Proba_Moves_Acc_Sum;
-      MCSignType try_sign_ratio;
-      uint64_t debug_counter;
+  /// A vector of (moves, proposition_probability), which is also a move itself
+  template <typename MCSignType> class move_set {
+    std::vector<move<MCSignType>> move_vec;
+    std::vector<std::string> names_;
+    move<MCSignType> *current;
+    size_t current_move_number;
+    random_generator *RNG;
+    std::vector<double> Proba_Moves, Proba_Moves_Acc_Sum;
+    MCSignType try_sign_ratio;
+    uint64_t debug_counter;
 
 #ifdef TRIQS_MCTOOLS_DEBUG
-      static constexpr bool debug = true;
+    static constexpr bool debug = true;
 #else
-      static constexpr bool debug = false;
+    static constexpr bool debug = false;
 #endif
 
-      public:
-      /// Need a random_generator for attempt, see below...
-      move_set(random_generator &R) : RNG(&R) {
-        Proba_Moves.push_back(0);
-        debug_counter = 0;
-      }
+    public:
+    /// Need a random_generator for attempt, see below...
+    move_set(random_generator &R) : RNG(&R) {
+      Proba_Moves.push_back(0);
+      debug_counter = 0;
+    }
 
-      move_set(move_set const &rhs)            = delete;
-      move_set(move_set &&rhs)                 = default;
-      move_set &operator=(move_set const &rhs) = delete;
-      move_set &operator=(move_set &&rhs)      = default;
+    move_set(move_set const &rhs)            = delete;
+    move_set(move_set &&rhs)                 = default;
+    move_set &operator=(move_set const &rhs) = delete;
+    move_set &operator=(move_set &&rhs)      = default;
 
-      /**
+    /**
    * Add move M with its probability of being proposed.
    * NB : the proposition_probability needs to be >0 but does not need to be
    * normalized. Normalization is automatically done with all the added moves
    * before starting the run
    */
-      template <typename MoveType> void add(MoveType &&M, std::string name, double proposition_probability) {
-        move_vec.emplace_back(true, std::forward<MoveType>(M));
-        assert(proposition_probability >= 0);
-        Proba_Moves.push_back(proposition_probability);
-        names_.push_back(name);
-        normaliseProba(); // ready to run after each add !
+    template <typename MoveType> void add(MoveType &&M, std::string name, double proposition_probability) {
+      move_vec.emplace_back(true, std::forward<MoveType>(M));
+      assert(proposition_probability >= 0);
+      Proba_Moves.push_back(proposition_probability);
+      names_.push_back(name);
+      normaliseProba(); // ready to run after each add !
+    }
+
+    private:
+    bool attempt_treat_infinite_ratio(std::complex<double>, double &) { return true; }
+
+    bool attempt_treat_infinite_ratio(double rate_ratio, double &abs_rate_ratio) {
+      bool is_inf = std::isinf(rate_ratio);
+      if (is_inf) {                                           // in case the ratio is infinite
+        abs_rate_ratio = 100;                                 // 1.e30; // >1 for metropolis
+        try_sign_ratio = (std::signbit(rate_ratio) ? -1 : 1); // signbit -> true iif the number is negative
       }
+      return !is_inf;
+    }
 
-      private:
-      bool attempt_treat_infinite_ratio(std::complex<double>, double &) { return true; }
-
-      bool attempt_treat_infinite_ratio(double rate_ratio, double &abs_rate_ratio) {
-        bool is_inf = std::isinf(rate_ratio);
-        if (is_inf) {                                           // in case the ratio is infinite
-          abs_rate_ratio = 100;                                 // 1.e30; // >1 for metropolis
-          try_sign_ratio = (std::signbit(rate_ratio) ? -1 : 1); // signbit -> true iif the number is negative
-        }
-        return !is_inf;
-      }
-
-      public:
-      /**
+    public:
+    /**
    *  - Picks up one of the move at random (weighted by their proposition probability),
    *  - Call attempt method of that move
    *  - Returns the metropolis ratio R (see move concept).
    *    The sign ratio returned by the try method of the move is kept.
    */
-      double attempt() {
-        assert(Proba_Moves_Acc_Sum.size() > 0);
-        if (move_vec.size() == 0) TRIQS_RUNTIME_ERROR << "ERROR in attempting Monte-Carlo Move: No move was registered!";
-        // Choice of move with its probability
-        double proba = (*RNG)();
-        assert(proba >= 0);
-        current_move_number = 0;
-        while (proba >= Proba_Moves_Acc_Sum[current_move_number]) { current_move_number++; }
-        assert(current_move_number > 0);
-        assert(current_move_number <= move_vec.size());
-        current_move_number--;
-        current = &move_vec[current_move_number];
-        if (debug) {
-          std::cerr << "*******************************************************" << std::endl;
-          std::cerr << "move number : " << debug_counter++ << std::endl;
-          std::cerr << "Name of the proposed move: " << name_of_currently_selected() << std::endl;
-          std::cerr << "  Proposition probability = " << proba << std::endl;
-        }
-        MCSignType rate_ratio = current->attempt();
-        double abs_rate_ratio;
-        if (attempt_treat_infinite_ratio(rate_ratio, abs_rate_ratio)) { // in case the ratio is infinite
-          if (!std::isfinite(std::abs(rate_ratio)))
-            TRIQS_RUNTIME_ERROR << "Monte Carlo Error : the rate (" << rate_ratio << ") is not finite in move " << name_of_currently_selected();
-          abs_rate_ratio = std::abs(rate_ratio);
-          if (debug) std::cerr << " Metropolis ratio " << rate_ratio << ". Abs(Metropolis ratio) " << abs_rate_ratio << std::endl;
-          assert((abs_rate_ratio >= 0));
-          try_sign_ratio = (abs_rate_ratio > 1.e-14 ? rate_ratio / abs_rate_ratio : 1); // keep the sign
-        }
-        return abs_rate_ratio;
+    double attempt() {
+      assert(Proba_Moves_Acc_Sum.size() > 0);
+      if (move_vec.size() == 0) TRIQS_RUNTIME_ERROR << "ERROR in attempting Monte-Carlo Move: No move was registered!";
+      // Choice of move with its probability
+      double proba = (*RNG)();
+      assert(proba >= 0);
+      current_move_number = 0;
+      while (proba >= Proba_Moves_Acc_Sum[current_move_number]) { current_move_number++; }
+      assert(current_move_number > 0);
+      assert(current_move_number <= move_vec.size());
+      current_move_number--;
+      current = &move_vec[current_move_number];
+      if (debug) {
+        std::cerr << "*******************************************************" << std::endl;
+        std::cerr << "move number : " << debug_counter++ << std::endl;
+        std::cerr << "Name of the proposed move: " << name_of_currently_selected() << std::endl;
+        std::cerr << "  Proposition probability = " << proba << std::endl;
       }
+      MCSignType rate_ratio = current->attempt();
+      double abs_rate_ratio;
+      if (attempt_treat_infinite_ratio(rate_ratio, abs_rate_ratio)) { // in case the ratio is infinite
+        if (!std::isfinite(std::abs(rate_ratio)))
+          TRIQS_RUNTIME_ERROR << "Monte Carlo Error : the rate (" << rate_ratio << ") is not finite in move " << name_of_currently_selected();
+        abs_rate_ratio = std::abs(rate_ratio);
+        if (debug) std::cerr << " Metropolis ratio " << rate_ratio << ". Abs(Metropolis ratio) " << abs_rate_ratio << std::endl;
+        assert((abs_rate_ratio >= 0));
+        try_sign_ratio = (abs_rate_ratio > 1.e-14 ? rate_ratio / abs_rate_ratio : 1); // keep the sign
+      }
+      return abs_rate_ratio;
+    }
 
-      /**
+    /**
    *  accept the move previously selected and tried.
    *  Returns the Sign computed as, if M is the move :
    *  Sign = sign (M.attempt()) * M.accept()
    */
-      MCSignType accept() {
-        MCSignType accept_sign_ratio = current->accept();
-        // just make sure that accept_sign_ratio is a sign!
-        if (debug) {
-          if (std::abs(std::abs(accept_sign_ratio) - 1.0) > 1.e-10) TRIQS_RUNTIME_ERROR << "|sign| !=1 !!!";
-          std::cerr.setf(std::ios::scientific, std::ios::floatfield);
-          std::cerr << " ... Move accepted" << std::endl;
-          std::cerr << "   try_sign_ratio = " << try_sign_ratio << std::endl;
-          std::cerr << "   accept_sign_ratio = " << accept_sign_ratio << std::endl;
-          std::cerr << "   their product  =  " << try_sign_ratio * accept_sign_ratio << std::endl;
-        }
-        return try_sign_ratio * accept_sign_ratio;
+    MCSignType accept() {
+      MCSignType accept_sign_ratio = current->accept();
+      // just make sure that accept_sign_ratio is a sign!
+      if (debug) {
+        if (std::abs(std::abs(accept_sign_ratio) - 1.0) > 1.e-10) TRIQS_RUNTIME_ERROR << "|sign| !=1 !!!";
+        std::cerr.setf(std::ios::scientific, std::ios::floatfield);
+        std::cerr << " ... Move accepted" << std::endl;
+        std::cerr << "   try_sign_ratio = " << try_sign_ratio << std::endl;
+        std::cerr << "   accept_sign_ratio = " << accept_sign_ratio << std::endl;
+        std::cerr << "   their product  =  " << try_sign_ratio * accept_sign_ratio << std::endl;
       }
+      return try_sign_ratio * accept_sign_ratio;
+    }
 
-      /**  reject the move :  Call the reject() method of the move previously selected
+    /**  reject the move :  Call the reject() method of the move previously selected
   */
-      void reject() {
-        if (debug) std::cerr << " ... Move rejected" << std::endl;
-        current->reject();
-      }
+    void reject() {
+      if (debug) std::cerr << " ... Move rejected" << std::endl;
+      current->reject();
+    }
 
-      ///
-      void clear_statistics() {
-        for (auto &m : move_vec) {
-          m.clear_statistics();
-          auto ms = m.as_move_set();
-          if (ms) ms->clear_statistics();
+    ///
+    void clear_statistics() {
+      for (auto &m : move_vec) {
+        m.clear_statistics();
+        auto ms = m.as_move_set();
+        if (ms) ms->clear_statistics();
+      }
+    }
+
+    ///
+    void collect_statistics(mpi::communicator const &c) {
+      for (auto &m : move_vec) m.collect_statistics(c);
+    }
+
+    ///
+    void calibrate(mpi::communicator const &c) {
+      for (auto &m : move_vec) m.calibrate(c);
+    }
+
+    /// Acceptance rate of all moves as a map name:string -> acceptance_rate:double
+    std::map<std::string, double> get_acceptance_rates() const {
+      std::map<std::string, double> r;
+      for (unsigned int u = 0; u < move_vec.size(); ++u) {
+        r.insert({names_[u], move_vec[u].acceptance_rate()});
+        auto ms = move_vec[u].as_move_set();
+        if (ms) { // if it is a move set, flatten the result
+          auto ar = ms->get_acceptance_rates();
+          r.insert(ar.begin(), ar.end());
         }
       }
+      return r;
+    }
 
-      ///
-      void collect_statistics(mpi::communicator const &c) {
-        for (auto &m : move_vec) m.collect_statistics(c);
+    /// Pretty printing of the acceptance probability of the moves.
+    std::string get_statistics(std::string decal = "") const {
+      std::ostringstream s;
+      for (unsigned int u = 0; u < move_vec.size(); ++u) {
+        auto ms = move_vec[u].as_move_set();
+        s << decal << "Move " << (ms ? "set " : " ") << names_[u] << ": " << move_vec[u].acceptance_rate() << "\n";
+        if (ms) s << ms->get_statistics(decal + "  ");
       }
+      return s.str();
+    }
 
-      /// Acceptance rate of all moves as a map name:string -> acceptance_rate:double
-      std::map<std::string, double> get_acceptance_rates() const {
-        std::map<std::string, double> r;
-        for (unsigned int u = 0; u < move_vec.size(); ++u) {
-          r.insert({names_[u], move_vec[u].acceptance_rate()});
-          auto ms = move_vec[u].as_move_set();
-          if (ms) { // if it is a move set, flatten the result
-            auto ar = ms->get_acceptance_rates();
-            r.insert(ar.begin(), ar.end());
-          }
-        }
-        return r;
-      }
+    private:
+    void normaliseProba() { // Computes the normalised accumulated probability
+      if (move_vec.size() == 0) TRIQS_RUNTIME_ERROR << " no moves registered";
+      double acc = 0;
+      Proba_Moves_Acc_Sum.clear();
+      for (unsigned int u = 0; u < Proba_Moves.size(); ++u) acc += Proba_Moves[u];
+      assert(acc > 0);
+      for (unsigned int u = 0; u < Proba_Moves.size(); ++u) Proba_Moves_Acc_Sum.push_back(Proba_Moves[u] / acc);
+      for (unsigned int u = 1; u < Proba_Moves_Acc_Sum.size(); ++u) Proba_Moves_Acc_Sum[u] += Proba_Moves_Acc_Sum[u - 1];
+      assert(std::abs(Proba_Moves_Acc_Sum[Proba_Moves_Acc_Sum.size() - 1] - 1) < 1.e-13);
+      Proba_Moves_Acc_Sum[Proba_Moves_Acc_Sum.size() - 1] += 0.001;
+      // I shift the last proba acc so that even if random number in onecycle is 1 it is below that bound
+      assert(Proba_Moves_Acc_Sum.size() == move_vec.size() + 1);
+    }
 
-      /// Pretty printing of the acceptance probability of the moves.
-      std::string get_statistics(std::string decal = "") const {
-        std::ostringstream s;
-        for (unsigned int u = 0; u < move_vec.size(); ++u) {
-          auto ms = move_vec[u].as_move_set();
-          s << decal << "Move " << (ms ? "set " : " ") << names_[u] << ": " << move_vec[u].acceptance_rate() << "\n";
-          if (ms) s << ms->get_statistics(decal + "  ");
-        }
-        return s.str();
-      }
+    std::string name_of_currently_selected() const { return names_[current_move_number]; }
 
-      private:
-      void normaliseProba() { // Computes the normalised accumulated probability
-        if (move_vec.size() == 0) TRIQS_RUNTIME_ERROR << " no moves registered";
-        double acc = 0;
-        Proba_Moves_Acc_Sum.clear();
-        for (unsigned int u = 0; u < Proba_Moves.size(); ++u) acc += Proba_Moves[u];
-        assert(acc > 0);
-        for (unsigned int u = 0; u < Proba_Moves.size(); ++u) Proba_Moves_Acc_Sum.push_back(Proba_Moves[u] / acc);
-        for (unsigned int u = 1; u < Proba_Moves_Acc_Sum.size(); ++u) Proba_Moves_Acc_Sum[u] += Proba_Moves_Acc_Sum[u - 1];
-        assert(std::abs(Proba_Moves_Acc_Sum[Proba_Moves_Acc_Sum.size() - 1] - 1) < 1.e-13);
-        Proba_Moves_Acc_Sum[Proba_Moves_Acc_Sum.size() - 1] += 0.001;
-        // I shift the last proba acc so that even if random number in onecycle is 1 it is below that bound
-        assert(Proba_Moves_Acc_Sum.size() == move_vec.size() + 1);
-      }
+    public:
+    // HDF5 interface
+    friend void h5_write(h5::group g, std::string const &name, move_set const &ms) {
+      auto gr = g.create_group(name);
+      for (size_t u = 0; u < ms.move_vec.size(); ++u) h5_write(gr, ms.names_[u], ms.move_vec[u]);
+    }
 
-      std::string name_of_currently_selected() const { return names_[current_move_number]; }
+    friend void h5_read(h5::group g, std::string const &name, move_set &ms) {
+      auto gr = g.open_group(name);
+      for (size_t u = 0; u < ms.move_vec.size(); ++u) h5_read(gr, ms.names_[u], ms.move_vec[u]);
+    }
 
-      public:
-      // HDF5 interface
-      friend void h5_write(h5::group g, std::string const &name, move_set const &ms) {
-        auto gr = g.create_group(name);
-        for (size_t u = 0; u < ms.move_vec.size(); ++u) h5_write(gr, ms.names_[u], ms.move_vec[u]);
-      }
-
-      friend void h5_read(h5::group g, std::string const &name, move_set &ms) {
-        auto gr = g.open_group(name);
-        for (size_t u = 0; u < ms.move_vec.size(); ++u) h5_read(gr, ms.names_[u], ms.move_vec[u]);
-      }
-
-    }; // class move_set
-  }    // namespace mc_tools
-} // namespace triqs
+  }; // class move_set
+} // namespace triqs::mc_tools

--- a/c++/triqs/mc_tools/random_generator.hpp
+++ b/c++/triqs/mc_tools/random_generator.hpp
@@ -54,7 +54,7 @@ namespace triqs {
       random_generator() : random_generator("mt19937", 198) {}
 
       ///
-      random_generator(random_generator const &p);
+      random_generator(random_generator const &p) = delete;
 
       random_generator(random_generator &&) = default;
 

--- a/c++/triqs/stat/accumulator.hpp
+++ b/c++/triqs/stat/accumulator.hpp
@@ -174,7 +174,7 @@ namespace triqs::stat {
           acc_count.push_back(0);
         }
         // Multiply to ensure element can be element-wise multiplied [FIXME with concepts]
-        Qk.emplace_back(make_real(nda::hadamard(data_instance_local, data_instance_local)));
+        Qk.emplace_back(make_real(nda::hadamard(nda::conj(data_instance_local), data_instance_local)));
         Mk.emplace_back(std::move(data_instance_local));
       }
 
@@ -303,7 +303,7 @@ namespace triqs::stat {
     long count = 0;
     details::log_binning<T> log_bins;
     details::lin_binning<T> lin_bins;
-    std::vector<get_real_t<T>> auto_corr_times;
+    std::vector<get_real_t<T>> auto_corr_times; // will be filled by the default callback if n_log_bins > 0
 
     // HDF5
     friend void h5_write(h5::group g, std::string const &name, accumulator<T> const &l) {
@@ -324,7 +324,7 @@ namespace triqs::stat {
     [[nodiscard]] static std::string hdf5_format() { return "accumulator"; }
 
     accumulator() = default;
-    auto auto_correlation_times() const { return auto_corr_times; }
+    auto const &auto_correlation_times() const { return auto_corr_times; }
 
     ///
     /// @tparam T

--- a/c++/triqs/stat/jackknife.hpp
+++ b/c++/triqs/stat/jackknife.hpp
@@ -21,7 +21,6 @@
 #include <functional>
 #include <numeric>
 #include <type_traits>
-#include <triqs/arrays.hpp>
 // #include <triqs/arrays/math_functions.hpp>
 #include <mpi/vector.hpp>
 
@@ -63,13 +62,20 @@ namespace triqs::stat {
 
     //----------------------------------------------------------------
 
+    // OP : only jackknifed_t<V> ?!
+    // Constraint : f(ja[0]...)
     // implementation of jacknife.
     // mpi iif the c pointer is not null. If null the computation is on this node only.
-    template <typename F, typename... Jacknifed> auto jackknife_impl(mpi::communicator *c, F &&f, Jacknifed const &...ja) {
+
+    template <typename F, typename... Jacknifed>
+    auto jackknife_impl(mpi::communicator *c, F &&f, Jacknifed const &...ja)
+      requires requires { f(ja[0]...); }
+    {
 
       // N is the size of the series, it should be all equal and !=0
       std::array<long, sizeof...(Jacknifed)> dims{long(ja.original_series.size())...};
       long N = dims[0];
+      // OP : ?SHOULD MOVE UP
       if (N == 0) TRIQS_RUNTIME_ERROR << "No data !";
       if (not((ja.original_series.size() == N) and ...)) TRIQS_RUNTIME_ERROR << " Jackknife : size mismatch";
 

--- a/c++/triqs/utility/buffered_function.hpp
+++ b/c++/triqs/utility/buffered_function.hpp
@@ -38,6 +38,12 @@ namespace triqs {
       /// Default constructor : no function bufferized. () will throw in this state
       buffered_function() = default;
 
+
+      buffered_function(buffered_function &&) = default;
+      buffered_function(buffered_function const &x)= delete;
+      buffered_function operator=(buffered_function &&) = default;
+      buffered_function operator=(buffered_function const &) = delete;
+
       /** Constructor
    *
    * @tparam Function : type of the function to bufferize

--- a/c++/triqs/utility/buffered_function.hpp
+++ b/c++/triqs/utility/buffered_function.hpp
@@ -41,8 +41,8 @@ namespace triqs {
 
       buffered_function(buffered_function &&) = default;
       buffered_function(buffered_function const &x)= delete;
-      buffered_function operator=(buffered_function &&) = default;
-      buffered_function operator=(buffered_function const &) = delete;
+      buffered_function &operator=(buffered_function &&) = default;
+      buffered_function &operator=(buffered_function const &) = delete;
 
       /** Constructor
    *

--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -112,7 +112,7 @@ external_dependency(h5
 external_dependency(nda
   GIT_REPO https://github.com/TRIQS/nda
   VERSION 1.3
-  GIT_TAG 1.3.x
+  GIT_TAG hadamard # 1.3.x
 ) 
 
 # -- cppdlr --

--- a/test/c++/gfs/gf_dlr.cpp
+++ b/test/c++/gfs/gf_dlr.cpp
@@ -58,17 +58,17 @@ TEST(Gf, dlr_mat) {
   EXPECT_EQ(g1.mesh().mesh_hash(), g1b.mesh().mesh_hash());
 
   // compare dlr_imfreq against exact result
-  auto g3 = make_gf_dlr_imfreq(g2);
+  auto g3       = make_gf_dlr_imfreq(g2);
   auto g3_check = gf<dlr_imfreq, matrix_valued>{{beta, Fermion, w_max, eps}, {1, 1}};
-  for (auto w : g3_check.mesh()) g3_check[w] = 1 / (w - e0);
+  for (auto iw : g3_check.mesh()) g3_check[iw] = 1 / (iw - e0);
 
   EXPECT_GF_NEAR(g3, g3_check);
   EXPECT_EQ(g3.mesh().mesh_hash(), g3_check.mesh().mesh_hash());
 
   // eval g2 on tau is fine
   for (auto tau : g1.mesh()) { EXPECT_COMPLEX_NEAR(g2(tau)(0, 0), g1[tau](0, 0), tol); }
-  // eval g2 on w is fine
-  for (auto w : g3.mesh()) { EXPECT_COMPLEX_NEAR(g2(w)(0, 0), g3[w](0, 0), tol); }
+  // eval g2 on iw is fine
+  for (auto iw : g3.mesh()) { EXPECT_COMPLEX_NEAR(g2(iw)(0, 0), g3[iw](0, 0), tol); }
 }
 // ------------------------------------------------------------
 // simpler test, scalar_valued. Same as in Python.
@@ -81,7 +81,7 @@ TEST(Gf, dlr_mat2) {
   double tol   = 1.e-9;
 
   auto gw = gf<dlr_imfreq, scalar_valued>{dlr_imfreq{beta, Fermion, w_max, eps}};
-  for (auto w : gw.mesh()) gw[w] = 1 / (w - e0);
+  for (auto iw : gw.mesh()) gw[iw] = 1 / (iw - e0);
 
   auto gc = make_gf_dlr(gw);
   auto gt = make_gf_dlr_imtime(gc);
@@ -107,7 +107,7 @@ TEST(Gf, DLR_basic) {
   EXPECT_EQ(m_w_f.eps(), eps);
   EXPECT_EQ(m_w_b.eps(), eps);
 
-  for (const auto &tau : m_tau) {
+  for (auto tau : m_tau) {
     EXPECT_TRUE(tau <= beta);
     EXPECT_TRUE(tau >= 0.0);
   }
@@ -147,12 +147,12 @@ TEST(Gf, DLR_cross_construction) {
   EXPECT_NE(mw.mesh_hash(), mt.mesh_hash());
   EXPECT_NE(mw.mesh_hash(), mc.mesh_hash());
 
-  for (const auto &[c1, c2] : itertools::zip(mc, mc2)) { EXPECT_EQ(c1, c2); }
-  for (const auto &[c1, c2] : itertools::zip(mc, mc3)) { EXPECT_EQ(c1, c2); }
-  for (const auto &[t1, t2] : itertools::zip(mt, mt2)) { EXPECT_CLOSE(t1, t2); }
-  for (const auto &[t1, t2] : itertools::zip(mt, mt3)) { EXPECT_CLOSE(t1, t2); }
-  for (const auto &[w1, w2] : itertools::zip(mw, mw2)) { EXPECT_CLOSE(dcomplex(w1), dcomplex(w2)); }
-  for (const auto &[w1, w2] : itertools::zip(mw, mw3)) { EXPECT_CLOSE(dcomplex(w1), dcomplex(w2)); }
+  for (auto [c1, c2] : itertools::zip(mc, mc2)) { EXPECT_EQ(c1, c2); }
+  for (auto [c1, c2] : itertools::zip(mc, mc3)) { EXPECT_EQ(c1, c2); }
+  for (auto [t1, t2] : itertools::zip(mt, mt2)) { EXPECT_CLOSE(t1, t2); }
+  for (auto [t1, t2] : itertools::zip(mt, mt3)) { EXPECT_CLOSE(t1, t2); }
+  for (auto [w1, w2] : itertools::zip(mw, mw2)) { EXPECT_CLOSE(dcomplex(w1), dcomplex(w2)); }
+  for (auto [w1, w2] : itertools::zip(mw, mw3)) { EXPECT_CLOSE(dcomplex(w1), dcomplex(w2)); }
 }
 
 // ----------------------------------------------------------------
@@ -184,19 +184,19 @@ TEST(Gf, DLR_imtime_grid) {
   EXPECT_GF_NEAR(G1, G2);
 
   auto GpG = G1 + G2; // Addition
-  for (const auto &tau : mesh) {
+  for (auto tau : mesh) {
     EXPECT_CLOSE(GpG[tau], G1[tau] * 2.);
     EXPECT_CLOSE(GpG[tau], 2. * G1[tau]);
   }
 
   auto G4 = 4. * G2; // Multiply with scalar
-  for (const auto &tau : mesh) {
+  for (auto tau : mesh) {
     EXPECT_CLOSE(G4[tau], G1[tau] * 4.);
     EXPECT_CLOSE(G4[tau], 4. * G1[tau]);
   }
 
   auto GG = G1 * G2; // Multiplication
-  for (const auto &tau : mesh) { EXPECT_CLOSE(GG[tau], G1[tau] * G1[tau]); }
+  for (auto tau : mesh) { EXPECT_CLOSE(GG[tau], G1[tau] * G1[tau]); }
 
   EXPECT_TRUE(GG.mesh().statistic() == Boson);
 }
@@ -213,7 +213,7 @@ TEST(Gf, DLR_imfreq_grid) {
   auto mesh = dlr_imfreq{beta, Fermion, w_max, eps};
   auto G1   = gf<dlr_imfreq, scalar_valued>{mesh};
 
-  for (const auto &iw : mesh) { G1[iw] = 1. / (iw - omega); }
+  for (auto iw : mesh) { G1[iw] = 1. / (iw - omega); }
 
   auto Gc = G1; // copy
   EXPECT_GF_NEAR(G1, Gc);
@@ -224,26 +224,26 @@ TEST(Gf, DLR_imfreq_grid) {
   // Take view and assign
   auto G2  = gf<dlr_imfreq, scalar_valued>{mesh};
   auto G2v = gf_view(G2);
-  for (const auto &iw : mesh) { G2v[iw] = 1. / (iw - omega); }
+  for (auto iw : mesh) { G2v[iw] = 1. / (iw - omega); }
 
   EXPECT_GF_NEAR(G2, G2v);
   EXPECT_GF_NEAR(G1, G2v);
   EXPECT_GF_NEAR(G1, G2);
 
   auto GpG = G1 + G2; // Addition
-  for (const auto &iw : mesh) {
+  for (auto iw : mesh) {
     EXPECT_CLOSE(GpG[iw], G1[iw] * 2.);
     EXPECT_CLOSE(GpG[iw], 2. * G1[iw]);
   }
 
   auto G4 = 4. * G2; // Multiply with scalar
-  for (const auto &iw : mesh) {
+  for (auto iw : mesh) {
     EXPECT_CLOSE(G4[iw], G1[iw] * 4.);
     EXPECT_CLOSE(G4[iw], 4. * G1[iw]);
   }
 
   auto GG = G1 * G2; // Multiplication
-  for (const auto &iw : mesh) { EXPECT_CLOSE(GG[iw], G1[iw] * G1[iw]); }
+  for (auto iw : mesh) { EXPECT_CLOSE(GG[iw], G1[iw] * G1[iw]); }
 }
 
 // ----------------------------------------------------------------
@@ -263,17 +263,14 @@ TEST(Gf, DLR_clef) {
   auto gt2  = gf{mesh};
 
   static_assert(std::is_same_v<decltype(gt2), decltype(gt)>);
-  for (const auto &tau : mesh) gt2[tau] = onefermion(tau, omega, beta);
+  for (auto tau : mesh) gt2[tau] = onefermion(tau, omega, beta);
   EXPECT_GF_NEAR(gt, gt2);
 
   auto gw = gf<dlr_imfreq, scalar_valued>{{beta, Fermion, w_max, eps}};
   gw[iw_] << 1. / (iw_ - omega);
 
   auto gw2 = gf<dlr_imfreq, scalar_valued>{{beta, Fermion, w_max, eps}};
-
-  // Should not compile. Wrong mesh point
-  //for (const auto &iw : mesh) gw2[iw] = 1 / (iw - omega);
-  for (const auto &iw : gw2.mesh()) gw2[iw] = 1 / (iw - omega);
+  for (auto iw : gw2.mesh()) gw2[iw] = 1 / (iw - omega);
 
   EXPECT_GF_NEAR(gw, gw2);
 }
@@ -428,10 +425,6 @@ TEST(Gf, DLR_mesh_point_mismatch) {
   auto gw  = gf<dlr_imfreq, scalar_valued>{{beta, Fermion, w_max, eps}};
   auto gw2 = gf<dlr_imfreq, scalar_valued>{{beta2, Fermion, w_max, eps}};
   for (auto iw : gw.mesh()) EXPECT_DEBUG_DEATH(gw2[iw], "Precondition m.mesh_hash");
-
-  // THIS PART SHOULD NOT COMPILE AND GIVE A GOOD ERROR MESSAGE
-  // auto gwold = gf<imfreq, scalar_valued>{{beta2, Fermion}};
-  // for (auto iw : gw.mesh()) gwold[iw] = 0; // must not compile
 }
 
 // ----------------------------------------------------------------
@@ -447,20 +440,17 @@ TEST(Gf, DLR_density) {
   double omega = 1.337;
   gt[tau_] << -nda::clef::exp(-omega * tau_) / (1 + nda::clef::exp(-beta * omega));
 
-  // SHOULD NOT COMPILE. DELETED FUNCTION
-  // auto d = triqs::gfs::density(gt);
-
   // Density from dlr is efficient (by design)
   // only requires interpolation at \tau=\beta ( n = -G(\beta) )
   auto gc = make_gf_dlr(gt);
-  auto nc  = triqs::gfs::density(gc);
+  auto nc = triqs::gfs::density(gc);
   EXPECT_COMPLEX_NEAR(nc, 1 / (1 + std::exp(beta * omega)), 1.e-9);
 
-  auto nt  = triqs::gfs::density(gt);
+  auto nt = triqs::gfs::density(gt);
   EXPECT_COMPLEX_NEAR(nt, 1 / (1 + std::exp(beta * omega)), 1.e-9);
 
   auto gw = make_gf_dlr_imfreq(gc);
-  auto nw  = triqs::gfs::density(gw);
+  auto nw = triqs::gfs::density(gw);
   EXPECT_COMPLEX_NEAR(nw, 1 / (1 + std::exp(beta * omega)), 1.e-9);
 }
 // ----------------------------------------------------------------
@@ -526,13 +516,13 @@ TEST(Gf, DLR_two_poles) {
   auto gtau = gf<dlr_imtime, scalar_valued>{{beta, Fermion, w_max, eps}};
   gtau[tau_] << 0.5 * onefermion(tau_, e1, beta) + 0.5 * onefermion(tau_, e2, beta);
 
-  auto gdlr = make_gf_dlr(gtau);
-  auto giw  = make_gf_dlr_imfreq(gdlr);
+  auto giw = make_gf_dlr_imfreq(gtau);
 
   auto G2_iw = giw;
   G2_iw[iw_] << 0.5 / (iw_ - e1) + 0.5 / (iw_ - e2);
 
   EXPECT_GF_NEAR(giw, G2_iw);
+  EXPECT_GF_NEAR(giw, make_gf_from_fourier(gtau));
 }
 
 // ----------------------------------------------------------------
@@ -549,13 +539,13 @@ TEST(Gf, DLR_multivar) {
   auto gtau        = gf{dlr_it_mesh * dlr_it_mesh};
   gtau[tau_, taup_] << onefermion(tau_, e1, beta) * onefermion(taup_, e2, beta);
 
-  auto gdlr = make_gf_dlr<0, 1>(gtau);
-  auto giw  = make_gf_dlr_imfreq<0, 1>(gdlr);
+  auto giw = make_gf_dlr_imfreq<0, 1>(gtau);
 
   auto G2_iw = giw;
   G2_iw[iw_, iwp_] << 1.0 / (iw_ - e1) / (iwp_ - e2);
 
   EXPECT_GF_NEAR(giw, G2_iw);
+  EXPECT_GF_NEAR(giw, (make_gf_from_fourier<0, 1>(gtau)));
 }
 
 // ----------------------------------------------------------------

--- a/test/c++/gfs/gf_dlr.cpp
+++ b/test/c++/gfs/gf_dlr.cpp
@@ -550,4 +550,18 @@ TEST(Gf, DLR_multivar) {
 
 // ----------------------------------------------------------------
 
+TEST(Gf, DLR_FT_iw_to_tau) {
+  auto beta    = 2.0;
+  auto mu      = 0.5;
+  auto wmax    = 10 * beta;
+  auto eps_DLR = 1e-10;
+
+  auto const iw_mesh = dlr_imfreq{beta, Fermion, wmax, eps_DLR};
+  auto G0_iw         = gf<dlr_imfreq, scalar_valued>{iw_mesh};
+  for (auto iw : G0_iw.mesh()) { G0_iw[iw] = 1.0 / (iw + mu); }
+
+  auto G0 = make_gf_from_fourier(G0_iw);
+  for (auto tau : G0.mesh()) { EXPECT_COMPLEX_NEAR(G0[tau], onefermion(tau, -mu, beta), 10*eps_DLR); }
+}
+
 MAKE_MAIN;


### PR DESCRIPTION
Implemented a callback in the (linear) accumulator, which is called after each recompression step if defined. It defaults to the calculation of autocorrelation times from the variances of the original and binned data. Based on PR#79 in TRIQS/nda (https://github.com/TRIQS/nda/pull/79).