### PR TITLE
[op] U_matrix:spherical_to_cubic add l=3 support

### DIFF
--- a/python/triqs/operators/util/U_matrix.py
+++ b/python/triqs/operators/util/U_matrix.py
@@ -405,33 +405,28 @@ def spherical_to_cubic(l, convention='triqs'):
             T[3,1] = 1.0/sqrt(2);   T[3,3] = -1.0/sqrt(2)
             T[4,0] = 1.0/sqrt(2);   T[4,4] = 1.0/sqrt(2)
     elif l == 3:
+        # l=3 cubic orderings used here:
+        # triqs:     ("x(x^2-3y^2)", "z(x^2-y^2)", "xz^2", "z^3", "yz^2", "xyz", "y(3x^2-y^2)")
+        # vasp:      ("y(3x^2-y^2)", "xyz", "yz^2", "z^3", "xz^2", "z(x^2-y^2)", "x(x^2-3y^2)")
+        # wannier90: ("z^3", "xz^2", "yz^2", "z(x^2-y^2)", "xyz", "x(x^2-3y^2)", "y(3x^2-y^2)")
+        # qe: same as wannier90
+        T_triqs = np.zeros((size,size),dtype=complex)
+        T_triqs[0,0] = 1.0/sqrt(2);   T_triqs[0,6] = -1.0/sqrt(2)
+        T_triqs[1,1] = 1.0/sqrt(2);   T_triqs[1,5] =  1.0/sqrt(2)
+        T_triqs[2,2] = 1.0/sqrt(2);   T_triqs[2,4] = -1.0/sqrt(2)
+        T_triqs[3,3] = 1.0
+        T_triqs[4,2] = 1j/sqrt(2);    T_triqs[4,4] =  1j/sqrt(2)
+        T_triqs[5,1] = 1j/sqrt(2);    T_triqs[5,5] = -1j/sqrt(2)
+        T_triqs[6,0] = 1j/sqrt(2);    T_triqs[6,6] =  1j/sqrt(2)
+
         if convention == 'triqs':
-            cubic_names = ("x(x^2-3y^2)","z(x^2-y^2)","xz^2","z^3","yz^2","xyz","y(3x^2-y^2)")
-            T[0,0] = 1.0/sqrt(2);   T[0,6] = -1.0/sqrt(2)
-            T[1,1] = 1.0/sqrt(2);   T[1,5] =  1.0/sqrt(2)
-            T[2,2] = 1.0/sqrt(2);   T[2,4] = -1.0/sqrt(2)
-            T[3,3] = 1.0
-            T[4,2] = 1j/sqrt(2);    T[4,4] =  1j/sqrt(2)
-            T[5,1] = 1j/sqrt(2);    T[5,5] = -1j/sqrt(2)
-            T[6,0] = 1j/sqrt(2);    T[6,6] =  1j/sqrt(2)
+            T = T_triqs
         elif convention == 'vasp':
-            cubic_names = ("y(3x^2-y^2)","xyz","yz^2","z^3","xz^2","z(x^2-y^2)","x(x^2-3y^2)")
-            T[0,0] = 1j/sqrt(2);    T[0,6] =  1j/sqrt(2)
-            T[1,1] = 1j/sqrt(2);    T[1,5] = -1j/sqrt(2)
-            T[2,2] = 1j/sqrt(2);    T[2,4] =  1j/sqrt(2)
-            T[3,3] = 1.0
-            T[4,2] = 1.0/sqrt(2);   T[4,4] = -1.0/sqrt(2)
-            T[5,1] = 1.0/sqrt(2);   T[5,5] =  1.0/sqrt(2)
-            T[6,0] = 1.0/sqrt(2);   T[6,6] = -1.0/sqrt(2)
+            row_permutation = (6, 5, 4, 3, 2, 1, 0)
+            T = T_triqs[row_permutation, :]
         elif convention in ('wannier90', 'qe'):
-            cubic_names = ("z^3","xz^2","yz^2","z(x^2-y^2)","xyz","x(x^2-3y^2)","y(3x^2-y^2)")
-            T[0,3] = 1.0
-            T[1,2] = 1.0/sqrt(2);   T[1,4] = -1.0/sqrt(2)
-            T[2,2] = 1j/sqrt(2);    T[2,4] =  1j/sqrt(2)
-            T[3,1] = 1.0/sqrt(2);   T[3,5] =  1.0/sqrt(2)
-            T[4,1] = 1j/sqrt(2);    T[4,5] = -1j/sqrt(2)
-            T[5,0] = 1.0/sqrt(2);   T[5,6] = -1.0/sqrt(2)
-            T[6,0] = 1j/sqrt(2);    T[6,6] =  1j/sqrt(2)
+            row_permutation = (3, 2, 4, 1, 5, 0, 6)
+            T = T_triqs[row_permutation, :]
     else: raise ValueError("spherical_to_cubic: implemented only for l=0,1,2,3")
 
     return T

--- a/python/triqs/operators/util/U_matrix.py
+++ b/python/triqs/operators/util/U_matrix.py
@@ -333,14 +333,22 @@ def spherical_to_cubic(l, convention='triqs'):
     l : integer
         Angular momentum of shell being treated (l=2 for d shell, l=3 for f shell).
     convention : string, optional
-                 The basis convention.
-                 Takes the values
+                 The basis convention. For l=2 (d shell) the cubic orderings are:
 
-                 - 'triqs': basis ordered as ("xy","yz","z^2","xz","x^2-y^2"),
+                 - 'triqs': ("xy","yz","z^2","xz","x^2-y^2"),
                  - 'vasp': same as 'triqs',
-                 - 'wien2k': basis ordered as ("z^2","x^2-y^2","xy","yz","xz"),
-                 - 'wannier90': basis order as ("z^2", "xz", "yz", "x^2-y^2", "xy"),
+                 - 'wien2k': ("z^2","x^2-y^2","xy","yz","xz"),
+                 - 'wannier90': ("z^2","xz","yz","x^2-y^2","xy"),
                  - 'qe': same as 'wannier90'.
+
+                 For l=3 (f shell) the cubic orderings are:
+
+                 - 'triqs': ("x(x^2-3y^2)","z(x^2-y^2)","xz^2","z^3","yz^2","xyz","y(3x^2-y^2)"),
+                 - 'vasp': ("y(3x^2-y^2)","xyz","yz^2","z^3","xz^2","z(x^2-y^2)","x(x^2-3y^2)"),
+                 - 'wannier90': ("z^3","xz^2","yz^2","z(x^2-y^2)","xyz","x(x^2-3y^2)","y(3x^2-y^2)"),
+                 - 'qe': same as 'wannier90',
+                 - 'wien2k': not supported for l=3 (dmftproj uses site-symmetry-specific
+                   transformations; see dmftproj/SRC_templates/case.cf_f_mm2).
 
     Returns
     -------
@@ -354,10 +362,13 @@ def spherical_to_cubic(l, convention='triqs'):
 
     size = 2*l+1
     T = np.zeros((size,size),dtype=complex)
-    if convention in ['wien2k', 'wannier90', 'qe'] and l == 3:
-        raise ValueError("spherical_to_cubic: [wien2k, wannier90, qe] convention implemented only for l=0,1,2")
+    if convention == 'wien2k' and l == 3:
+        raise ValueError("spherical_to_cubic: 'wien2k' convention not implemented for l=3 "
+                         "(dmftproj uses point-group-specific transformations; see "
+                         "dmftproj/SRC_templates/case.cf_f_mm2).")
     if l == 0:
         cubic_names = ("s")
+        T[0,0] = 1.0
     elif l == 1:
         if convention == 'wannier90' or convention == 'qe':
             cubic_names = ("z","x","y")
@@ -394,14 +405,33 @@ def spherical_to_cubic(l, convention='triqs'):
             T[3,1] = 1.0/sqrt(2);   T[3,3] = -1.0/sqrt(2)
             T[4,0] = 1.0/sqrt(2);   T[4,4] = 1.0/sqrt(2)
     elif l == 3:
-        cubic_names = ("x(x^2-3y^2)","z(x^2-y^2)","xz^2","z^3","yz^2","xyz","y(3x^2-y^2)")
-        T[0,0] = 1.0/sqrt(2);    T[0,6] = -1.0/sqrt(2)
-        T[1,1] = 1.0/sqrt(2);    T[1,5] = 1.0/sqrt(2)
-        T[2,2] = 1.0/sqrt(2);    T[2,4] = -1.0/sqrt(2)
-        T[3,3] = 1.0
-        T[4,2] = 1j/sqrt(2);   T[4,4] = 1j/sqrt(2)
-        T[5,1] = 1j/sqrt(2);   T[5,5] = -1j/sqrt(2)
-        T[6,0] = 1j/sqrt(2);   T[6,6] = 1j/sqrt(2)
+        if convention == 'triqs':
+            cubic_names = ("x(x^2-3y^2)","z(x^2-y^2)","xz^2","z^3","yz^2","xyz","y(3x^2-y^2)")
+            T[0,0] = 1.0/sqrt(2);   T[0,6] = -1.0/sqrt(2)
+            T[1,1] = 1.0/sqrt(2);   T[1,5] =  1.0/sqrt(2)
+            T[2,2] = 1.0/sqrt(2);   T[2,4] = -1.0/sqrt(2)
+            T[3,3] = 1.0
+            T[4,2] = 1j/sqrt(2);    T[4,4] =  1j/sqrt(2)
+            T[5,1] = 1j/sqrt(2);    T[5,5] = -1j/sqrt(2)
+            T[6,0] = 1j/sqrt(2);    T[6,6] =  1j/sqrt(2)
+        elif convention == 'vasp':
+            cubic_names = ("y(3x^2-y^2)","xyz","yz^2","z^3","xz^2","z(x^2-y^2)","x(x^2-3y^2)")
+            T[0,0] = 1j/sqrt(2);    T[0,6] =  1j/sqrt(2)
+            T[1,1] = 1j/sqrt(2);    T[1,5] = -1j/sqrt(2)
+            T[2,2] = 1j/sqrt(2);    T[2,4] =  1j/sqrt(2)
+            T[3,3] = 1.0
+            T[4,2] = 1.0/sqrt(2);   T[4,4] = -1.0/sqrt(2)
+            T[5,1] = 1.0/sqrt(2);   T[5,5] =  1.0/sqrt(2)
+            T[6,0] = 1.0/sqrt(2);   T[6,6] = -1.0/sqrt(2)
+        elif convention in ('wannier90', 'qe'):
+            cubic_names = ("z^3","xz^2","yz^2","z(x^2-y^2)","xyz","x(x^2-3y^2)","y(3x^2-y^2)")
+            T[0,3] = 1.0
+            T[1,2] = 1.0/sqrt(2);   T[1,4] = -1.0/sqrt(2)
+            T[2,2] = 1j/sqrt(2);    T[2,4] =  1j/sqrt(2)
+            T[3,1] = 1.0/sqrt(2);   T[3,5] =  1.0/sqrt(2)
+            T[4,1] = 1j/sqrt(2);    T[4,5] = -1j/sqrt(2)
+            T[5,0] = 1.0/sqrt(2);   T[5,6] = -1.0/sqrt(2)
+            T[6,0] = 1j/sqrt(2);    T[6,6] =  1j/sqrt(2)
     else: raise ValueError("spherical_to_cubic: implemented only for l=0,1,2,3")
 
     return T

--- a/test/python/base/U_mat.py
+++ b/test/python/base/U_mat.py
@@ -56,7 +56,8 @@ assert_arrays_are_close(U_ref, U)
 assert_arrays_are_close(U_p_ref, U_p)
 
 
-# test spherical_to_cubic unitarity for all supported (l, convention) pairs
+# Algebraic sanity check: spherical_to_cubic must be unitary for all supported
+# (l, convention) pairs. This does not validate convention-specific ordering.
 for l in (0, 1, 2, 3):
     for convention in ('triqs', 'vasp', 'wannier90', 'qe', 'wien2k'):
         if convention == 'wien2k' and l == 3:
@@ -65,3 +66,23 @@ for l in (0, 1, 2, 3):
         identity = numpy.eye(2*l+1)
         assert_arrays_are_close(T @ T.conj().T, identity)
         assert_arrays_are_close(T.conj().T @ T, identity)
+
+
+# For l=3, conventions are related by row permutations of the TRIQS basis.
+T_triqs = spherical_to_cubic(3, convention='triqs')
+T_vasp = spherical_to_cubic(3, convention='vasp')
+T_wannier90 = spherical_to_cubic(3, convention='wannier90')
+T_qe = spherical_to_cubic(3, convention='qe')
+
+assert_arrays_are_close(T_vasp, T_triqs[(6, 5, 4, 3, 2, 1, 0), :])
+assert_arrays_are_close(T_wannier90, T_triqs[(3, 2, 4, 1, 5, 0, 6), :])
+assert_arrays_are_close(T_qe, T_wannier90)
+
+
+got_l3_wien2k_error = False
+try:
+    spherical_to_cubic(3, convention='wien2k')
+except ValueError:
+    got_l3_wien2k_error = True
+
+assert(got_l3_wien2k_error)

--- a/test/python/base/U_mat.py
+++ b/test/python/base/U_mat.py
@@ -54,3 +54,14 @@ U, U_p = U_matrix_kanamori(n_orb=3, U_int=3.2, Up_int=1.67, J_hund=1.35, full_Ui
 
 assert_arrays_are_close(U_ref, U)
 assert_arrays_are_close(U_p_ref, U_p)
+
+
+# test spherical_to_cubic unitarity for all supported (l, convention) pairs
+for l in (0, 1, 2, 3):
+    for convention in ('triqs', 'vasp', 'wannier90', 'qe', 'wien2k'):
+        if convention == 'wien2k' and l == 3:
+            continue
+        T = spherical_to_cubic(l, convention=convention)
+        identity = numpy.eye(2*l+1)
+        assert_arrays_are_close(T @ T.conj().T, identity)
+        assert_arrays_are_close(T.conj().T @ T, identity)


### PR DESCRIPTION
This commit adds l=3 support for spherical_to_cubic for convention=triqs,vasp,qe, and wannier90 . Previously only triqs was supported.

I also added the trivial l=0 code path.

For Wien2k this seems to be not so trivial since the case.cf_f_mm2 only specific to C2v symmetry and no generic transformation is possible. Users have to do this manually and call via convention='triqs' then.

This also implements a trivial unitary check for the transformation.

This fixes an issue raised here: https://github.com/TRIQS/solid_dmft/issues/114