### PR TITLE
[test] h5diff: ignore HDF5 group key ordering

### DIFF
--- a/python/triqs/utility/h5diff.py
+++ b/python/triqs/utility/h5diff.py
@@ -37,7 +37,7 @@ def compare(key, a, b, level, precision):
         assert t == type(b), "%s have different types"%key
 
         if t == dict or isinstance(a, HDFArchiveGroup) :
-            if list(a.keys()) != list(b.keys()):
+            if set(a.keys()) != set(b.keys()):
                 failures.append("Two archive groups '%s' with different keys \n %s \n vs\n %s"%(key,list(a.keys()), list(b.keys())))
             for k in a.keys():
                 compare(key + '/'+ k, a[k], b[k], level + 1, precision)


### PR DESCRIPTION
Compare archive group keys as sets rather than lists so h5diff doesn’t fail when identical groups are written with different key iteration order (e.g. across HDF5/Python versions).

This is a problem with certain hdf5 installations apparently. I never saw this fail before but today on my archlinux machine after some python updates the order in the h5 archive was different: 
```
ctest -V -R Py_hk_convert                                                                                                                                                                                                                                                               
UpdateCTestConfiguration  from :/home/hampel/git/triqs/dft_tools/build/DartConfiguration.tcl                                                                                                                                                                                                
Test project /home/hampel/git/triqs/dft_tools/build                                                                                                                                                                                                                                         
Constructing a list of tests                                                                                                                                                                                                                                                                
Done constructing a list of tests                                                                                                                                                                                                                                                           
Updating test list for fixtures                                                                                                                                                                                                                                                             
Added 0 tests to meet fixture requirements                                                                                                                                                                                                                                                  
Checking test dependency graph...                                                                                                                                                                                                                                                           
Checking test dependency graph end                                                                                                                                                                                                                                                          
test 2                                                                                                                                                                                                                                                                                      
    Start 2: Py_hk_convert                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                            
2: Test command: /home/hampel/pyvenv/devpy/bin/python3.14 "/home/hampel/git/triqs/dft_tools/build/_deps/dftkit-src/test/python/hk/hk_convert.py"                                                                                                                                            
2: Working Directory: /home/hampel/git/triqs/dft_tools/build/_deps/dftkit-build/test/python/hk                                                                                                                                                                                              
2: Environment variables:                                                                                                                                                                                                                                                                   
2:  PYTHONPATH=/home/hampel/git/triqs/dft_tools/build/_deps/dftkit-build/python:                                                                                                                                                                                                            
2: Test timeout computed to be: 10000000                                                                                                                                                                                                                                                    
2: Starting serial run at: 2026-02-09 10:01:58.465411                                                                                                                                                                                                                                       
2: Warning: could not identify MPI environment!                                                                                                                                                                                                                                             
2: Reading input from hk_convert_hamiltonian.hk...                                                                                                                                                                                                                                          
2: --------------------------------------------------                                                                                                                                                                                                                                       
2: --------------------  FAILED  --------------------                                                                                                                                                                                                                                       
2: --------------------------------------------------                                                                                                                                                                                                                                       
2: Two archive groups '/dft_input' with different keys                                                                                                                                                                                                                                      
2:  ['inequiv_to_corr', 'n_corr_shells', 'dft_code', 'n_orbitals', 'use_rotations', 'symm_op', 'dim_reps', 'corr_shells', 'proj_mat', 'corr_to_inequiv', 'T', 'SP', 'SO', 'n_reps', 'shells', 'hopping', 'n_inequiv_shells', 'n_k', 'charge_below', 'rot_mat_time_inv', 'bz_weights', 'rot_m
at', 'k_dep_projection', 'energy_unit', 'n_shells', 'density_required']                                                                                                                                                                                                                     
2:  vs                                                                                                                                                                                                                                                                                      
2:  ['SO', 'SP', 'T', 'bz_weights', 'charge_below', 'corr_shells', 'corr_to_inequiv', 'density_required', 'dft_code', 'dim_reps', 'energy_unit', 'hopping', 'inequiv_to_corr', 'k_dep_projection', 'n_corr_shells', 'n_inequiv_shells', 'n_k', 'n_orbitals', 'n_reps', 'n_shells', 'proj_mat
', 'rot_mat', 'rot_mat_time_inv', 'shells', 'symm_op', 'use_rotations']                                                                                                                                                                                                                     
2: --------------------------------------------------                                                                                                                                                                                                                                       
2: Two archive groups '/dft_input/corr_shells' with different keys                                                                                                                                                                                                                          
2:  ['atom', 'sort', 'l', 'dim', 'SO', 'irep']                                                                                                                                                                                                                                              
2:  vs                                                                                                                                                                                                                                                                                      
2:  ['SO', 'atom', 'dim', 'irep', 'l', 'sort']                                                                                                                                                                                                                                              
2: --------------------------------------------------                                                                                                                                                                                                                                       
2: Two archive groups '/dft_input/shells' with different keys                                                                                                                                                                                                                               
2:  ['atom', 'sort', 'l', 'dim']                                                                                                                                                                                                                                                            
2:  vs                                                                                                                                                                                                                                                                                      
2:  ['atom', 'dim', 'l', 'sort']                                                                                                                                                                                                                                                            
2: --------------------------------------------------                                                                                                                                                                                                                                       
2: Traceback (most recent call last):                                                                                                                                                                                                                                                       
2:   File "/home/hampel/git/triqs/dft_tools/build/_deps/dftkit-src/test/python/hk/hk_convert.py", line 35, in <module>                                                                                                                                                                      
2:     h5diff("hk_convert.out.h5","hk_convert.ref.h5")                                                                                                                                                                                                                                      
2:     ~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                                                                                                      
2:   File "/home/hampel/pyvenv/devpy/lib/python3.14/site-packages/triqs/utility/h5diff.py", line 98, in h5diff                                                                                                                                                                              
2:     raise RuntimeError("FAILED")                                                                                                                                                                                                                                                         
2: RuntimeError: FAILED                                                                                                                                                                                                                                                                     
1/1 Test #2: Py_hk_convert ....................***Failed    0.19 sec                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                            
0% tests passed, 1 tests failed out of 1                                                                                                                                                    
```

I think it would not hurt to just switch to `set` from `list` to prevent this issue.