### PR TITLE
[jenkins] make docker builds more efficient by avoiding extra checkouts

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -111,14 +111,18 @@ def platforms = [:]
 /****************** linux builds (in docker) */
 /* Each platform must have a corresponding Dockerfile.PLATFORM in triqs/jenkins */
 def dockerPlatforms = ["ubuntu-clang", "ubuntu-gcc", "ubuntu-intel", "sanitize"]
+buildImages(dockerPlatforms.collect { platform ->
+  [ tag: platform,
+    context: 'jenkins',
+    dockerfile: "Dockerfile.$platform"
+  ]
+}, checkout: true)
 for (int i = 0; i < dockerPlatforms.size(); i++) {
   def platform = dockerPlatforms[i]
   platforms[platform] = { ->
     stage(platform) {
       timeout(time: 2, unit: 'HOURS') {
-        buildPod(tag: platform,
-          context: 'jenkins',
-          dockerfile: "Dockerfile.$platform",
+        runPod(tag: platform,
           devShm: true,
           mounts: mounts) {
           runBuild(platform, installBase, [])


### PR DESCRIPTION
This is just an optimization, but probably saves a couple minutes. I can make the same change on app4triqs.