### PR TITLE
Makes meshes random access ranges

### DIFF
--- a/c++/triqs/mesh.hpp
+++ b/c++/triqs/mesh.hpp
@@ -37,6 +37,7 @@
 #include "arrays.hpp"
 
 #include "./mesh/utils.hpp"
+#include "./mesh/mesh_iterator.hpp"
 
 #include "./mesh/imtime.hpp"
 #include "./mesh/imfreq.hpp"

--- a/c++/triqs/mesh/bases/linear.hpp
+++ b/c++/triqs/mesh/bases/linear.hpp
@@ -21,6 +21,7 @@
 #include <ranges>
 #include <stdexcept>
 #include "../utils.hpp"
+#include "../mesh_iterator.hpp"
 
 namespace triqs::mesh::details {
 
@@ -181,16 +182,10 @@ namespace triqs::mesh::details {
 
     // -------------------------- Range & Iteration --------------------------
 
-    private:
-    [[nodiscard]] auto r_() const {
-      return itertools::transform(range(size()), [this](long i) { return (*this)[i]; });
-    }
-
-    public:
-    [[nodiscard]] auto begin() const { return r_().begin(); }
-    [[nodiscard]] auto cbegin() const { return r_().cbegin(); }
-    [[nodiscard]] auto end() const { return r_().end(); }
-    [[nodiscard]] auto cend() const { return r_().cend(); }
+    [[nodiscard]] auto begin() const { return mesh_iterator<linear<Mesh, Value>>{.mesh_ptr = this, .data_index = 0}; }
+    [[nodiscard]] auto cbegin() const { return begin(); }
+    [[nodiscard]] auto end() const { return mesh_iterator<linear<Mesh, Value>>{.mesh_ptr = this, .data_index = size()}; }
+    [[nodiscard]] auto cend() const { return end(); }
 
     // -------------------- serialization -------------------
 

--- a/c++/triqs/mesh/brzone.hpp
+++ b/c++/triqs/mesh/brzone.hpp
@@ -25,6 +25,7 @@
 #include <triqs/lattice/brillouin_zone.hpp>
 #include <nda/linalg.hpp>
 #include "./k_expr.hpp"
+#include "./mesh_iterator.hpp"
 
 namespace triqs::mesh {
 
@@ -295,16 +296,10 @@ namespace triqs::mesh {
 
     // -------------------------- Range & Iteration --------------------------
 
-    private:
-    [[nodiscard]] auto r_() const {
-      return itertools::transform(range(size()), [this](long i) { return (*this)[i]; });
-    }
-
-    public:
-    [[nodiscard]] auto begin() const { return r_().begin(); }
-    [[nodiscard]] auto cbegin() const { return r_().cbegin(); }
-    [[nodiscard]] auto end() const { return r_().end(); }
-    [[nodiscard]] auto cend() const { return r_().cend(); }
+    [[nodiscard]] auto begin() const { return mesh_iterator<brzone>{.mesh_ptr = this, .data_index = 0}; }
+    [[nodiscard]] auto cbegin() const { return begin(); }
+    [[nodiscard]] auto end() const { return mesh_iterator<brzone>{.mesh_ptr = this, .data_index = size()}; }
+    [[nodiscard]] auto cend() const { return end(); }
 
     // -------------------- serialization -------------------
 

--- a/c++/triqs/mesh/cyclat.hpp
+++ b/c++/triqs/mesh/cyclat.hpp
@@ -20,6 +20,7 @@
 #pragma once
 #include "utils.hpp"
 #include <triqs/lattice/bravais_lattice.hpp>
+#include "./mesh_iterator.hpp"
 
 namespace triqs::mesh {
 
@@ -197,16 +198,10 @@ namespace triqs::mesh {
 
     // -------------------------- Range & Iteration --------------------------
 
-    private:
-    [[nodiscard]] auto r_() const {
-      return itertools::transform(range(size()), [this](long i) { return (*this)[i]; });
-    }
-
-    public:
-    [[nodiscard]] auto begin() const { return r_().begin(); }
-    [[nodiscard]] auto cbegin() const { return r_().cbegin(); }
-    [[nodiscard]] auto end() const { return r_().end(); }
-    [[nodiscard]] auto cend() const { return r_().cend(); }
+    [[nodiscard]] auto begin() const { return mesh_iterator<cyclat>{.mesh_ptr = this, .data_index = 0}; }
+    [[nodiscard]] auto cbegin() const { return begin(); }
+    [[nodiscard]] auto end() const { return mesh_iterator<cyclat>{.mesh_ptr = this, .data_index = size()}; }
+    [[nodiscard]] auto cend() const { return end(); }
 
     // -------------------- serialization -------------------
 

--- a/c++/triqs/mesh/discrete.hpp
+++ b/c++/triqs/mesh/discrete.hpp
@@ -17,6 +17,8 @@
 
 #pragma once
 #include "./utils.hpp"
+#include "./mesh_iterator.hpp"
+
 namespace triqs::mesh {
 
   struct discrete {
@@ -104,16 +106,10 @@ namespace triqs::mesh {
 
     // -------------------------- Range & Iteration --------------------------
 
-    private:
-    [[nodiscard]] auto r_() const {
-      return itertools::transform(range(size()), [this](long i) { return (*this)[i]; });
-    }
-
-    public:
-    [[nodiscard]] auto begin() const { return r_().begin(); }
-    [[nodiscard]] auto cbegin() const { return r_().cbegin(); }
-    [[nodiscard]] auto end() const { return r_().end(); }
-    [[nodiscard]] auto cend() const { return r_().cend(); }
+    [[nodiscard]] auto begin() const { return mesh_iterator<discrete>{.mesh_ptr = this, .data_index = 0}; }
+    [[nodiscard]] auto cbegin() const { return begin(); }
+    [[nodiscard]] auto end() const { return mesh_iterator<discrete>{.mesh_ptr = this, .data_index = size()}; }
+    [[nodiscard]] auto cend() const { return end(); }
 
     // -------------------- print  -------------------
 

--- a/c++/triqs/mesh/dlr.hpp
+++ b/c++/triqs/mesh/dlr.hpp
@@ -19,6 +19,7 @@
 #pragma once
 #include "utils.hpp"
 #include "domains/matsubara.hpp"
+#include "./mesh_iterator.hpp"
 #include <cppdlr/cppdlr.hpp>
 #include <memory>
 
@@ -202,16 +203,10 @@ namespace triqs::mesh {
 
     // -------------------------- Range & Iteration --------------------------
 
-    private:
-    [[nodiscard]] auto r_() const {
-      return itertools::transform(nda::range(size()), [this](long i) { return (*this)[i]; });
-    }
-
-    public:
-    [[nodiscard]] auto begin() const { return r_().begin(); }
-    [[nodiscard]] auto cbegin() const { return r_().cbegin(); }
-    [[nodiscard]] auto end() const { return r_().end(); }
-    [[nodiscard]] auto cend() const { return r_().cend(); }
+    [[nodiscard]] auto begin() const { return mesh_iterator<dlr>{.mesh_ptr = this, .data_index = 0}; }
+    [[nodiscard]] auto cbegin() const { return begin(); }
+    [[nodiscard]] auto end() const { return mesh_iterator<dlr>{.mesh_ptr = this, .data_index = size()}; }
+    [[nodiscard]] auto cend() const { return end(); }
 
     // -------------------- print  -------------------
 

--- a/c++/triqs/mesh/dlr_imfreq.hpp
+++ b/c++/triqs/mesh/dlr_imfreq.hpp
@@ -20,6 +20,7 @@
 #include "utils.hpp"
 #include "dlr.hpp"
 #include "domains/matsubara.hpp"
+#include "./mesh_iterator.hpp"
 
 #include <cppdlr/cppdlr.hpp>
 
@@ -198,16 +199,10 @@ namespace triqs::mesh {
 
     // -------------------------- Range & Iteration --------------------------
 
-    private:
-    [[nodiscard]] auto r_() const {
-      return itertools::transform(nda::range(size()), [this](long i) { return (*this)[i]; });
-    }
-
-    public:
-    [[nodiscard]] auto begin() const { return r_().begin(); }
-    [[nodiscard]] auto cbegin() const { return r_().cbegin(); }
-    [[nodiscard]] auto end() const { return r_().end(); }
-    [[nodiscard]] auto cend() const { return r_().cend(); }
+    [[nodiscard]] auto begin() const { return mesh_iterator<dlr_imfreq>{.mesh_ptr = this, .data_index = 0}; }
+    [[nodiscard]] auto cbegin() const { return begin(); }
+    [[nodiscard]] auto end() const { return mesh_iterator<dlr_imfreq>{.mesh_ptr = this, .data_index = size()}; }
+    [[nodiscard]] auto cend() const { return end(); }
 
     // -------------------- print  -------------------
 

--- a/c++/triqs/mesh/dlr_imtime.hpp
+++ b/c++/triqs/mesh/dlr_imtime.hpp
@@ -19,6 +19,7 @@
 #pragma once
 #include "utils.hpp"
 #include "dlr.hpp"
+#include "./mesh_iterator.hpp"
 
 #include <cppdlr/cppdlr.hpp>
 
@@ -203,16 +204,10 @@ namespace triqs::mesh {
 
     // -------------------------- Range & Iteration --------------------------
 
-    private:
-    [[nodiscard]] auto r_() const {
-      return itertools::transform(nda::range(size()), [this](long i) { return (*this)[i]; });
-    }
-
-    public:
-    [[nodiscard]] auto begin() const { return r_().begin(); }
-    [[nodiscard]] auto cbegin() const { return r_().cbegin(); }
-    [[nodiscard]] auto end() const { return r_().end(); }
-    [[nodiscard]] auto cend() const { return r_().cend(); }
+    [[nodiscard]] auto begin() const { return mesh_iterator<dlr_imtime>{.mesh_ptr = this, .data_index = 0}; }
+    [[nodiscard]] auto cbegin() const { return begin(); }
+    [[nodiscard]] auto end() const { return mesh_iterator<dlr_imtime>{.mesh_ptr = this, .data_index = size()}; }
+    [[nodiscard]] auto cend() const { return end(); }
 
     // -------------------- print  -------------------
 

--- a/c++/triqs/mesh/imfreq.hpp
+++ b/c++/triqs/mesh/imfreq.hpp
@@ -21,6 +21,7 @@
 #include "./utils.hpp"
 #include "./domains/matsubara.hpp"
 #include "./tail_fitter.hpp"
+#include "./mesh_iterator.hpp"
 
 namespace triqs::mesh {
 
@@ -237,16 +238,10 @@ namespace triqs::mesh {
 
     // -------------------------- Range & Iteration --------------------------
 
-    private:
-    [[nodiscard]] auto r_() const {
-      return itertools::transform(range(size()), [this](long i) { return (*this)[i]; });
-    }
-
-    public:
-    [[nodiscard]] auto begin() const { return r_().begin(); }
-    [[nodiscard]] auto cbegin() const { return r_().cbegin(); }
-    [[nodiscard]] auto end() const { return r_().end(); }
-    [[nodiscard]] auto cend() const { return r_().cend(); }
+    [[nodiscard]] auto begin() const { return mesh_iterator<imfreq>{.mesh_ptr = this, .data_index = 0}; }
+    [[nodiscard]] auto cbegin() const { return begin(); }
+    [[nodiscard]] auto end() const { return mesh_iterator<imfreq>{.mesh_ptr = this, .data_index = size()}; }
+    [[nodiscard]] auto cend() const { return end(); }
 
     // -------------------- print  -------------------
 

--- a/c++/triqs/mesh/legendre.hpp
+++ b/c++/triqs/mesh/legendre.hpp
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include "./mesh_iterator.hpp"
 #include "utils.hpp"
 #include <triqs/utility/legendre.hpp>
 
@@ -120,16 +121,10 @@ namespace triqs::mesh {
 
     // -------------------------- Range & Iteration --------------------------
 
-    private:
-    [[nodiscard]] auto r_() const {
-      return itertools::transform(range(size()), [this](long i) { return (*this)[i]; });
-    }
-
-    public:
-    [[nodiscard]] auto begin() const { return r_().begin(); }
-    [[nodiscard]] auto cbegin() const { return r_().cbegin(); }
-    [[nodiscard]] auto end() const { return r_().end(); }
-    [[nodiscard]] auto cend() const { return r_().cend(); }
+    [[nodiscard]] auto begin() const { return mesh_iterator<legendre>{.mesh_ptr = this, .data_index = 0}; }
+    [[nodiscard]] auto cbegin() const { return begin(); }
+    [[nodiscard]] auto end() const { return mesh_iterator<legendre>{.mesh_ptr = this, .data_index = size()}; }
+    [[nodiscard]] auto cend() const { return end(); }
 
     // -------------------- print  -------------------
 

--- a/c++/triqs/mesh/mesh_iterator.hpp
+++ b/c++/triqs/mesh/mesh_iterator.hpp
@@ -113,7 +113,7 @@ namespace triqs::mesh {
      * @return True, if they belong to the same mesh and if their current data indices are equal.
      */
     [[nodiscard]] bool operator==(mesh_iterator const &other) const noexcept {
-      return mesh_ptr->mesh_hash() == other.mesh_ptr->mesh_hash() and data_index == other.data_index;
+      return mesh_ptr == other.mesh_ptr and data_index == other.data_index;
     }
 
     /**

--- a/c++/triqs/mesh/mesh_iterator.hpp
+++ b/c++/triqs/mesh/mesh_iterator.hpp
@@ -1,0 +1,188 @@
+// Copyright (c) 2016-2018 Commissariat à l'énergie atomique et aux énergies alternatives (CEA)
+// Copyright (c) 2016-2018 Centre national de la recherche scientifique (CNRS)
+// Copyright (c) 2018-2023 Simons Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You may obtain a copy of the License at
+//     https://www.gnu.org/licenses/gpl-3.0.txt
+//
+// Authors: Thomas Ayral, Philipp Dumitrescu, Michel Ferrero, Olivier Parcollet, Nils Wentzell
+
+/**
+ * @file
+ * @brief Provides a generic random access iterator for 1D meshes.
+ */
+
+#pragma once
+
+#include <compare>
+#include <cstddef>
+#include <iterator>
+
+namespace triqs::mesh {
+
+  /**
+   * @brief A generic random access iterator for 1D meshes.
+   * 
+   * @details The iterator simply store a pointer to the underlying mesh and the data index of the current mesh point.
+   * It uses the mesh's `operator[]` to access the mesh points via the data index.
+   * 
+   * @tparam M Mesh type.
+   */
+  template <typename M> struct mesh_iterator {
+    /// Value type.
+    using value_type = typename M::mesh_point_t;
+
+    /// Iterator category.
+    using iterator_category = std::random_access_iterator_tag;
+
+    /// Pointer type.
+    using pointer = value_type *;
+
+    /// Difference type.
+    using difference_type = std::ptrdiff_t;
+
+    /// Reference type.
+    using reference = value_type const &;
+
+    /// Pointer to the underlying mesh.
+    M const *mesh_ptr{nullptr};
+
+    /// Current data index.
+    long data_index{-1};
+
+    /**
+     * @brief Pre-increment operator increments the current data index by \f$ 1 \f$.
+     * @return Reference to `this` iterator.
+     */
+    mesh_iterator &operator++() noexcept {
+      ++data_index;
+      return *this;
+    }
+
+    /**
+     * @brief Post-increment operator increments the current data index by \f$ 1 \f$.
+     * @return Copy of `this` iterator before incrementing.
+     */
+    mesh_iterator operator++(int) noexcept {
+      mesh_iterator tmp = *this;
+      ++data_index;
+      return tmp;
+    }
+
+    /**
+     * @brief Pre-decrement operator decrements the current data index by \f$ 1 \f$.
+     * @return Reference to `this` iterator.
+     */
+    mesh_iterator &operator--() noexcept {
+      --data_index;
+      return *this;
+    }
+
+    /**
+     * @brief Post-decrement operator decrements the current data index by \f$ 1 \f$.
+     * @return Copy of `this` iterator before decrementing.
+     */
+    mesh_iterator operator--(int) noexcept {
+      mesh_iterator tmp = *this;
+      --data_index;
+      return tmp;
+    }
+
+    /**
+     * @brief Three-way comparison operator for two iterators.
+     *
+     * @param rhs Right hand side iterator to compare with.
+     * @return It returns the result of a three-way comparison of their current values.
+     */
+    [[nodiscard]] std::strong_ordering operator<=>(mesh_iterator const &rhs) const noexcept { return data_index <=> rhs.data_index; }
+
+    /**
+     * @brief Equal-to operator for two iterators.
+     *
+     * @param other Iterator to compare with.
+     * @return True, if they belong to the same mesh and if their current data indices are equal.
+     */
+    [[nodiscard]] bool operator==(mesh_iterator const &other) const noexcept {
+      return mesh_ptr->mesh_hash() == other.mesh_ptr->mesh_hash() and data_index == other.data_index;
+    }
+
+    /**
+     * @brief Dereference operator.
+     * @return Mesh point at the current data index.
+     */
+    [[nodiscard]] value_type operator*() const noexcept { return mesh_ptr->operator[](data_index); }
+
+    /**
+     * @brief Member access operator.
+     * @return Mesh point at the current data index.
+     */
+    [[nodiscard]] value_type operator->() const noexcept { return operator*(); }
+
+    /**
+     * @brief Addition assignment operator.
+     * @param n Number of steps to add to the current data index.
+     * @return Reference to `this` iterator with its current data index increased by \f$ n \f$.
+     */
+    mesh_iterator &operator+=(difference_type n) noexcept {
+      data_index += n;
+      return *this;
+    }
+
+    /**
+     * @brief Addition operator for an iterator and an integer.
+     * @param n Number of steps to add to the current data index.
+     * @return Copy of `this` object with its current data index increased by \f$ n \f$.
+     */
+    [[nodiscard]] mesh_iterator operator+(difference_type n) const noexcept { return {.mesh_ptr = mesh_ptr, .data_index = data_index + n}; }
+
+    /**
+     * @brief Addition operator for an integer and an iterator.
+     * @param n Number of steps to add to the current data index of the iterator.
+     * @param it Iterator.
+     * @return Copy of the given iterator with its current data index increased by \f$ n \f$.
+     */
+    [[nodiscard]] friend mesh_iterator operator+(difference_type n, mesh_iterator it) noexcept { return it + n; }
+
+    /**
+     * @brief Subtraction assignment operator.
+     * @param n Number of steps to subtract from the current data index.
+     * @return Reference to `this` iterator with its current data index decreased by \f$ n \f$.
+     */
+    mesh_iterator &operator-=(difference_type n) noexcept {
+      data_index -= n;
+      return *this;
+    }
+
+    /**
+     * @brief Subtraction operator for an iterator and an integer.
+     * @param n Number of steps to subtract from the current data index.
+     * @return Copy of `this` iterator with its current data index decreased by \f$ n \f$.
+     */
+    [[nodiscard]] mesh_iterator operator-(difference_type n) const noexcept { return {.mesh_ptr = mesh_ptr, .data_index = data_index - n}; }
+
+    /**
+     * @brief Get the distance between two iterators.
+     * @param rhs Right-hand side iterator.
+     * @return Number of steps between the two iterators.
+     */
+    [[nodiscard]] difference_type operator-(mesh_iterator const &rhs) const noexcept { return data_index - rhs.data_index; }
+
+    /**
+     * @brief Subscript operator.
+     * @param n Number of steps to add to the current value.
+     * @return Mesh point at the current data index increased by \f$ n \f$.
+     */
+    [[nodiscard]] value_type operator[](difference_type n) const noexcept { return mesh_ptr->operator[](data_index + n); }
+  };
+
+} // namespace triqs::mesh

--- a/test/c++/meshes/mesh_iterator.cpp
+++ b/test/c++/meshes/mesh_iterator.cpp
@@ -35,6 +35,17 @@ struct my_mesh {
 // Test random access concept.
 static_assert(std::random_access_iterator<triqs::mesh::mesh_iterator<my_mesh>>);
 static_assert(std::ranges::random_access_range<my_mesh>);
+static_assert(std::ranges::random_access_range<triqs::mesh::brzone>);
+static_assert(std::ranges::random_access_range<triqs::mesh::cyclat>);
+static_assert(std::ranges::random_access_range<triqs::mesh::discrete>);
+static_assert(std::ranges::random_access_range<triqs::mesh::dlr_imtime>);
+static_assert(std::ranges::random_access_range<triqs::mesh::dlr_imfreq>);
+static_assert(std::ranges::random_access_range<triqs::mesh::dlr>);
+static_assert(std::ranges::random_access_range<triqs::mesh::imfreq>);
+static_assert(std::ranges::random_access_range<triqs::mesh::imtime>);
+static_assert(std::ranges::random_access_range<triqs::mesh::legendre>);
+static_assert(std::ranges::random_access_range<triqs::mesh::refreq>);
+static_assert(std::ranges::random_access_range<triqs::mesh::retime>);
 
 TEST(TRIQS, MeshIteratorZeroSize) {
   my_mesh mesh{0};

--- a/test/c++/meshes/mesh_iterator.cpp
+++ b/test/c++/meshes/mesh_iterator.cpp
@@ -1,0 +1,97 @@
+// Copyright (c) 2022-2023 Simons Foundation
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You may obtain a copy of the License at
+//     https://www.gnu.org/licenses/gpl-3.0.txt
+//
+// Authors: Nils Wentzell
+
+#include <triqs/mesh.hpp>
+#include <triqs/test_tools/arrays.hpp>
+
+#include <iterator>
+#include <ranges>
+
+// Custom mesh for testing.
+struct my_mesh {
+  using mesh_point_t = long;
+  long sz{10};
+  [[nodiscard]] mesh_point_t operator[](long data_index) const { return data_index; }
+  [[nodiscard]] long size() const { return sz; }
+  [[nodiscard]] auto begin() const { return triqs::mesh::mesh_iterator<my_mesh>{.mesh_ptr = this, .data_index = 0}; }
+  [[nodiscard]] auto end() const { return triqs::mesh::mesh_iterator<my_mesh>{.mesh_ptr = this, .data_index = size()}; }
+  [[nodiscard]] auto mesh_hash() const { return sz; }
+};
+
+// Test random access concept.
+static_assert(std::random_access_iterator<triqs::mesh::mesh_iterator<my_mesh>>);
+static_assert(std::ranges::random_access_range<my_mesh>);
+
+TEST(TRIQS, MeshIteratorZeroSize) {
+  my_mesh mesh{0};
+  EXPECT_EQ(mesh.begin(), mesh.end());
+  int i = 0;
+  for ([[maybe_unused]] auto m : mesh) ++i;
+  EXPECT_EQ(i, 0);
+}
+
+TEST(TRIQS, MeshIteratorComparisons) {
+  auto check_comparisons = [](auto &&rg) {
+    auto check_ordering = [](auto &&it, auto &&it2) {
+      EXPECT_TRUE(it < it2);
+      EXPECT_TRUE(it <= it2);
+      EXPECT_TRUE(it2 > it);
+      EXPECT_TRUE(it2 >= it);
+    };
+    auto it  = rg.begin();
+    auto it2 = rg.end();
+    EXPECT_TRUE(it == rg.begin());
+    EXPECT_TRUE(it2 == rg.end());
+    EXPECT_TRUE(it != it2);
+    check_ordering(it, it2);
+    for (; it != it2; ++it, --it2) check_ordering(it, it2);
+    EXPECT_TRUE(it == it2);
+    for (; it != rg.end(); it++);
+    for (; it2 != rg.begin(); it2--);
+    EXPECT_TRUE(it == rg.end());
+    EXPECT_TRUE(it2 == rg.begin());
+    EXPECT_TRUE(it != it2);
+    check_ordering(it2, it);
+  };
+  check_comparisons(my_mesh(2));
+  check_comparisons(my_mesh(6));
+  check_comparisons(my_mesh(10));
+}
+
+TEST(TRIQS, MeshIteratorRandomAccessOperations) {
+  auto mesh     = my_mesh(10);
+  auto it_begin = mesh.begin();
+  auto it_end   = mesh.end();
+  auto it       = mesh.begin();
+  for (int i = 0; i < mesh.size(); ++i, ++it) {
+    EXPECT_EQ(it_begin[i], *it);
+    EXPECT_EQ(it_begin + i, it);
+    EXPECT_EQ(i + it_begin, it);
+    EXPECT_EQ(it_end - (mesh.size() - i), it);
+    EXPECT_EQ(it - it_begin, i);
+    EXPECT_EQ(it_end - it, mesh.size() - i);
+
+    auto it_tmp = it_begin;
+    it_tmp += i;
+    EXPECT_EQ(it_tmp, it);
+    it_tmp = it_end;
+    it_tmp -= mesh.size() - i;
+    EXPECT_EQ(it_tmp, it);
+  }
+}
+
+MAKE_MAIN;

--- a/test/c++/meshes/mesh_iterator.cpp
+++ b/test/c++/meshes/mesh_iterator.cpp
@@ -69,7 +69,10 @@ TEST(TRIQS, MeshIteratorComparisons) {
     EXPECT_TRUE(it2 == rg.end());
     EXPECT_TRUE(it != it2);
     check_ordering(it, it2);
-    for (; it != it2; ++it, --it2) check_ordering(it, it2);
+    for (; it != it2;) {
+      check_ordering(it++, it2);
+      if (it != it2) check_ordering(it, it2--);
+    }
     EXPECT_TRUE(it == it2);
     for (; it != rg.end(); it++);
     for (; it2 != rg.begin(); it2--);
@@ -79,7 +82,8 @@ TEST(TRIQS, MeshIteratorComparisons) {
     check_ordering(it2, it);
   };
   check_comparisons(my_mesh(2));
-  check_comparisons(my_mesh(6));
+  check_comparisons(my_mesh(5));
+  check_comparisons(my_mesh(7));
   check_comparisons(my_mesh(10));
 }
 


### PR DESCRIPTION
- add a generic `mesh_iterator` for 1D meshes that simply iterates over data indices and uses the meshe's `operator[]` to access mesh points
- make all meshes (except `prod`) random access ranges

This allows us to simplify parallel for loops:

```
  auto mesh = triqs::mesh::imfreq(10, triqs::mesh::Fermion, 10);
#pragma omp parallel for
  for (auto m : mpi::chunk(mesh, world)) {
    ...
  }
```