### PR TITLE
Add direct evaluation of imaginary time Green's function with semicircular spectral function

### DIFF
--- a/python/triqs/gf/descriptors.py
+++ b/python/triqs/gf/descriptors.py
@@ -89,21 +89,16 @@ semicircle
         mu = self.chem_potential
         Id = 1. if len(G.target_shape) == 0 else numpy.identity(G.target_shape[0])
         if type(G.mesh) in [MeshImFreq, MeshDLRImFreq]:
-            def f(om_):
-                return g_semicirc_iw(om_ + mu, D) * Id
+            vals = g_semicirc_iw(G.mesh.values() + mu, D)
         elif type(G.mesh) in [MeshReFreq, MeshReFreqPts, MeshReFreqLog]:
-            def f(om_):
-                return g_semicirc_w(om_.real + mu, D) * Id
+            vals = g_semicirc_w(G.mesh.values().real + mu, D)
         elif type(G.mesh) in [MeshImTime, MeshDLRImTime]:
             if mu != 0.:
                 raise NotImplementedError("SemiCircular on imaginary-time mesh with non-zero chemical potential is not supported")
             vals = g_semicirc_tau(G.mesh.values(), G.mesh.beta, D)
-            G.data[:] = numpy.multiply.outer(vals, Id)
-            return G
         else:
             raise TypeError(f"SemiCircular: mesh type not supported: {type(G.mesh)}")
-
-        Function(f)(G)
+        G.data[:] = numpy.multiply.outer(vals, Id)
         return G
 
 ##################################################

--- a/python/triqs/gf/descriptors.py
+++ b/python/triqs/gf/descriptors.py
@@ -93,7 +93,7 @@ semicircle
                 return g_semicirc_iw(om_ + mu, D) * Id
         elif type(G.mesh) in [MeshReFreq, MeshReFreqPts, MeshReFreqLog]:
             def f(om_):
-                return g_semicirc_w(om_.real + mu, D)
+                return g_semicirc_w(om_.real + mu, D) * Id
         elif type(G.mesh) in [MeshImTime, MeshDLRImTime]:
             if mu != 0.:
                 raise NotImplementedError("SemiCircular on imaginary-time mesh with non-zero chemical potential is not supported")

--- a/python/triqs/gf/descriptors.py
+++ b/python/triqs/gf/descriptors.py
@@ -87,27 +87,21 @@ semicircle
     def __call__(self,G):
         D = self.half_bandwidth
         mu = self.chem_potential
+        Id = 1. if len(G.target_shape) == 0 else numpy.identity(G.target_shape[0])
         if type(G.mesh) in [MeshImFreq, MeshDLRImFreq]:
-            Id = complex(1,0) if len(G.target_shape) == 0 else numpy.identity(G.target_shape[0],numpy.complex128)
             def f(om_):
-                om = om_ + mu
-                return g_semicirc_iw(om, D) * Id
+                return g_semicirc_iw(om_ + mu, D) * Id
         elif type(G.mesh) in [MeshReFreq, MeshReFreqPts, MeshReFreqLog]:
             def f(om_):
-                om = om_.real + mu
-                return g_semicirc_w(om, D)
+                return g_semicirc_w(om_.real + mu, D)
         elif type(G.mesh) in [MeshImTime, MeshDLRImTime]:
             if mu != 0.:
                 raise NotImplementedError("SemiCircular on imaginary-time mesh with non-zero chemical potential is not supported")
-            Id = 1. if len(G.target_shape) == 0 else numpy.identity(G.target_shape[0])
-            tau = numpy.array([t.value for t in G.mesh])
-            beta = G.mesh.beta
-            vals = g_semicirc_tau(tau, beta, D)
-            for n in range(len(tau)):
-                G.data[n,...] = vals[n] * Id
+            vals = g_semicirc_tau(G.mesh.values(), G.mesh.beta, D)
+            G.data[:] = numpy.multiply.outer(vals, Id)
             return G
         else:
-            raise TypeError("SemiCircular: mesh type not supported: " + str(type(G.mesh)))
+            raise TypeError(f"SemiCircular: mesh type not supported: {type(G.mesh)}")
 
         Function(f)(G)
         return G

--- a/python/triqs/gf/descriptors.py
+++ b/python/triqs/gf/descriptors.py
@@ -22,7 +22,8 @@
 r""" """
 
 from .descriptor_base import *
-from .meshes import MeshImFreq, MeshDLRImFreq, MeshReFreq, MeshReFreqPts, MeshReFreqLog
+from .meshes import MeshImFreq, MeshDLRImFreq, MeshReFreq, MeshReFreqPts, MeshReFreqLog, MeshImTime, MeshDLRImTime
+from .semicirc import g_semicirc_iw, g_semicirc_w, g_semicirc_tau
 import warnings
 
 #######################################
@@ -70,7 +71,7 @@ class SemiCircular (Base):
 
     where :math:`A(\omega) = \theta( D - |\omega|) 2 \sqrt{ D^2 - \omega^2}/(\pi D^2)`.
 
-    (Only works in combination with frequency Green's functions.)
+    (Works with frequency and imaginary-time Green's functions.)
     """
     def __init__ (self, half_bandwidth, chem_potential=0.):
         r""":param half_bandwidth: :math:`D`, the half bandwidth of the
@@ -86,25 +87,29 @@ semicircle
     def __call__(self,G):
         D = self.half_bandwidth
         mu = self.chem_potential
-        Id = complex(1,0) if len(G.target_shape) == 0 else numpy.identity(G.target_shape[0],numpy.complex128)
-        from cmath import sqrt
         if type(G.mesh) in [MeshImFreq, MeshDLRImFreq]:
+            Id = complex(1,0) if len(G.target_shape) == 0 else numpy.identity(G.target_shape[0],numpy.complex128)
             def f(om_):
                 om = om_ + mu
-                return (om - 1j*copysign(1,om.imag)*sqrt(D*D - om**2))/D/D*2*Id
+                return g_semicirc_iw(om, D) * Id
         elif type(G.mesh) in [MeshReFreq, MeshReFreqPts, MeshReFreqLog]:
             def f(om_):
-              om = om_.real + mu
-              if (om > -D) and (om < D):
-                return (2.0/D**2) * (om - 1j* sqrt(D**2 - om**2))
-              else:
-                return (2.0/D**2) * (om - copysign(1,om) * sqrt(om**2 - D**2))
+                om = om_.real + mu
+                return g_semicirc_w(om, D)
+        elif type(G.mesh) in [MeshImTime, MeshDLRImTime]:
+            if mu != 0.:
+                raise NotImplementedError("SemiCircular on imaginary-time mesh with non-zero chemical potential is not supported")
+            Id = 1. if len(G.target_shape) == 0 else numpy.identity(G.target_shape[0])
+            tau = numpy.array([t.value for t in G.mesh])
+            beta = G.mesh.beta
+            vals = g_semicirc_tau(tau, beta, D)
+            for n in range(len(tau)):
+                G.data[n,...] = vals[n] * Id
+            return G
         else:
-            raise TypeError("This initializer is only correct in frequency")
+            raise TypeError("SemiCircular: mesh type not supported: " + str(type(G.mesh)))
 
-        Id = 1. if len(G.target_shape) == 0 else numpy.identity(G.target_shape[0])
         Function(f)(G)
-
         return G
 
 ##################################################

--- a/python/triqs/gf/semicirc.py
+++ b/python/triqs/gf/semicirc.py
@@ -42,7 +42,8 @@ def g_semicirc_iw(iw, D):
     G : complex or ndarray
     """
     iw = np.asarray(iw, dtype=complex)
-    return (2.0 / D**2) * (iw - 1j * np.sign(iw.imag) * np.sqrt(D**2 + (iw / 1j)**2))
+    w = iw.imag
+    return (2.0 / D**2) * (iw - 1j * np.sign(w) * np.sqrt(D**2 + w**2))
 
 
 # ── Real frequency ──────────────────────────────────────────────────────────

--- a/python/triqs/gf/semicirc.py
+++ b/python/triqs/gf/semicirc.py
@@ -1,0 +1,195 @@
+r"""Green's function for a semi-circular density of states.
+
+.. math::
+
+    \rho(\omega) = \frac{2}{\pi D^2}\,\sqrt{D^2 - \omega^2},
+    \qquad |\omega| \le D
+
+Closed-form expressions exist on the Matsubara and real-frequency axes.
+On the imaginary-time axis a fast panel quadrature is used.
+
+Functions
+---------
+g_semicirc_iw            Matsubara frequency  G(iω_n)
+g_semicirc_w             Real frequency       G(ω + i0⁺)
+g_semicirc_tau           Imaginary time       G(τ)   via panel quadrature
+g_semicirc_tau_adapquad  Imaginary time       G(τ)   via adaptive quadrature
+"""
+
+import numpy as np
+from scipy.special import roots_jacobi, roots_legendre
+from scipy.integrate import quad
+
+
+# ── Matsubara frequency ─────────────────────────────────────────────────────
+
+def g_semicirc_iw(iw, D):
+    r"""Semi-circular Green's function on the Matsubara axis.
+
+    .. math::
+        G(i\omega) = \frac{2}{D^2}\bigl(i\omega
+            - i\,\mathrm{sign}(\omega)\,\sqrt{D^2 + \omega^2}\bigr)
+
+    Parameters
+    ----------
+    iw : complex or array_like
+        Matsubara frequencies (purely imaginary, e.g. ``1j * wn``).
+    D  : float
+        Half-bandwidth.
+
+    Returns
+    -------
+    G : complex or ndarray
+    """
+    iw = np.asarray(iw, dtype=complex)
+    return (2.0 / D**2) * (iw - 1j * np.sign(iw.imag) * np.sqrt(D**2 + (iw / 1j)**2))
+
+
+# ── Real frequency ──────────────────────────────────────────────────────────
+
+def g_semicirc_w(w, D):
+    r"""Retarded semi-circular Green's function on the real-frequency axis.
+
+    .. math::
+        G^R(\omega) = \frac{2}{D^2}
+        \begin{cases}
+            \omega - i\sqrt{D^2 - \omega^2}, & |\omega| < D \\
+            \omega - \mathrm{sign}(\omega)\sqrt{\omega^2 - D^2}, & |\omega| \ge D
+        \end{cases}
+
+    Parameters
+    ----------
+    w : float or array_like
+        Real frequencies.
+    D : float
+        Half-bandwidth.
+
+    Returns
+    -------
+    G : complex or ndarray
+    """
+    w = np.atleast_1d(np.asarray(w, dtype=float))
+    G = np.empty(w.shape, dtype=complex)
+    inside = np.abs(w) < D
+    G[inside] = (2.0 / D**2) * (w[inside] - 1j * np.sqrt(D**2 - w[inside]**2))
+    G[~inside] = (2.0 / D**2) * (w[~inside] - np.sign(w[~inside]) * np.sqrt(w[~inside]**2 - D**2))
+    return G.squeeze()
+
+
+# ── Imaginary time ──────────────────────────────────────────────────────────
+
+def g_semicirc_tau(tau, beta, D, p=12, n_levels=None):
+    r"""Semi-circular Green's function on the imaginary-time axis.
+
+    Evaluates
+
+    .. math::
+        G(\tau) = -\frac{2}{\pi}\int_0^1
+            \frac{e^{-\tau D\omega} + e^{(\tau-\beta)D\omega}}
+                 {1 + e^{-\beta D\omega}}\,
+            \sqrt{1-\omega^2}\,d\omega
+
+    using dyadic panel quadrature on :math:`[0,1]`:
+
+    * Gauss-Jacobi (:math:`\alpha=1/2,\,\beta_J=0`) on the panel
+      :math:`[1/2,\,1]` to absorb the :math:`\sqrt{1-\omega}` singularity.
+    * Gauss-Legendre on all other panels, which are dyadically refined
+      toward :math:`\omega = 0`.
+
+    Parameters
+    ----------
+    tau      : float or array_like
+        Imaginary time(s), :math:`0 \le \tau \le \beta`.
+    beta     : float
+        Inverse temperature.
+    D        : float
+        Half-bandwidth.
+    p        : int
+        Quadrature order per panel (default 12).
+    n_levels : int or None
+        Number of dyadic refinement levels.  Default
+        :math:`\lceil\log_2(\beta D)\rceil` so the smallest panel width
+        :math:`2^{-n} < 1/(\beta D)`.
+
+    Returns
+    -------
+    G : float or ndarray
+    """
+    tau = np.atleast_1d(np.asarray(tau, dtype=float))
+
+    if n_levels is None:
+        n_levels = max(1, int(np.ceil(np.log2(beta * D))))
+
+    # Dyadic panel endpoints: [0, 2^{-n}, 2^{-(n-1)}, ..., 1/2]
+    eps = np.array([0.0] + [2.0**(-k) for k in range(n_levels, 0, -1)])
+
+    gl_x, gl_w = roots_legendre(p)
+    gj_x, gj_w = roots_jacobi(p, 0.5, 0.0)
+
+    G = np.zeros(tau.size)
+
+    # Rightmost panel [1/2, 1]: Gauss-Jacobi absorbs sqrt(1-w).
+    # Map [-1,1] -> [1/2,1]:  w = 3/4 + t/4,  1-w = (1-t)/4
+    w = 0.75 + 0.25 * gj_x
+    bDw = beta * D * w
+    tDw = tau[:, None] * (D * w[None, :])
+    K = (np.exp(-tDw) + np.exp(tDw - bDw)) / (1.0 + np.exp(-bDw))
+    G -= (2.0 / np.pi) * 0.25**1.5 * ((K * np.sqrt(1.0 + w)) @ gj_w)
+
+    # Remaining panels: Gauss-Legendre
+    for i in range(n_levels):
+        a, b = eps[i], eps[i + 1]
+        h = (b - a) / 2.0
+        m = (a + b) / 2.0
+        w = m + h * gl_x
+        bDw = beta * D * w
+        tDw = tau[:, None] * (D * w[None, :])
+        K = (np.exp(-tDw) + np.exp(tDw - bDw)) / (1.0 + np.exp(-bDw))
+        G -= (2.0 / np.pi) * h * ((K * np.sqrt(1.0 - w**2)) @ gl_w)
+
+    return G.squeeze()
+
+
+# ── Imaginary time (adaptive quadrature reference) ──────────────────────────
+
+def g_semicirc_tau_adapquad(tau, beta, D, epsabs=0.0, epsrel=1e-13):
+    r"""Semi-circular Green's function on the imaginary-time axis via
+    adaptive quadrature (scipy.integrate.quad).
+
+    Evaluates the original integral
+
+    .. math::
+        G(\tau) = -\int_{-D}^{D}
+            \frac{e^{-\tau\omega}}{1 + e^{-\beta\omega}}\,\rho(\omega)\,d\omega
+
+    by splitting into :math:`[-D,0]` and :math:`[0,D]` to avoid overflow.
+
+    Parameters
+    ----------
+    tau    : float or array_like
+        Imaginary time(s), :math:`0 \le \tau \le \beta`.
+    beta   : float
+        Inverse temperature.
+    D      : float
+        Half-bandwidth.
+    epsabs : float
+        Absolute error tolerance (default 0).
+    epsrel : float
+        Relative error tolerance (default 1e-13).
+
+    Returns
+    -------
+    G : float or ndarray
+    """
+    tau = np.atleast_1d(np.asarray(tau, dtype=float))
+    G = np.zeros_like(tau)
+    rho = lambda w: (2.0 / (np.pi * D**2)) * np.sqrt(np.clip(D**2 - w**2, 0.0, None))
+
+    for j, t in enumerate(tau):
+        v1, _ = quad(lambda w: np.exp(-t*w) / (1 + np.exp(-beta*w)) * rho(w),
+                     0, D, limit=500, epsabs=epsabs, epsrel=epsrel)
+        v2, _ = quad(lambda w: np.exp((beta-t)*w) / (np.exp(beta*w) + 1) * rho(w),
+                     -D, 0, limit=500, epsabs=epsabs, epsrel=epsrel)
+        G[j] = -(v1 + v2)
+
+    return G.squeeze()

--- a/test/python/base/CMakeLists.txt
+++ b/test/python/base/CMakeLists.txt
@@ -19,6 +19,7 @@ add_python_test(gf_fourier_real)
 add_python_test(g_tau_mul)
 add_python_test(gf_dlr)
 add_python_test(gf_chebyshev)
+add_python_test(gf_semicirc_tau)
 add_python_test(block_gf_constr)
 add_python_test(gf_bcast MPI_NUMPROC 2)
 

--- a/test/python/base/gf_semicirc_tau.py
+++ b/test/python/base/gf_semicirc_tau.py
@@ -5,7 +5,7 @@ import numpy as np
 import unittest
 
 from triqs.gf import Gf, make_gf_dlr
-from triqs.gf.meshes import MeshDLRImTime, MeshDLRImFreq, MeshImFreq
+from triqs.gf.meshes import MeshDLRImTime, MeshDLRImFreq, MeshImFreq, MeshImTime, MeshReFreq
 from triqs.gf.descriptors import SemiCircular
 from triqs.gf.semicirc import g_semicirc_tau, g_semicirc_tau_adapquad, g_semicirc_iw
 
@@ -54,6 +54,29 @@ class test_g_semicirc_tau(unittest.TestCase):
         for j, tau in enumerate(test_taus):
             self.assertAlmostEqual(g_c(tau), ref_tau[j], delta=10*eps,
                                    msg=f"iw->dlr->tau failed at tau={tau}")
+
+    def test_matrix_target_is_diagonal(self):
+        """SemiCircular on matrix-valued Gfs must produce a diagonal with
+        off-diagonals identically zero on every supported mesh."""
+        beta, D = 10., 1.
+        meshes = {
+            'ImFreq':  MeshImFreq(beta, 'Fermion', 50),
+            'ImTime':  MeshImTime(beta, 'Fermion', 101),
+            'ReFreq':  MeshReFreq(w_min=-2., w_max=2., n_w=51),
+        }
+        for name, mesh in meshes.items():
+            g_mat = Gf(mesh=mesh, target_shape=[2, 2])
+            g_mat << SemiCircular(D)
+            g_sca = Gf(mesh=mesh, target_shape=[])
+            g_sca << SemiCircular(D)
+
+            diag = np.einsum('nii->ni', g_mat.data)
+            off = g_mat.data - np.einsum('ni,ij->nij', diag, np.eye(2))
+            self.assertLess(np.max(np.abs(off)), 1e-14,
+                            f"{name}: off-diagonals not zero")
+            for i in range(2):
+                np.testing.assert_allclose(g_mat.data[:, i, i], g_sca.data,
+                                           err_msg=f"{name}: diagonal[{i}] differs from scalar")
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/python/base/gf_semicirc_tau.py
+++ b/test/python/base/gf_semicirc_tau.py
@@ -1,0 +1,59 @@
+"""Test g_semicirc_tau panel quadrature against adaptive quadrature reference,
+and SemiCircular descriptor on DLR imaginary-time meshes."""
+
+import numpy as np
+import unittest
+
+from triqs.gf import Gf, make_gf_dlr
+from triqs.gf.meshes import MeshDLRImTime, MeshDLRImFreq, MeshImFreq
+from triqs.gf.descriptors import SemiCircular
+from triqs.gf.semicirc import g_semicirc_tau, g_semicirc_tau_adapquad, g_semicirc_iw
+
+
+class test_g_semicirc_tau(unittest.TestCase):
+
+    def _check(self, D):
+        betas = np.logspace(0, 4, 5)
+        for beta in betas:
+            left = np.logspace(np.log10(1.0 / D), np.log10(beta / 2), 10)
+            taus = np.union1d(left, beta - left)
+            G_panel = g_semicirc_tau(taus, beta, D)
+            G_ref = g_semicirc_tau_adapquad(taus, beta, D)
+            err = np.max(np.abs(G_panel - G_ref))
+            self.assertLess(err, 1e-12,
+                            f"D={D}, beta={beta:.1f}: max error {err:.2e} exceeds tolerance")
+
+    def test_D1(self):
+        self._check(D=1.0)
+
+    def test_D05(self):
+        self._check(D=0.5)
+
+    def test_dlr_tau_to_iw(self):
+        beta, eps, w_max, D = 100., 1e-10, 1., 1.
+
+        g_tau = Gf(mesh=MeshDLRImTime(beta, 'Fermion', w_max, eps), target_shape=[])
+        g_tau << SemiCircular(D)
+        g_c = make_gf_dlr(g_tau)
+
+        iw_mesh = MeshImFreq(beta, 'Fermion', 100)
+        for iw in iw_mesh:
+            ref = g_semicirc_iw(iw.value, D)
+            self.assertAlmostEqual(g_c(iw), ref, delta=10*eps,
+                                   msg=f"tau->dlr->iw failed at {iw.value}")
+
+    def test_dlr_iw_to_tau(self):
+        beta, eps, w_max, D = 100., 1e-10, 1., 1.
+
+        g_iw = Gf(mesh=MeshDLRImFreq(beta, 'Fermion', w_max, eps), target_shape=[])
+        g_iw << SemiCircular(D)
+        g_c = make_gf_dlr(g_iw)
+
+        test_taus = np.linspace(0, beta, 50)
+        ref_tau = g_semicirc_tau(test_taus, beta, D)
+        for j, tau in enumerate(test_taus):
+            self.assertAlmostEqual(g_c(tau), ref_tau[j], delta=10*eps,
+                                   msg=f"iw->dlr->tau failed at tau={tau}")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
With this pull request, syntax like
```
g_tau = Gf(mesh=MeshDLRImTime(beta, 'Fermion', w_max, eps), target_shape=[])
g_tau << SemiCircular(D)
```
now works correctly. Formulas/algorithms to compute the Green's function with a semicircular spectral function have been factored into a new file, and the descriptors.py file has been updated to use these. The imaginary time Green's function is computed from the Lehmann representation using a custom adaptive Gauss quadrature, which is tested for near-machine-precision agreement against automatic adaptive quadrature in scipy. The notation above is also tested by comparing against the analytic Matsubara frequency formula after Fourier transform.