### PR TITLE
[test] add tests for SemiCircular testing mu!=0 and fix after #1003

### DIFF
--- a/python/triqs/gfs/descriptors.py
+++ b/python/triqs/gfs/descriptors.py
@@ -23,7 +23,7 @@ r""" """
 
 from .descriptor_base import *
 from triqs.mesh import MeshImFreq, MeshDLRImFreq, MeshReFreq, MeshReFreqPts, MeshReFreqLog, MeshImTime, MeshDLRImTime
-from .semicirc import g_semicirc_iw, g_semicirc_w, g_semicirc_tau
+from .semicirc import g_semicirc_z, g_semicirc_w, g_semicirc_tau
 import warnings
 
 #######################################
@@ -89,7 +89,7 @@ semicircle
         mu = self.chem_potential
         Id = 1. if len(G.target_shape) == 0 else numpy.identity(G.target_shape[0])
         if type(G.mesh) in [MeshImFreq, MeshDLRImFreq]:
-            vals = g_semicirc_iw(G.mesh.values() + mu, D)
+            vals = g_semicirc_z(G.mesh.values() + mu, D)
         elif type(G.mesh) in [MeshReFreq, MeshReFreqPts, MeshReFreqLog]:
             vals = g_semicirc_w(G.mesh.values().real + mu, D)
         elif type(G.mesh) in [MeshImTime, MeshDLRImTime]:

--- a/python/triqs/gfs/semicirc.py
+++ b/python/triqs/gfs/semicirc.py
@@ -26,14 +26,27 @@ from scipy.integrate import quad
 def g_semicirc_iw(iw, D):
     r"""Semi-circular Green's function on the Matsubara axis.
 
+    For purely imaginary arguments :math:`i\omega_n`:
+
     .. math::
         G(i\omega) = \frac{2}{D^2}\bigl(i\omega
             - i\,\mathrm{sign}(\omega)\,\sqrt{D^2 + \omega^2}\bigr)
 
+    For general complex arguments :math:`z = i\omega_n + \mu` (used when a
+    chemical potential shift is applied via :class:`SemiCircular`):
+
+    .. math::
+        G(z) = \frac{2}{D^2}\bigl(z - \sqrt{z^2 - D^2}\bigr)
+
+    where the branch of the square root is chosen so that
+    :math:`\operatorname{Im}(\sqrt{z^2-D^2})` has the same sign as
+    :math:`\operatorname{Im}(z)`.
+
     Parameters
     ----------
     iw : complex or array_like
-        Matsubara frequencies (purely imaginary, e.g. ``1j * wn``).
+        Matsubara frequencies, either purely imaginary (e.g. ``1j * wn``)
+        or complex (e.g. ``1j * wn + mu``).
     D  : float
         Half-bandwidth.
 
@@ -42,8 +55,22 @@ def g_semicirc_iw(iw, D):
     G : complex or ndarray
     """
     iw = np.asarray(iw, dtype=complex)
-    w = iw.imag
-    return (2.0 / D**2) * (iw - 1j * np.sign(w) * np.sqrt(D**2 + w**2))
+    if np.all(iw.real == 0):
+        # Fast path for purely imaginary z = iω_n: the formula simplifies to
+        #   G(iω) = (2/D²)(iω − i·sign(ω)·√(D²+ω²))
+        # which is purely imaginary with Im(G) < 0 for ω > 0.
+        w = iw.imag
+        return (2.0 / D**2) * (iw - 1j * np.sign(w) * np.sqrt(D**2 + w**2))
+
+    # General Hilbert-transform formula for complex z (e.g. z = iω_n + μ):
+    sqrt_val = np.sqrt(iw**2 - D**2 + 0j)  # principal branch: Im(sqrt) >= 0
+
+    # Flip to the other sheet (negate) wherever the sign is wrong.
+    # Guard with nonzero: when Im(z)=0 (real axis), sign(Im(z))=0
+    nonzero = iw.imag != 0
+    flip = nonzero & (np.sign(sqrt_val.imag) != np.sign(iw.imag))
+    sqrt_val = np.where(flip, -sqrt_val, sqrt_val)
+    return (2.0 / D**2) * (iw - sqrt_val)
 
 
 # ── Real frequency ──────────────────────────────────────────────────────────

--- a/python/triqs/gfs/semicirc.py
+++ b/python/triqs/gfs/semicirc.py
@@ -5,15 +5,15 @@ r"""Green's function for a semi-circular density of states.
     \rho(\omega) = \frac{2}{\pi D^2}\,\sqrt{D^2 - \omega^2},
     \qquad |\omega| \le D
 
-Closed-form expressions exist on the Matsubara and real-frequency axes.
+Closed-form expressions exist in the complex frequency plane.
 On the imaginary-time axis a fast panel quadrature is used.
 
 Functions
 ---------
-g_semicirc_iw            Matsubara frequency  G(iω_n)
-g_semicirc_w             Real frequency       G(ω + i0⁺)
-g_semicirc_tau           Imaginary time       G(τ)   via panel quadrature
-g_semicirc_tau_adapquad  Imaginary time       G(τ)   via adaptive quadrature
+g_semicirc_z             Complex frequency (except [-D, D])  G(z)
+g_semicirc_w             Real frequency                      G(ω + i0⁺)
+g_semicirc_tau           Imaginary time                      G(τ) via panel quadrature
+g_semicirc_tau_adapquad  Imaginary time                      G(τ) via adaptive quadrature
 """
 
 import numpy as np
@@ -23,54 +23,25 @@ from scipy.integrate import quad
 
 # ── Matsubara frequency ─────────────────────────────────────────────────────
 
-def g_semicirc_iw(iw, D):
-    r"""Semi-circular Green's function on the Matsubara axis.
+def g_semicirc_z(z, D):
+    r"""Semi-circular Green's function for complex frequency without [-D, D].
 
-    For purely imaginary arguments :math:`i\omega_n`:
-
-    .. math::
-        G(i\omega) = \frac{2}{D^2}\bigl(i\omega
-            - i\,\mathrm{sign}(\omega)\,\sqrt{D^2 + \omega^2}\bigr)
-
-    For general complex arguments :math:`z = i\omega_n + \mu` (used when a
-    chemical potential shift is applied via :class:`SemiCircular`):
+    For general complex arguments :math:`z` not on the cut :math:`[-D, D]`, the Green's function is given by    
 
     .. math::
         G(z) = \frac{2}{D^2}\bigl(z - \sqrt{z^2 - D^2}\bigr)
 
-    where the branch of the square root is chosen so that
-    :math:`\operatorname{Im}(\sqrt{z^2-D^2})` has the same sign as
-    :math:`\operatorname{Im}(z)`.
-
     Parameters
     ----------
-    iw : complex or array_like
-        Matsubara frequencies, either purely imaginary (e.g. ``1j * wn``)
-        or complex (e.g. ``1j * wn + mu``).
-    D  : float
-        Half-bandwidth.
+    z : complex or array_like of complex frequencies not on the cut [-D, D].
+    D  : float, half-bandwidth (D > 0)
 
     Returns
     -------
     G : complex or ndarray
     """
-    iw = np.asarray(iw, dtype=complex)
-    if np.all(iw.real == 0):
-        # Fast path for purely imaginary z = iω_n: the formula simplifies to
-        #   G(iω) = (2/D²)(iω − i·sign(ω)·√(D²+ω²))
-        # which is purely imaginary with Im(G) < 0 for ω > 0.
-        w = iw.imag
-        return (2.0 / D**2) * (iw - 1j * np.sign(w) * np.sqrt(D**2 + w**2))
-
-    # General Hilbert-transform formula for complex z (e.g. z = iω_n + μ):
-    sqrt_val = np.sqrt(iw**2 - D**2 + 0j)  # principal branch: Im(sqrt) >= 0
-
-    # Flip to the other sheet (negate) wherever the sign is wrong.
-    # Guard with nonzero: when Im(z)=0 (real axis), sign(Im(z))=0
-    nonzero = iw.imag != 0
-    flip = nonzero & (np.sign(sqrt_val.imag) != np.sign(iw.imag))
-    sqrt_val = np.where(flip, -sqrt_val, sqrt_val)
-    return (2.0 / D**2) * (iw - sqrt_val)
+    z = np.asarray(z, dtype=complex)
+    return (2.0 / D**2) * (z - np.sqrt(z - D) * np.sqrt(z + D))
 
 
 # ── Real frequency ──────────────────────────────────────────────────────────

--- a/test/python/base/CMakeLists.txt
+++ b/test/python/base/CMakeLists.txt
@@ -19,7 +19,7 @@ add_python_test(gf_fourier_real)
 add_python_test(g_tau_mul)
 add_python_test(gf_dlr)
 add_python_test(gf_chebyshev)
-add_python_test(gf_semicirc_tau)
+add_python_test(gf_semicirc)
 add_python_test(block_gf_constr)
 add_python_test(gf_bcast MPI_NUMPROC 2)
 

--- a/test/python/base/gf_semicirc.py
+++ b/test/python/base/gf_semicirc.py
@@ -1,5 +1,5 @@
-"""Test g_semicirc_tau panel quadrature against adaptive quadrature reference,
-and SemiCircular descriptor on DLR imaginary-time meshes."""
+""" Test SemiCircular Green's function in imaginary time and Matsubara
+frequency, including chemical potential shifts. """
 
 import numpy as np
 import unittest
@@ -7,7 +7,7 @@ from scipy.integrate import quad
 
 from triqs.gfs import Gf, make_gf_dlr
 from triqs.gfs.descriptors import SemiCircular
-from triqs.gfs.semicirc import g_semicirc_tau, g_semicirc_tau_adapquad, g_semicirc_iw
+from triqs.gfs.semicirc import g_semicirc_tau, g_semicirc_tau_adapquad, g_semicirc_z
 from triqs.mesh import MeshDLRImTime, MeshDLRImFreq, MeshImFreq, MeshImTime, MeshReFreq
 
 
@@ -39,7 +39,7 @@ class test_g_semicirc_tau(unittest.TestCase):
 
         iw_mesh = MeshImFreq(beta, 'Fermion', 100)
         for iw in iw_mesh:
-            ref = g_semicirc_iw(iw.value, D)
+            ref = g_semicirc_z(iw.value, D)
             self.assertAlmostEqual(g_c(iw), ref, delta=10*eps,
                                    msg=f"tau->dlr->iw failed at {iw.value}")
 
@@ -81,7 +81,7 @@ class test_g_semicirc_tau(unittest.TestCase):
 
 class test_g_semicirc_iw_chem_potential(unittest.TestCase):
     """
-    Tests for SemiCircular/g_semicirc_iw with non-zero chem_potential.
+    Tests for SemiCircular Matsubara frequency Green's function with non-zero chemical potential.
     """
 
     def _occupation_reference(self, D, mu, beta):

--- a/test/python/base/gf_semicirc_tau.py
+++ b/test/python/base/gf_semicirc_tau.py
@@ -3,6 +3,7 @@ and SemiCircular descriptor on DLR imaginary-time meshes."""
 
 import numpy as np
 import unittest
+from scipy.integrate import quad
 
 from triqs.gfs import Gf, make_gf_dlr
 from triqs.gfs.descriptors import SemiCircular
@@ -77,6 +78,99 @@ class test_g_semicirc_tau(unittest.TestCase):
             for i in range(2):
                 np.testing.assert_allclose(g_mat.data[:, i, i], g_sca.data,
                                            err_msg=f"{name}: diagonal[{i}] differs from scalar")
+
+class test_g_semicirc_iw_chem_potential(unittest.TestCase):
+    """
+    Tests for SemiCircular/g_semicirc_iw with non-zero chem_potential.
+    """
+
+    def _occupation_reference(self, D, mu, beta):
+        """Numerically integrate n = integral rho(w) * f(w - mu) dw.
+
+        G(z) = H(z + mu) = int rho(w) / (z + mu - w) dw, so by the
+        Matsubara-sum identity the occupation is
+            n = int rho(w) * f(w - mu) dw,  f(x) = 1/(1+exp(beta*x)).
+        At T=0 this reduces to int_{-D}^{min(mu,D)} rho(w) dw.
+        """
+        rho = lambda w: (2.0 / (np.pi * D**2)) * np.sqrt(np.clip(D**2 - w**2, 0, None))
+        fermi = lambda w: 1.0 / (1.0 + np.exp(beta * (w - mu)))
+        n, _ = quad(lambda w: rho(w) * fermi(w), -D, D, limit=500, epsrel=1e-12)
+        return n
+
+    def _check_density(self, D, mu, beta, tol=1e-4):
+        """Check that SemiCircular(D, mu) gives the correct occupation on MeshImFreq."""
+        mesh = MeshImFreq(beta, 'Fermion', 1025)
+        g = Gf(mesh=mesh, target_shape=[])
+        g << SemiCircular(D, mu)
+        n_gf = g.density().real
+        n_ref = self._occupation_reference(D, mu, beta)
+        self.assertAlmostEqual(n_gf, n_ref, delta=tol,
+                               msg=f"D={D}, mu={mu}, beta={beta}: "
+                                   f"n_gf={n_gf:.6f} vs n_ref={n_ref:.6f}")
+
+    def _check_gf_values(self, D, mu, beta, n_iw_check=10, tol=1e-6):
+        """Check G(iw_n + mu) values against the brute-force Hilbert transform."""
+        mesh = MeshImFreq(beta, 'Fermion', 200)
+        g = Gf(mesh=mesh, target_shape=[])
+        g << SemiCircular(D, mu)
+
+        # Reference: direct Hilbert transform via quad
+        rho = lambda w: (2.0 / (np.pi * D**2)) * np.sqrt(np.clip(D**2 - w**2, 0, None))
+        checked = 0
+        for iw in mesh:
+            if checked >= n_iw_check:
+                break
+            z = complex(iw) + mu
+            g_ref_re, _ = quad(lambda w: rho(w) * (z.real - w) / ((z.real - w)**2 + z.imag**2),
+                               -D, D, limit=500, epsrel=1e-10)
+            g_ref_im, _ = quad(lambda w: rho(w) * (-z.imag) / ((z.real - w)**2 + z.imag**2),
+                               -D, D, limit=500, epsrel=1e-10)
+            g_ref = complex(g_ref_re, g_ref_im)
+            g_val = complex(g[iw])
+            self.assertAlmostEqual(g_val.real, g_ref.real, delta=tol,
+                                   msg=f"Re G at iw={complex(iw):.4f}: got {g_val.real:.6f}, ref {g_ref.real:.6f}")
+            self.assertAlmostEqual(g_val.imag, g_ref.imag, delta=tol,
+                                   msg=f"Im G at iw={complex(iw):.4f}: got {g_val.imag:.6f}, ref {g_ref.imag:.6f}")
+            checked += 1
+
+    def test_density_mu_positive(self):
+        """SemiCircular(D=2, mu=1): DOS center at -1, occupation ~0.8044."""
+        self._check_density(D=2.0, mu=1.0, beta=40.0)
+
+    def test_density_mu_large(self):
+        """SemiCircular(D=1, mu=2): DOS fully below Fermi, occupation ~1."""
+        self._check_density(D=1.0, mu=2.0, beta=40.0)
+
+    def test_density_mu_zero(self):
+        """SemiCircular(D=2, mu=0): symmetric DOS, occupation = 0.5."""
+        self._check_density(D=2.0, mu=0.0, beta=40.0, tol=1e-6)
+
+    def test_density_mu_negative(self):
+        """SemiCircular(D=2, mu=-1): DOS center at +1, occupation ~0.1956."""
+        self._check_density(D=2.0, mu=-1.0, beta=40.0)
+
+    def test_density_symmetry(self):
+        """Occupation(mu) + Occupation(-mu) = 1 by particle-hole symmetry."""
+        D, beta = 2.0, 40.0
+        for mu in [0.5, 1.0, 1.5]:
+            mesh = MeshImFreq(beta, 'Fermion', 1025)
+            gp = Gf(mesh=mesh, target_shape=[])
+            gm = Gf(mesh=mesh, target_shape=[])
+            gp << SemiCircular(D, mu)
+            gm << SemiCircular(D, -mu)
+            np = gp.density().real
+            nm = gm.density().real
+            self.assertAlmostEqual(np + nm, 1.0, delta=1e-4,
+                                   msg=f"PH symmetry failed for mu={mu}: np+nm={np+nm:.6f}")
+
+    def test_gf_values_mu_positive(self):
+        """GF values for SemiCircular(D=2, mu=1) match Hilbert-transform reference."""
+        self._check_gf_values(D=2.0, mu=1.0, beta=40.0)
+
+    def test_gf_values_mu_negative(self):
+        """GF values for SemiCircular(D=2, mu=-1) match Hilbert-transform reference."""
+        self._check_gf_values(D=2.0, mu=-1.0, beta=40.0)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
closes #1007

this PR adds tests for the SemiCircular wrapper in triqs to test also non-zero chemical potential. There was a regression undetected in PR #1003 that has to be fixed. 

This is split into two commits. 1) add proper testing 2) add a preliminary fix. 

Note: even though I carefully checked and tested this code and reviewed myself  I wrote this with Claude. So please recheck. I tried to make the changes as minimal as possible. Maybe there is a better alternative route to this. Feel free to change.

