### PR TITLE
[blockgf] enforce str block_names in gf_struct constr

### DIFF
--- a/python/triqs/gf/block_gf.py
+++ b/python/triqs/gf/block_gf.py
@@ -93,7 +93,8 @@ class BlockGf:
             GFlist = []
             for bl, bl_size in kwargs['gf_struct']:
                 BlockNameList.append(bl)
-                assert isinstance(bl_size, (int, np.integer)), "gf_struct should be a list of pairs of bl_name (str) and bl_size (int)"
+                assert isinstance(bl, str) and isinstance(bl_size, (int, np.integer)), \
+                    "gf_struct should be a list of pairs of bl_name (str) and bl_size (int)"
                 if bl_size > 0 and kwargs['target_rank'] > 0:
                     GFlist.append(Gf(mesh=kwargs['mesh'], target_shape=[bl_size]*kwargs['target_rank'], name='G_%s'%bl))
                 else:


### PR DESCRIPTION
Dear Triqs developers,

The current python api for creating BlockGf:s using the `(mesh, gf_struct)` input does not enforce `block_names` (i.e. the first index in each `gf_struct` tuple) to be of type `str`. This causes h5 serialization to break. Try e.g. on `triqs/unstable`

```python
from h5 import HDFArchive
from triqs.gf import BlockGf, MeshImTime

m = MeshImTime(1.0, 'Fermion', n_tau=100)
G_tau = BlockGf(mesh=m, gf_struct=[(0, 1)]) # <== First index in the gf_struct tuple has to be str not int!
print(G_tau)

with HDFArchive('blockgf_h5_bug.h5', 'w') as A:
    A['G_tau'] = G_tau
```

givng

```
Traceback (most recent call last):
  File "/.../blockgf_h5_bug.py", line 13, in <module>
    A['G_tau'] = G_tau
  File "/.../triqs/lib/python3.10/site-packages/h5/archive.py", line 173, in __setitem__
    for k, v in list(d.items()) : SubGroup[k] = v
  File "/.../triqs/lib/python3.10/site-packages/h5/archive.py", line 137, in __setitem__
    assert '/' not in key, "/ can not be part of a key"
TypeError: argument of type 'int' is not iterable
```

This pull request adds an assert checking the type in the first index of the gf_struct tuples passed to BlockGf, enforcing it to be of type `str` like is done in the other BlockGf constructors. Running the example above the produces 

```
Traceback (most recent call last):
  File "/Users/hugstr/dev/soehyb/doc/user_guides/blockgf_h5_bug.py", line 6, in <module>
    G_tau = BlockGf(mesh=m, gf_struct=[(0, 1)])
  File "/Users/hugstr/apps/triqs/lib/python3.10/site-packages/triqs/gf/block_gf.py", line 96, in __init__
    assert isinstance(bl, str) and isinstance(bl_size, (int, np.integer)), \
AssertionError: gf_struct should be a list of pairs of bl_name (str) and bl_size (int)
```

instead.

Please consider merging.