### PR TITLE
Add triqs.utility.utilities python module for C++ code in triqs/utility

### DIFF
--- a/c++/triqs/utility/time_pt.hpp
+++ b/c++/triqs/utility/time_pt.hpp
@@ -101,6 +101,9 @@ namespace triqs {
       /// Nmax
       static constexpr uint64_t Nmax = std::numeric_limits<uint64_t>::max();
 
+      /// Get the HDF5 format tag.
+      [[nodiscard]] static std::string hdf5_format() { return "time_pt"; }
+
       private:
       uint64_t n;
       double beta, val;
@@ -108,6 +111,7 @@ namespace triqs {
       /// Write into HDF5
       friend void h5_write(h5::group fg, std::string const &subgroup_name, time_pt const &g) {
         auto gr = fg.create_group(subgroup_name);
+        write_hdf5_format(gr, g); // NOLINT
         h5_write(gr, "beta", g.beta);
         h5_write(gr, "val", g.val);
         h5_write(gr, "n", g.n);
@@ -116,6 +120,7 @@ namespace triqs {
       /// Read from HDF5
       friend void h5_read(h5::group fg, std::string const &subgroup_name, time_pt &g) {
         auto gr = fg.open_group(subgroup_name);
+        assert_hdf5_format(gr, g); // NOLINT
         h5_read(gr, "beta", g.beta);
         h5_read(gr, "val", g.val);
         h5_read(gr, "n", g.n);

--- a/python/triqs/utility/utilities.cpp
+++ b/python/triqs/utility/utilities.cpp
@@ -1,0 +1,4 @@
+#include <c2py/c2py.hpp>
+#include <triqs/utility/time_pt.hpp>
+
+#include "utilities.wrap.cxx"

--- a/python/triqs/utility/utilities.toml
+++ b/python/triqs/utility/utilities.toml
@@ -1,0 +1,4 @@
+package_name = "triqs.utility"
+documentation = "Utilities generated from C++ code in triqs/utility."
+namespaces = "triqs::utility"
+match_names = "triqs::utility::time_pt"

--- a/python/triqs/utility/utilities.wrap.cxx
+++ b/python/triqs/utility/utilities.wrap.cxx
@@ -1,0 +1,117 @@
+
+// C.f. https://numpy.org/doc/1.21/reference/c-api/array.html#importing-the-api
+#define PY_ARRAY_UNIQUE_SYMBOL _cpp2py_ARRAY_API
+#ifndef CLAIR_C2PY_WRAP_GEN
+#ifdef __clang__
+// #pragma clang diagnostic ignored "-W#warnings"
+#endif
+#ifdef __GNUC__
+#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+#pragma GCC diagnostic ignored "-Wcast-function-type"
+#pragma GCC diagnostic ignored "-Wcpp"
+#endif
+
+#define C2PY_VERSION_MAJOR 0
+#define C2PY_VERSION_MINOR 1
+
+#include <c2py/c2py.hpp>
+#include <c2py/serialization/h5.hpp>
+
+using c2py::operator""_a;
+
+// ==================== enums =====================
+
+// ==================== module classes =====================
+
+// --------- class _c2py_cls_0 -----------
+using _c2py_cls_0                                            = triqs::utility::time_pt;
+template <> constexpr bool c2py::is_wrapped<_c2py_cls_0>     = true;
+template <> inline constexpr auto c2py::tp_name<_c2py_cls_0> = "triqs.utility.utilities.TimePt";
+static const auto _c2py_init_0 =
+   c2py::dispatcher_c_kw_t{c2py::c_constructor<_c2py_cls_0>(), c2py::c_constructor<_c2py_cls_0, unsigned long long, double>("n_", "beta_")};
+template <> constexpr initproc c2py::tp_init<_c2py_cls_0> = c2py::pyfkw_constructor<_c2py_init_0>;
+template <>
+const std::string c2py::tp_ctor_doc<_c2py_cls_0> = _c2py_init_0.doc(R"DOC(
+Default constructor: :math:`\tau=0`
+)DOC");
+
+// ----- Method table ----
+template <>
+PyMethodDef c2py::tp_methods<_c2py_cls_0>[] = {
+   {"__write_hdf5__", c2py::tpxx_write_h5<_c2py_cls_0>, METH_VARARGS, "  "},
+   {"__getstate__", c2py::getstate_h5<_c2py_cls_0>, METH_NOARGS, ""},
+   {"__setstate__", c2py::setstate_h5<_c2py_cls_0>, METH_O, ""},
+   {nullptr, nullptr, 0, nullptr} // Sentinel
+};
+
+template <>
+const std::string c2py::tp_doc<_c2py_cls_0> = R"DOC(A point in imaginary time, i.e. :math:`\tau \in [0,\beta]`, but defined on a very thin grid.
+
+* Regular type.
+
+* **Rationale**: the position in the segment is given by an uint64_t,
+  i.e. a very long integer.
+  This allows exact comparisons, which notoriously dangerous on floating point number.
+
+* Each time point is constructed from a segment, Cf time_segment class.
+* It can be casted to a double, but the reverse is wrong.)DOC"
+   + std::string{"\n\n----------\n\n"} + c2py::tp_ctor_doc<_c2py_cls_0>;
+
+// ==================== module functions ====================
+
+//--------------------- module function table  -----------------------------
+
+static PyMethodDef module_methods[] = {
+   {nullptr, nullptr, 0, nullptr} // Sentinel
+};
+
+//--------------------- module struct & init error definition ------------
+
+//// module doc directly in the code or "" if not present...
+/// Or mandatory ?
+static struct PyModuleDef module_def = {PyModuleDef_HEAD_INIT,
+                                        "utilities",                                                          /* name of module */
+                                        R"RAWDOC(Utilities generated from C++ code in triqs/utility.)RAWDOC", /* module documentation, may be NULL */
+                                        -1, /* size of per-interpreter state of the module, or -1 if the module keeps state in global variables. */
+                                        module_methods,
+                                        NULL,
+                                        NULL,
+                                        NULL,
+                                        NULL};
+
+//--------------------- module init function -----------------------------
+
+extern "C" __attribute__((visibility("default"))) PyObject *PyInit_utilities() {
+
+  if (not c2py::check_python_version("utilities")) return NULL;
+
+  // import numpy iff 'numpy/arrayobject.h' included
+#ifdef Py_ARRAYOBJECT_H
+  import_array();
+#endif
+
+  PyObject *m;
+
+  if (PyType_Ready(&c2py::wrap_pytype<c2py::py_range>) < 0) return NULL;
+  if (PyType_Ready(&c2py::wrap_pytype<_c2py_cls_0>) < 0) return NULL;
+
+  m = PyModule_Create(&module_def);
+  if (m == NULL) return NULL;
+
+  auto &conv_table = *c2py::conv_table_sptr.get();
+
+  conv_table[std::type_index(typeid(c2py::py_range)).name()] = &c2py::wrap_pytype<c2py::py_range>;
+#define _add_type(T, N) c2py::add_type_object_to_main<T>(N, m, conv_table)
+  _add_type(_c2py_cls_0, "TimePt");
+#undef _add_type
+
+  c2py::pyref module = c2py::pyref::module("h5.formats");
+  if (not module) return nullptr;
+  c2py::pyref register_class = module.attr("register_class");
+
+  register_h5_type<_c2py_cls_0>(register_class);
+
+  return m;
+}
+#endif
+// CLAIR_WRAP_GEN

--- a/python/triqs/utility/utilities.wrap.hxx
+++ b/python/triqs/utility/utilities.wrap.hxx
@@ -1,0 +1,7 @@
+#include <c2py/c2py.hpp>
+
+#ifndef C2PY_HXX_DECLARATION_utilities_GUARDS
+#define C2PY_HXX_DECLARATION_utilities_GUARDS
+template <> constexpr bool c2py::is_wrapped<triqs::utility::time_pt>     = true;
+template <> inline constexpr auto c2py::tp_name<triqs::utility::time_pt> = "triqs.utility.utilities.TimePt";
+#endif

--- a/test/python/CMakeLists.txt
+++ b/test/python/CMakeLists.txt
@@ -13,5 +13,6 @@ file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/${w90_files} DESTINATION ${CMAKE_CURRENT_B
 add_python_test(operators)
 add_python_test(lattice_utils)
 add_python_test(lattice_tight_binding)
+add_python_test(utility_time_pt)
 
 add_all_subdirectories_with_cmakelist()

--- a/test/python/utility_time_pt.py
+++ b/test/python/utility_time_pt.py
@@ -1,0 +1,61 @@
+# Copyright (c) 2026 Simons Foundation
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You may obtain a copy of the License at
+#     https:#www.gnu.org/licenses/gpl-3.0.txt
+
+import unittest
+from triqs.utility.utilities import TimePt
+from h5 import HDFArchive
+
+beta = 10.0
+# Largest grid index (time_pt::Nmax == 2**64 - 1), corresponding to tau = beta.
+NMAX = 2**64 - 1
+
+class test_time_pt(unittest.TestCase):
+
+    def test_default(self):
+        # Default construction is tau = 0 on a zero segment.
+        self.assertEqual(str(TimePt()), "0 [time_pt : beta = 0 n = 0]")
+
+    def test_repr_fields(self):
+        # str/repr exposes the stored beta and integer grid index n.
+        self.assertEqual(str(TimePt(0, beta)), "0 [time_pt : beta = 10 n = 0]")
+        self.assertIn("n = %d" % NMAX, str(TimePt(NMAX, beta)))
+
+    def test_equality_is_on_grid_index(self):
+        # Comparison uses the exact integer index, not the (lossy) double value,
+        # and is independent of beta.
+        self.assertEqual(TimePt(0, beta), TimePt(0, beta))
+        self.assertEqual(TimePt(5, beta), TimePt(5, 2 * beta))
+        self.assertNotEqual(TimePt(0, beta), TimePt(NMAX, beta))
+
+    def test_ordering(self):
+        lo   = TimePt(0, beta)
+        half = TimePt(NMAX // 2, beta)
+        hi   = TimePt(NMAX, beta)
+        self.assertTrue(lo < half < hi)
+        self.assertTrue(hi > half > lo)
+        self.assertTrue(lo <= TimePt(0, beta))
+        self.assertTrue(hi >= half)
+
+    def test_h5_roundtrip(self):
+        tp = TimePt(NMAX // 3, beta)
+        with HDFArchive("time_pt.h5", 'w') as ar:
+            ar['tp'] = tp
+        with HDFArchive("time_pt.h5", 'r') as ar:
+            tp2 = ar['tp']
+        self.assertIsInstance(tp2, TimePt)
+        self.assertEqual(tp, tp2)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- porting cthyb to clair + c2py requires `time_pt` to be wrapped